### PR TITLE
Adapt Silicon to support PluginAwareReporter

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -23,6 +23,7 @@ import viper.silicon.reporting.condenseToViperResult
 import viper.silicon.verifier.DefaultMasterVerifier
 import viper.silver.cfg.silver.SilverCfg
 import viper.silver.logger.ViperStdOutLogger
+import viper.silver.plugin.PluginAwareReporter
 
 object Silicon {
   val name = BuildInfo.projectName
@@ -59,7 +60,7 @@ object Silicon {
                                       debugInfo: Seq[(String, Any)] = Nil)
                                      : Silicon = {
 
-    val silicon = new Silicon(reporter, debugInfo)
+    val silicon = new Silicon(PluginAwareReporter(reporter), debugInfo)
 
     silicon.parseCommandLine(args :+ "dummy-file-to-prevent-cli-parser-from-complaining-about-missing-file-name.silver")
 
@@ -67,13 +68,13 @@ object Silicon {
   }
 }
 
-class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] = Nil)
+class Silicon(val reporter: PluginAwareReporter, private var debugInfo: Seq[(String, Any)] = Nil)
     extends SilVerifier
        with LazyLogging {
 
-  def this(debugInfo: Seq[(String, Any)]) = this(StdIOReporter(), debugInfo)
+  def this(debugInfo: Seq[(String, Any)]) = this(PluginAwareReporter(StdIOReporter()), debugInfo)
 
-  def this() = this(StdIOReporter(), Nil)
+  def this() = this(PluginAwareReporter(StdIOReporter()), Nil)
 
   val name: String = Silicon.name
   val version = Silicon.version
@@ -281,8 +282,12 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
   }
 }
 
-class SiliconFrontend(override val reporter: Reporter,
-                      override implicit val logger: Logger = ViperStdOutLogger("SiliconFrontend", "INFO").get) extends SilFrontend {
+class SiliconFrontend(override val reporter: PluginAwareReporter,
+                      override implicit val logger: Logger) extends SilFrontend {
+
+  def this(reporter: Reporter, logger: Logger = ViperStdOutLogger("SiliconFrontend", "INFO").get) =
+    this(PluginAwareReporter(reporter), logger)
+
   protected var siliconInstance: Silicon = _
 
   def createVerifier(fullCmd: String) = {

--- a/src/main/scala/decider/Z3ProverStdIO.scala
+++ b/src/main/scala/decider/Z3ProverStdIO.scala
@@ -18,12 +18,13 @@ import viper.silicon.reporting.{ExternalToolError, Z3InteractionFailed}
 import viper.silicon.state.IdentifierFactory
 import viper.silicon.state.terms._
 import viper.silicon.verifier.Verifier
-import viper.silver.reporter.{ConfigurationConfirmation, InternalWarningMessage, Reporter}
+import viper.silver.plugin.PluginAwareReporter
+import viper.silver.reporter.{ConfigurationConfirmation, InternalWarningMessage}
 
 class Z3ProverStdIO(uniqueId: String,
                     termConverter: TermToSMTLib2Converter,
                     identifierFactory: IdentifierFactory,
-                    reporter: Reporter)
+                    reporter: PluginAwareReporter)
     extends Prover
        with LazyLogging {
 

--- a/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
+++ b/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
@@ -13,13 +13,14 @@ import viper.silicon.rules.functionSupporter
 import viper.silicon.state.{Identifier, SimpleIdentifier, SuffixedIdentifier, SymbolConverter}
 import viper.silicon.state.terms._
 import viper.silicon.supporters.ExpressionTranslator
-import viper.silver.reporter.{InternalWarningMessage, Reporter}
+import viper.silver.plugin.PluginAwareReporter
+import viper.silver.reporter.InternalWarningMessage
 
 class HeapAccessReplacingExpressionTranslator(symbolConverter: SymbolConverter,
                                               fresh: (String, Sort) => Var,
                                               resolutionFailureMessage: (ast.Positioned, FunctionData) => String,
                                               stopOnResolutionFailure: (ast.Positioned, FunctionData) => Boolean,
-                                              reporter: Reporter)
+                                              reporter: PluginAwareReporter)
     extends ExpressionTranslator
        with LazyLogging {
 

--- a/src/main/scala/verifier/DefaultMasterVerifier.scala
+++ b/src/main/scala/verifier/DefaultMasterVerifier.scala
@@ -25,6 +25,7 @@ import viper.silicon.supporters.qps._
 import viper.silicon.utils.Counter
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.cfg.silver.SilverCfg
+import viper.silver.plugin.PluginAwareReporter
 import viper.silver.reporter.{ConfigurationConfirmation, Reporter, VerificationResultMessage}
 
 /* TODO: Extract a suitable MasterVerifier interface, probably including
@@ -37,7 +38,7 @@ trait MasterVerifier extends Verifier {
   def verificationPoolManager: VerificationPoolManager
 }
 
-class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
+class DefaultMasterVerifier(config: Config, override val reporter: PluginAwareReporter)
     extends BaseVerifier(config, "00")
        with MasterVerifier
        with DefaultFunctionVerificationUnitProvider

--- a/src/main/scala/verifier/SlaveVerifier.scala
+++ b/src/main/scala/verifier/SlaveVerifier.scala
@@ -8,11 +8,11 @@ package viper.silicon.verifier
 
 import viper.silver.components.StatefulComponent
 import viper.silicon.supporters._
-import viper.silver.reporter.Reporter
+import viper.silver.plugin.PluginAwareReporter
 
 class SlaveVerifier(master: MasterVerifier,
                     uniqueId: String,
-                    override val reporter: Reporter)
+                    override val reporter: PluginAwareReporter)
     extends BaseVerifier(Verifier.config, uniqueId)
        with DefaultMethodVerificationUnitProvider
        with DefaultCfgVerificationUnitProvider {

--- a/src/main/scala/verifier/Verifier.scala
+++ b/src/main/scala/verifier/Verifier.scala
@@ -17,13 +17,13 @@ import viper.silicon.state.terms.{AxiomRewriter, TriggerGenerator}
 import viper.silicon.supporters.{PredicateData, QuantifierSupporter, SnapshotSupporter}
 import viper.silicon.supporters.functions.FunctionData
 import viper.silicon.utils.Counter
-import viper.silver.reporter.Reporter
+import viper.silver.plugin.PluginAwareReporter
 
 trait Verifier {
   def uniqueId: String
 
   def logger: Logger
-  def reporter: Reporter
+  def reporter: PluginAwareReporter
   def counter(id: AnyRef): Counter
 
   def decider: Decider


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by **@aterga** on 2019-05-26 13:20
> Last updated on 2020-02-14 14:40
> Original Bitbucket pull request id: 56
>
> Participants:
>
> * **@mschwerhoff** (reviewer) :heavy_check_mark:
>
> Source: https://github.com/viperproject/silicon/commit/fab2f2f68e321b1d840edbd6d5b814cb6a09e219 on branch `arshavir/silicon-plugin-aware-reporting/default`
> Destination: https://github.com/viperproject/silicon/commit/76f21ec30b0fe9e7be00e4e6f56db9fd42984a42 on branch `master`
>
> State: **`OPEN`**

For details, see [Silver PL 120](https://github.com/viperproject/silver/pull/421 ).
