### PR TITLE
Remove unused let-result from definitional function axiom

### DIFF
--- a/src/main/scala/supporters/functions/FunctionData.scala
+++ b/src/main/scala/supporters/functions/FunctionData.scala
@@ -204,9 +204,7 @@ class FunctionData(val programFunction: ast.Function,
     optBody.map(translatedBody => {
       val pre = And(translatedPres)
       val nestedDefinitionalAxioms = generateNestedDefinitionalAxioms
-      val innermostBody = And(nestedDefinitionalAxioms ++ List(Implies(pre, And(functionApplication === translatedBody))))
-      val bodyBindings: Map[Var, Term] = Map(formalResult -> limitedFunctionApplication)
-      val body = Let(toMap(bodyBindings), innermostBody)
+      val body = And(nestedDefinitionalAxioms ++ List(Implies(pre, And(functionApplication === translatedBody))))
       val allTriggers = (
            Seq(Trigger(functionApplication))
         ++ predicateTriggers.values.map(pt => Trigger(Seq(triggerFunctionApplication, pt))))


### PR DESCRIPTION
>  **Pull request** :twisted_rightwards_arrows: created by bitbucket user **maurobringolf** on 2020-02-10 15:45
> Last updated on 2020-02-10 15:46
> Original Bitbucket pull request id: 66
>
> Participants:
>
> * **@mschwerhoff** (reviewer)
>
> Source: https://github.com/viperproject/silicon/commit/67405ca5a3767faf19f4d67f671293da3444237a on branch `maurobringolf/silicon/function-drop-unneeded-result`
> Destination: https://github.com/viperproject/silicon/commit/76f21ec30b0fe9e7be00e4e6f56db9fd42984a42 on branch `master`
>
> State: **`OPEN`**

A minor improvement: I think we can omit the translated `result` variable from a functions definitional axiom since it is only used in the post-condition axiom \(and cannot be referred to from the function body\). No tests are affected by this change.
