### PR TITLE
A workaround for test argument passing

### DIFF
--- a/src/test/scala/SiliconTests.scala
+++ b/src/test/scala/SiliconTests.scala
@@ -56,15 +56,16 @@ class SiliconTests extends SilSuite {
     }
   }
 
-  lazy val verifiers = List(createSiliconInstance())
+  lazy val verifiers = verifiers(Map.empty)
+  override def verifiers(configMap: Map[String, Any]) = List(createSiliconInstance(configMap))
 
   val commandLineArguments: Seq[String] =
     Seq("--timeout", "300" /* seconds */)
 
-  private def createSiliconInstance() = {
+  private def createSiliconInstance(configMap: Map[String, Any]) = {
     val args =
       commandLineArguments ++
-      Silicon.optionsFromScalaTestConfigMap(prefixSpecificConfigMap.getOrElse("silicon", Map()))
+      Silicon.optionsFromScalaTestConfigMap(prefixSpecificConfigMap(configMap).getOrElse("silicon", Map()))
     val reporter = NoopReporter
     val debugInfo = ("startedBy" -> "viper.silicon.SiliconTests") :: Nil
     val silicon = Silicon.fromPartialCommandLineArguments(args, reporter, debugInfo)

--- a/src/test/scala/SiliconTests.scala
+++ b/src/test/scala/SiliconTests.scala
@@ -13,6 +13,7 @@ import viper.silver.verifier.{AbstractError, Verifier, Failure => SilFailure, Su
 import viper.silicon.{Silicon, SiliconFrontend, SymbExLogger}
 import viper.silver.frontend.DefaultStates
 import viper.silver.reporter.NoopReporter
+import viper.silver.plugin.PluginAwareReporter
 
 class SiliconTests extends SilSuite {
   private val siliconTestDirectories =
@@ -56,22 +57,22 @@ class SiliconTests extends SilSuite {
     }
   }
 
-  lazy val verifiers = verifiers(Map.empty)
-  override def verifiers(configMap: Map[String, Any]) = List(createSiliconInstance(configMap))
+  val silicon = {
+    val reporter = PluginAwareReporter(NoopReporter)
+    val debugInfo = ("startedBy" -> "viper.silicon.SiliconTests") :: Nil
+    new Silicon(reporter, debugInfo)
+  }
+
+  def verifiers = List(silicon)
+
+  override def configureVerifiersFromConfigMap(configMap: Map[String, Any]) = {
+    val args = Silicon.optionsFromScalaTestConfigMap(prefixSpecificConfigMap(configMap).getOrElse("silicon", Map()))
+    silicon.parseCommandLine(args :+ Silicon.dummyInputFilename)
+  }
 
   val commandLineArguments: Seq[String] =
     Seq("--timeout", "300" /* seconds */)
 
-  private def createSiliconInstance(configMap: Map[String, Any]) = {
-    val args =
-      commandLineArguments ++
-      Silicon.optionsFromScalaTestConfigMap(prefixSpecificConfigMap(configMap).getOrElse("silicon", Map()))
-    val reporter = NoopReporter
-    val debugInfo = ("startedBy" -> "viper.silicon.SiliconTests") :: Nil
-    val silicon = Silicon.fromPartialCommandLineArguments(args, reporter, debugInfo)
-
-    silicon
-  }
 }
 
 class SiliconFrontendWithUnitTesting extends SiliconFrontend(NoopReporter) {


### PR DESCRIPTION
Passing test arguments through scalatest, i.e. `testOnly -- -Dsilicon:logLevel=DEBUG` is not working for me. I could not figure out the precise root issue, but found a small workaround. Maybe someone else can understand and fix the root issue using this?

@mschwerhoff 

https://github.com/viperproject/silver/pull/452