### PR TITLE
Use Z3's API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ lib/
 silver
 viper_tutorial_examples
 .bsp/
+*.so
+*.log

--- a/build.sbt
+++ b/build.sbt
@@ -28,6 +28,8 @@ lazy val silicon = (project in file("."))
     // scalacOptions ++= Seq("-Xelide-below", "1000"),
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
     libraryDependencies += "org.apache.commons" % "commons-pool2" % "2.6.0",
+    libraryDependencies += "com.microsoft.z3" % "z3" % "4.8.7" from "http://www.sosy-lab.org/ivy/org.sosy_lab/javasmt-solver-z3/com.microsoft.z3-4.8.7.jar",
+    libraryDependencies += "com.regblanc" %% "scala-smtlib" % "0.2.2",
 
     // Only get a few compilation errors at once
     maxErrors := 5,

--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ lazy val silicon = (project in file("."))
     // scalacOptions ++= Seq("-Xelide-below", "1000"),
     libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.0",
     libraryDependencies += "org.apache.commons" % "commons-pool2" % "2.6.0",
-    libraryDependencies += "com.microsoft.z3" % "z3" % "4.8.7" from "http://www.sosy-lab.org/ivy/org.sosy_lab/javasmt-solver-z3/com.microsoft.z3-4.8.7.jar",
+    libraryDependencies += "com.microsoft.z3" % "z3" % "4.8.9" from "http://www.sosy-lab.org/ivy/org.sosy_lab/javasmt-solver-z3/com.microsoft.z3-4.8.9.jar",
     libraryDependencies += "com.regblanc" %% "scala-smtlib" % "0.2.2",
 
     // Only get a few compilation errors at once

--- a/silicon.sh
+++ b/silicon.sh
@@ -9,9 +9,18 @@ set -e
 BASEDIR="$(realpath `dirname $0`)"
 
 CP_FILE="$BASEDIR/silicon_classpath.txt"
+LIB_Z3_JAVA="$BASEDIR/libz3java.so"
+LIB_Z3="$BASEDIR/libz3.so"
 
 if [ ! -f $CP_FILE ]; then
     (cd $BASEDIR; sbt "export runtime:dependencyClasspath" | tail -n1 > $CP_FILE)
 fi
 
-java -Xss30M -Dlogback.configurationFile="$BASEDIR/src/main/resources/logback.xml" -cp "`cat $CP_FILE`" viper.silicon.SiliconRunner $@
+if [ ! -f "$LIB_Z3_JAVA" ]; then
+     curl 'http://www.sosy-lab.org/ivy/org.sosy_lab/javasmt-solver-z3/libz3java-4.8.7.so' -o "$LIB_Z3_JAVA"
+fi
+if [ ! -f "$LIB_Z3" ]; then
+     curl 'http://www.sosy-lab.org/ivy/org.sosy_lab/javasmt-solver-z3/libz3-4.8.7.so' -o "$LIB_Z3"
+fi
+
+java -Xss30M -Djava.library.path="$(pwd)/" -Dlogback.configurationFile="$BASEDIR/src/main/resources/logback.xml" -cp "`cat $CP_FILE`" viper.silicon.SiliconRunner $@

--- a/silicon.sh
+++ b/silicon.sh
@@ -4,8 +4,6 @@
 
 set -e
 
-set -e
-
 BASEDIR="$(realpath `dirname $0`)"
 
 CP_FILE="$BASEDIR/silicon_classpath.txt"
@@ -23,4 +21,4 @@ if [ ! -f "$LIB_Z3" ]; then
      curl 'http://www.sosy-lab.org/ivy/org.sosy_lab/javasmt-solver-z3/libz3-4.8.7.so' -o "$LIB_Z3"
 fi
 
-java -Xss30M -Djava.library.path="$(pwd)/" -Dlogback.configurationFile="$BASEDIR/src/main/resources/logback.xml" -cp "`cat $CP_FILE`" viper.silicon.SiliconRunner $@
+java -Xss30M -Djava.library.path="$BASEDIR" -Dlogback.configurationFile="$BASEDIR/src/main/resources/logback.xml" -cp "`cat $CP_FILE`" viper.silicon.SiliconRunner $@

--- a/src/main/resources/preamble.smt2
+++ b/src/main/resources/preamble.smt2
@@ -37,7 +37,7 @@
          (< p $Perm.Write)))
 
 ; min function for permissions
-(define-fun $Perm.min ((p1 $Perm) (p2 $Perm)) Real
+(define-fun $Perm.min ((p1 $Perm) (p2 $Perm)) $Perm
     (ite (<= p1 p2) p1 p2))
 
 ; --- Sort wrappers ---

--- a/src/main/scala/decider/TermToSMTLib2Converter.scala
+++ b/src/main/scala/decider/TermToSMTLib2Converter.scala
@@ -328,7 +328,7 @@ class TermToSMTLib2Converter
     else
       render(t)
 
-  protected def render(id: Identifier, sanitizeIdentifier: Boolean = true): String = {
+  def render(id: Identifier, sanitizeIdentifier: Boolean = true): String = {
     val repr: String = id match {
       case SimpleIdentifier(name) => name
       case SuffixedIdentifier(prefix, separator, suffix) => s"${render(prefix, false)}$separator$suffix"

--- a/src/main/scala/decider/TermToZ3Converter.scala
+++ b/src/main/scala/decider/TermToZ3Converter.scala
@@ -1,0 +1,121 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2019 ETH Zurich.
+
+package decider
+
+import com.microsoft.z3
+import viper.silicon.state.terms._
+import viper.silicon.state.Identifier
+
+import scala.collection.mutable
+
+class TermToZ3Converter(private val ctx: z3.Context,
+                        private val renderSortName: Sort => String,
+                        private val renderIdentifier: Identifier => String,
+                        private val renderTerm: Term => String) {
+  private val sortMap: mutable.Map[String, (z3.Symbol, z3.Sort)] = mutable.Map()
+  // The same function symbol can be used in multiple functions declarations that differ for the signature.
+  private val funcs: mutable.Buffer[(z3.Symbol, z3.FuncDecl)] = mutable.Buffer()
+  private var cachedSortSymbols: Array[z3.Symbol] = Array()
+  private var cachedSortTypes: Array[z3.Sort] = Array()
+  private var cachedFuncSymbols: Array[z3.Symbol] = Array()
+  private var cachedFuncDecls: Array[z3.FuncDecl] = Array()
+
+  // Initialize with builtin sorts
+  registerSort("Bool", _ => ctx.getBoolSort)
+  registerSort("Int", _ => ctx.getIntSort)
+  registerSort("Real", _ => ctx.getRealSort)
+
+  def registerSort(name: String, mkSort: (z3.Symbol) => z3.Sort): z3.Sort = {
+    if (sortMap.contains(name)) {
+      throw new IllegalArgumentException(s"A sort named '$name' has already been registered.")
+    }
+    val symbol = ctx.mkSymbol(name)
+    val sort = mkSort(symbol)
+    sortMap(name) = (symbol, sort)
+    // Invalidate cache
+    cachedSortSymbols = null
+    cachedSortTypes = null
+    sort
+  }
+
+  def getSort(name: String): z3.Sort = {
+    sortMap(name)._2
+  }
+
+  def registerFuncDecl(name: String, mkFunDecl: (z3.Symbol) => z3.FuncDecl): z3.FuncDecl = {
+    val symbol = ctx.mkSymbol(name)
+    val funcDecl = mkFunDecl(symbol)
+    funcs.append((symbol, funcDecl))
+    // Invalidate cache
+    cachedFuncSymbols = null
+    cachedFuncDecls = null
+    funcDecl
+  }
+
+  /// Interpret an SMTLIB2 command, returning the first parsed boolean expressions.
+  def parseCommand(command: String): z3.BoolExpr = {
+    if (cachedSortSymbols == null || cachedSortTypes == null) {
+      val sorts = sortMap.values.toSeq
+      cachedSortSymbols = sorts.map(_._1).toArray
+      cachedSortTypes = sorts.map(_._2).toArray
+    }
+    if (cachedFuncSymbols == null || cachedFuncDecls == null) {
+      cachedFuncSymbols = funcs.map(_._1).toArray
+      cachedFuncDecls = funcs.map(_._2).toArray
+    }
+    ctx.parseSMTLIB2String(
+      command.replace("\n", " ").replace("\t", " "),
+      cachedSortSymbols,
+      cachedSortTypes,
+      cachedFuncSymbols,
+      cachedFuncDecls
+    ).head
+  }
+
+  def declare(decl: Decl): Option[z3.BoolExpr] = {
+    decl match {
+      case SortDecl(sort: Sort) =>
+        val name = renderSortName(sort)
+        registerSort(name, ctx.mkUninterpretedSort)
+        None
+
+      case FunctionDecl(fun: Function) =>
+        val name: String = renderIdentifier(fun.id)
+        val argSortNames = fun.argSorts.map(renderSortName).filter(_ != "")
+        val z3ArgSorts = argSortNames.map(sortMap).map(_._2).toArray
+        val returnSortName = renderSortName(fun.resultSort)
+        val z3ResultSort = sortMap(returnSortName)._2
+        registerFuncDecl(name, ctx.mkFuncDecl(_, z3ArgSorts, z3ResultSort))
+        None
+
+      case swd @ SortWrapperDecl(from, to) =>
+        val name: String = renderIdentifier(swd.id)
+        val argSortName = renderSortName(from)
+        val z3ArgSort = sortMap(argSortName)._2
+        val returnSortName = renderSortName(to)
+        val z3ResultSort = sortMap(returnSortName)._2
+        registerFuncDecl(name, ctx.mkFuncDecl(_, z3ArgSort, z3ResultSort))
+        None
+
+      case MacroDecl(id, args, body) =>
+        val name: String = renderIdentifier(id)
+        val argSortNames = args.map(_.sort).map(renderSortName)
+        val z3ArgSorts = argSortNames.map(sortMap).map(_._2).toArray
+        val resultSortName = renderSortName(body.sort)
+        val z3ResultSort = sortMap(resultSortName)._2
+        registerFuncDecl(name, ctx.mkFuncDecl(_, z3ArgSorts, z3ResultSort))
+
+        // Convert a Term to a Z3 expression by generating and parsing a SMTLIB2 command.
+        val paramNames = args.map(_.id).map(renderIdentifier)
+        val vars = args.map(p => s"(${p.id.name} ${renderSortName(p.sort)})")
+        val triggers = s":pattern (($name ${paramNames.mkString(" ")}))"
+        Some(parseCommand(
+          s"(assert (forall (${vars.mkString(" ")}) (! (= ($name ${paramNames.mkString(" ")}) ${renderTerm(body)}) $triggers)))"
+        ))
+    }
+  }
+}

--- a/src/main/scala/decider/Z3ProverStdIO.scala
+++ b/src/main/scala/decider/Z3ProverStdIO.scala
@@ -6,20 +6,23 @@
 
 package viper.silicon.decider
 
-import java.io.{BufferedReader, BufferedWriter, InputStreamReader, OutputStreamWriter, PrintWriter}
-import java.nio.file.{Path, Paths}
-import java.util.concurrent.TimeUnit
+import java.io.{PrintWriter, StringReader}
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import com.microsoft.z3
 import com.typesafe.scalalogging.LazyLogging
-import viper.silicon.{Config, Map, toMap}
+import org.scalactic.TimesOnInt.convertIntToRepeater
+import smtlib.trees.Commands._
+import smtlib.trees.Terms.SSymbol
+import viper.silicon.{Config, Map}
 import viper.silicon.common.config.Version
 import viper.silicon.interfaces.decider.{Prover, Sat, Unknown, Unsat}
-import viper.silicon.reporting.{ExternalToolError, Z3InteractionFailed}
+import viper.silicon.reporting.Z3InteractionFailed
 import viper.silicon.state.IdentifierFactory
 import viper.silicon.state.terms._
 import viper.silicon.verifier.Verifier
 import viper.silver.plugin.PluginAwareReporter
-import viper.silver.reporter.{ConfigurationConfirmation, InternalWarningMessage}
 
 class Z3ProverStdIO(uniqueId: String,
                     termConverter: TermToSMTLib2Converter,
@@ -31,19 +34,35 @@ class Z3ProverStdIO(uniqueId: String,
   private var pushPopScopeDepth = 0
   private var lastTimeout: Int = -1
   private var logfileWriter: PrintWriter = _
-  private var z3: Process = _
-  private var input: BufferedReader = _
-  private var output: PrintWriter = _
-  /* private */ var z3Path: Path = _
+  private var ctx: z3.Context = _
+  private var solver: z3.Solver = _
   var lastModel : String = null
+  var sortMap: mutable.Map[String, z3.Sort] = _
+  var sortSymbols: Array[z3.Symbol] = _
+  var sortTypes: Array[z3.Sort] = _
+  var funMap: mutable.Map[String, z3.FuncDecl] = _
+  var funSymbols: Array[z3.Symbol] = _
+  var funDecls: Array[z3.FuncDecl] = _
+
+  /// Not very robust, but they work for Silicon.
+  private object Patterns {
+    val Assert = """\(assert (.*)\)""".r
+    val SetOption = """\(set-option :([-_A-Za-z0-9$.]+) ("?[^"]+"?)\)[^(]*""".r
+    val DeclareSort = """\(declare-sort ([A-Za-z$.]+)\s?(\d+)?\)""".r
+    val DefineSort = """\(define-sort ([A-Za-z$.]+) \(\) ([A-Za-z]+)\)""".r
+    val DeclareConst = """\(declare-const ([A-Za-z$._]+) ([A-Za-z$.<>_]+)\)""".r
+    val DefineConst = """\(define-const ([A-Za-z$.]+) ([A-Za-z$.]+) ([A-Za-z0-9$.]+)\)""".r
+    val Int = """\d+""".r
+    val Double = """\|\d+\.\d+\|""".r
+  }
+
+  def z3Path(): String = {
+    "(dynamic library)"
+  }
 
   def z3Version(): Version = {
     val versionPattern = """\(?\s*:version\s+"(.*?)(?:\s*-.*?)?"\)?""".r
-    var line = ""
-
-    writeLine("(get-info :version)")
-
-    line = input.readLine()
+    val line = ":version \"" + z3.Version.getFullVersion().stripPrefix("Z3 ") + "\""
     comment(line)
 
     line match {
@@ -56,50 +75,24 @@ class Z3ProverStdIO(uniqueId: String,
     pushPopScopeDepth = 0
     lastTimeout = -1
     logfileWriter = if (Verifier.config.disableTempDirectory()) null else viper.silver.utility.Common.PrintWriter(Verifier.config.z3LogFile(uniqueId).toFile)
-    z3Path = Paths.get(Verifier.config.z3Exe)
-    z3 = createZ3Instance()
-    input = new BufferedReader(new InputStreamReader(z3.getInputStream))
-    output = new PrintWriter(new BufferedWriter(new OutputStreamWriter(z3.getOutputStream)), true)
-  }
+    z3.Global.ToggleWarningMessages(true)
 
-  private def createZ3Instance() = {
-    // One can pass some options. This allows to check whether they have been received.
-    val msg = s"Starting Z3 at location '$z3Path'"
-    reporter report ConfigurationConfirmation(msg)
-    logger debug msg
-
-    val z3File = z3Path.toFile
-
-    if (!z3File.isFile)
-      throw ExternalToolError("Z3", s"Cannot run Z3 at location '$z3File': not a file.")
-
-    if (!z3File.canExecute)
-      throw ExternalToolError("Z3", s"Cannot run Z3 at location '$z3File': file is not executable.")
-
-    val userProvidedZ3Args: Array[String] = Verifier.config.z3Args.toOption match {
-      case None =>
-        Array()
-
-      case Some(args) =>
-        // One can pass some options. This allows to check whether they have been received.
-        val msg = s"Additional command-line arguments are $args"
-        reporter report ConfigurationConfirmation(msg)
-        logger debug msg
-        args.split(' ').map(_.trim)
-    }
-
-    val builder = new ProcessBuilder(z3Path.toFile.getPath +: "-smt2" +: "-in" +: userProvidedZ3Args :_*)
-    builder.redirectErrorStream(true)
-
-    val process = builder.start()
-
-    Runtime.getRuntime.addShutdownHook(new Thread {
-      override def run() {
-        process.destroy()
-      }
-    })
-
-    process
+    // Initialize Z3 via the API
+    val cfg = Map[String, String](
+      //"global-decls" -> "true"
+    )
+    ctx = new z3.Context(mapAsJavaMap(cfg))
+    solver = ctx.mkSolver()
+    sortMap = mutable.Map(
+      "Int" -> ctx.getIntSort,
+      "Bool" -> ctx.getBoolSort,
+      "Real" -> ctx.getRealSort,
+    )
+    sortSymbols = Array()
+    sortTypes = Array()
+    funMap = mutable.Map()
+    funSymbols = Array()
+    funDecls = Array()
   }
 
   def reset() {
@@ -116,46 +109,141 @@ class Z3ProverStdIO(uniqueId: String,
       if (logfileWriter != null) {
         logfileWriter.flush()
       }
-      if (output != null) {
-        output.flush()
-      }
-      if (z3 != null) {
-        z3.destroyForcibly()
-        z3.waitFor(10, TimeUnit.SECONDS) /* Makes the current thread wait until the process has been shut down */
-      }
 
       if (logfileWriter != null) {
         logfileWriter.close()
       }
-      if (input != null) {
-        input.close()
-      }
-      if (output != null) {
-        output.close()
-      }
     }
+
+    solver = null
+    ctx = null
+    sortMap = null
+    sortSymbols = null
+    sortTypes = null
+    funMap = null
+    funSymbols = null
+    funDecls = null
   }
 
   def push(n: Int = 1) {
     pushPopScopeDepth += n
     val cmd = (if (n == 1) "(push)" else "(push " + n + ")") + " ; " + pushPopScopeDepth
-    writeLine(cmd)
-    readSuccess()
+    logToFile(cmd)
+    n times { solver.push() }
   }
 
   def pop(n: Int = 1) {
     val cmd = (if (n == 1) "(pop)" else "(pop " + n + ")") + " ; " + pushPopScopeDepth
     pushPopScopeDepth -= n
-    writeLine(cmd)
-    readSuccess()
+    logToFile(cmd)
+    solver.pop(n)
+  }
+
+  private def registerSort(name: String, mkSort: (z3.Symbol) => z3.Sort): z3.Sort = {
+    val symbol = ctx.mkSymbol(name)
+    val sort = mkSort(symbol)
+    sortMap.update(name, sort)
+    // FIXME: this is inefficient as it makes a copy of the array each time.
+    sortSymbols = sortSymbols :+ symbol
+    sortTypes = sortTypes :+ sort
+    sort
+  }
+
+  private def registerFuncDecl(name: String, mkSort: (z3.Symbol) => z3.FuncDecl): z3.FuncDecl = {
+    val symbol = ctx.mkSymbol(name)
+    val funDecl = mkSort(symbol)
+    funMap.update(name, funDecl)
+    // FIXME: this is inefficient as it makes a copy of the array each time.
+    funSymbols = funSymbols :+ symbol
+    funDecls = funDecls :+ funDecl
+    funDecl
+  }
+
+  private def parseCommand(cmd: String): Command = {
+    val input = new StringReader(cmd)
+    val lexer = new smtlib.lexer.Lexer(input)
+    val parser = new smtlib.parser.Parser(lexer)
+    parser.parseCommand
   }
 
   def emit(content: String) {
-    writeLine(content)
-    readSuccess()
+    logToFile(content)
+
+    // HACK: There are too many uses of `emit()`, so we are forced to interpret the command.
+    val command = content.replace("\t", " ").replace("\n", " ")
+    command match {
+      case Patterns.Assert(_) =>
+        parseSMTLIB2Command(command).foreach(solver.add(_))
+      // FIXME: It seems that these options are not allowed. Why?
+      case Patterns.SetOption(key, value) if
+          key == "global-decls" || key == "print-success" || key == "type_check" || key == "smt.qi.cost"
+            || key.startsWith("fp.spacer") || key == "smt.random_seed" || key.startsWith("sls.") => // Skip
+      case Patterns.SetOption(key, value) =>
+        val p = ctx.mkParams()
+        value match {
+          case "true" => p.add(key, true)
+          case "false" => p.add(key, false)
+          case Patterns.Int() if key == "smt.qi.eager_threshold" => p.add(key, value.toDouble)
+          case Patterns.Int() => p.add(key, value.toInt)
+          case Patterns.Double() => p.add(key, value.stripPrefix("|").stripSuffix("|").toDouble)
+          case _ => p.add(key, value)
+        }
+        solver.setParameters(p)
+      case Patterns.DeclareSort(name, arity) if arity == null || arity == "0" =>
+        registerSort(name, ctx.mkUninterpretedSort(_))
+      case Patterns.DefineSort(name, ref) if ref == "Real" =>
+        registerSort(name, _ => ctx.mkRealSort())
+      case Patterns.DeclareConst(name, sortName) =>
+        registerFuncDecl(name, ctx.mkFuncDecl(_, Array[z3.Sort](), sortMap(sortName)))
+      case Patterns.DefineConst(name, sortName, body) =>
+        registerFuncDecl(name, ctx.mkFuncDecl(_, Array[z3.Sort](), sortMap(sortName)))
+        parseSMTLIB2Command(s"(assert (= $name $body))").foreach(solver.add(_))
+      case complex_command =>
+        parseCommand(complex_command) match {
+          case DeclareFun(SSymbol(name), params, returnSort) =>
+            val paramSorts = params.map(_.toString).map(sortMap).toArray
+            registerFuncDecl(name, ctx.mkFuncDecl(_, paramSorts, sortMap(returnSort.toString)))
+          case DefineFun(FunDef(SSymbol(name), params, returnSort, body)) =>
+            val paramSorts = params.map(_.sort.toString).map(sortMap).toArray
+            registerFuncDecl(name, ctx.mkFuncDecl(_, paramSorts, sortMap(returnSort.toString)))
+            val paramNames = params.map(_.name.name)
+            val vars = params.map(p => s"(${p.name.name} ${p.sort.toString})")
+            val triggers = s":pattern (($name ${paramNames.mkString(" ")}))"
+            parseSMTLIB2Command(
+              s"(assert (forall (${vars.mkString(" ")}) (! (= ($name ${paramNames.mkString(" ")}) $body) $triggers)))"
+            ).foreach(solver.add(_))
+          case DeclareDatatypes(Seq((SSymbol(name), constructors))) =>
+            val localSortMap = (sortName: String) => if (sortName == name) { null } else { sortMap(name) }
+            var z3Constructors = Seq[z3.Constructor]()
+            for (constructor <- constructors) {
+              z3Constructors = z3Constructors :+ ctx.mkConstructor(
+                constructor.sym.name,
+                "is_" + constructor.sym.name, // FIXME: Is this correct? What should we use?
+                constructor.fields.map(_._1.name).toArray,
+                constructor.fields.map(_._2.toString).map(localSortMap).toArray,
+                null
+              )
+            }
+            registerSort(name, ctx.mkDatatypeSort(_, z3Constructors.toArray))
+          case todo =>
+            // This should be unreachable
+            throw new Exception(s"Unhandled SMTLIB2 command: '$todo''")
+        }
+    }
   }
 
 //  private val quantificationLogger = bookkeeper.logfiles("quantification-problems")
+
+  /// Interpret a smtlib2 command, returning the parsed expressions (e.g. those used in `(assert ...)` commands).
+  private def parseSMTLIB2Command(command: String): Array[z3.BoolExpr] = {
+    ctx.parseSMTLIB2String(
+      command.replace("\n", " ").replace("\t", " "),
+      sortSymbols,
+      sortTypes,
+      funSymbols,
+      funDecls
+    )
+  }
 
   def assume(term: Term) = {
 //    /* Detect certain simple problems with quantifiers.
@@ -166,7 +254,7 @@ class Z3ProverStdIO(uniqueId: String,
 //      val problems = QuantifierSupporter.detectQuantificationProblems(q)
 //
 //      if (problems.nonEmpty) {
-//        quantificationLogger.println(s"\n\n${q.toString(true)}")
+//        quantificationLogger.println(solver"\n\n${q.toString(true)}")
 //        quantificationLogger.println("Problems:")
 //        problems.foreach(p => quantificationLogger.println(s"  $p"))
 //      }
@@ -178,8 +266,8 @@ class Z3ProverStdIO(uniqueId: String,
   def assume(term: String) {
 //    bookkeeper.assumptionCounter += 1
 
-    writeLine("(assert " + term + ")")
-    readSuccess()
+    logToFile("(assert " + term + ")")
+    parseSMTLIB2Command("(assert " + term + ")").foreach(solver.add(_))
   }
 
   def assert(goal: Term, timeout: Option[Int] = None) =
@@ -204,12 +292,11 @@ class Z3ProverStdIO(uniqueId: String,
   private def assertUsingPushPop(goal: String): (Boolean, Long) = {
     push()
 
-    writeLine("(assert (not " + goal + "))")
-    readSuccess()
+    logToFile("(assert (not " + goal + "))")
+    parseSMTLIB2Command("(assert (not " + goal + "))").foreach(solver.add(_))
 
     val startTime = System.currentTimeMillis()
-    writeLine("(check-sat)")
-    val result = readUnsat()
+    val result = solver.check() == z3.Status.UNSATISFIABLE
     val endTime = System.currentTimeMillis()
 
     if (!result) {
@@ -231,31 +318,26 @@ class Z3ProverStdIO(uniqueId: String,
   def saturate(timeout: Int, comment: String): Unit = {
     this.comment(s"State saturation: $comment")
     setTimeout(Some(timeout))
-    writeLine("(check-sat)")
-    readLine()
+    logToFile("(check-sat)")
+    solver.check()
   }
 
   private def getModel(): Unit = {
     if (Verifier.config.counterexample.toOption.isDefined) {
-      writeLine("(get-model)")
-
-      var model = readModel("\n").trim()
-      if (model.startsWith("\"")){
-        model = model.replaceAll("\"", "")
-      }
-      lastModel = model
+      logToFile("(get-model)")
+      lastModel = solver.getModel.toString
     }
   }
 
   private def assertUsingSoftConstraints(goal: String): (Boolean, Long) = {
     val guard = fresh("grd", Nil, sorts.Bool)
 
-    writeLine(s"(assert (implies $guard (not $goal)))")
-    readSuccess()
+    logToFile(s"(assert (implies $guard (not $goal)))")
+    parseSMTLIB2Command(s"(assert (implies $guard (not $goal)))").foreach(solver.add(_))
 
     val startTime = System.currentTimeMillis()
-    writeLine(s"(check-sat $guard)")
-    val result = readUnsat()
+    logToFile(s"(check-sat $guard)")
+    val result = solver.check() == z3.Status.UNSATISFIABLE
     val endTime = System.currentTimeMillis()
 
     if (!result) {
@@ -268,12 +350,12 @@ class Z3ProverStdIO(uniqueId: String,
   def check(timeout: Option[Int] = None) = {
     setTimeout(timeout)
 
-    writeLine("(check-sat)")
+    logToFile("(check-sat)")
 
-    readLine() match {
-      case "sat" => Sat
-      case "unsat" => Unsat
-      case "unknown" => Unknown
+    solver.check() match {
+      case z3.Status.SATISFIABLE => Sat
+      case z3.Status.UNSATISFIABLE => Unsat
+      case z3.Status.UNKNOWN => Unknown
     }
   }
 
@@ -289,40 +371,22 @@ class Z3ProverStdIO(uniqueId: String,
       lastTimeout = effectiveTimeout
 
       if(Verifier.config.z3EnableResourceBounds()) {
-        writeLine(s"(set-option :rlimit ${effectiveTimeout * (Verifier.config.z3ResourcesPerMillisecond())})")
+        logToFile(s"(set-option :rlimit ${effectiveTimeout * (Verifier.config.z3ResourcesPerMillisecond())})")
+        val p = ctx.mkParams()
+        p.add("rlimit", effectiveTimeout * (Verifier.config.z3ResourcesPerMillisecond()))
+        solver.setParameters(p)
       } else {
-        writeLine(s"(set-option :timeout $effectiveTimeout)")
+        logToFile(s"(set-option :timeout $effectiveTimeout)")
+        val p = ctx.mkParams()
+        p.add("timeout", effectiveTimeout)
+        solver.setParameters(p)
       }
-      readSuccess()
     }
   }
 
   def statistics(): Map[String, String]= {
-    var repeat = true
-    var line = ""
-    var stats = scala.collection.immutable.SortedMap[String, String]()
-    val entryPattern = """\(?\s*:([A-za-z\-]+)\s+((?:\d+\.)?\d+)\)?""".r
-
-    writeLine("(get-info :all-statistics)")
-
-    do {
-      line = input.readLine()
-      comment(line)
-
-      /* Check that the first line starts with "(:". */
-      if (line.isEmpty && !line.startsWith("(:"))
-        throw Z3InteractionFailed(uniqueId, s"Unexpected output of Z3 while reading statistics: $line")
-
-      line match {
-        case entryPattern(entryName, entryNumber) =>
-          stats = stats + (entryName -> entryNumber)
-        case _ =>
-      }
-
-      repeat = !line.endsWith(")")
-    } while (repeat)
-
-    toMap(stats)
+    // TODO
+    Map()
   }
 
   def comment(str: String) = {
@@ -338,14 +402,46 @@ class Z3ProverStdIO(uniqueId: String,
     val fun = Fun(id, argSorts, resultSort)
     val decl = FunctionDecl(fun)
 
-    emit(termConverter.convert(decl))
+    declare(decl)
 
     fun
   }
 
   def declare(decl: Decl) {
     val str = termConverter.convert(decl)
-    emit(str)
+    logToFile(str)
+
+    decl match {
+      case SortDecl(sort: Sort) =>
+        val name: String = termConverter.convert(sort)
+        registerSort(name, ctx.mkUninterpretedSort(_))
+
+      case FunctionDecl(fun: Function) =>
+        val idDoc: String = termConverter.render(fun.id)
+        val z3ArgSortsDoc = fun.argSorts.map(termConverter.convert).filter(_ != "").map(sortMap).toArray
+        val z3ResultSortDoc = sortMap(termConverter.convert(fun.resultSort))
+        registerFuncDecl(idDoc, ctx.mkFuncDecl(_, z3ArgSortsDoc, z3ResultSortDoc))
+
+      case swd @ SortWrapperDecl(from, to) =>
+        val idDoc: String = termConverter.render(swd.id)
+        val z3ArgSortDoc = sortMap(termConverter.convert(from))
+        val z3ResultSortDoc = sortMap(termConverter.convert(to))
+        registerFuncDecl(idDoc, ctx.mkFuncDecl(_, z3ArgSortDoc, z3ResultSortDoc))
+
+      case MacroDecl(id, args, body) =>
+        val idDoc: String = termConverter.render(id)
+        val z3ArgSortsDoc = args.map(_.sort).map(termConverter.convert).map(sortMap).toArray
+        val z3ResultSortDoc = sortMap(termConverter.convert(body.sort))
+        registerFuncDecl(idDoc, ctx.mkFuncDecl(_, z3ArgSortsDoc, z3ResultSortDoc))
+
+        // HACK: Convert a Term to a Z3 expression by generating and parsing a SMTLIB2 command.
+        val paramNames = args.map(_.id.name)
+        val vars = args.map(p => s"(${p.id.name} ${termConverter.convert(p.sort)})")
+        val triggers = s":pattern (($idDoc ${paramNames.mkString(" ")}))"
+        parseSMTLIB2Command(
+          s"(assert (forall (${vars.mkString(" ")}) (! (= ($idDoc ${paramNames.mkString(" ")}) ${termConverter.convert(body)}) $triggers)))"
+        ).foreach(solver.add(_))
+    }
   }
 
 //  def resetAssertionCounter() { bookkeeper.assertionCounter = 0 }
@@ -356,75 +452,10 @@ class Z3ProverStdIO(uniqueId: String,
 //    resetAssumptionCounter()
 //  }
 
-  /* TODO: Handle multi-line output, e.g. multiple error messages. */
-
-  private def readSuccess() {
-    val answer = readLine()
-
-    if (answer != "success")
-      throw Z3InteractionFailed(uniqueId, s"Unexpected output of Z3. Expected 'success' but found: $answer")
-  }
-
-  private def readUnsat(): Boolean = readLine() match {
-    case "unsat" => true
-    case "sat" => false
-    case "unknown" => false
-
-    case result =>
-      throw Z3InteractionFailed(uniqueId, s"Unexpected output of Z3 while trying to refute an assertion: $result")
-  }
-
-  private def readModel(separator: String = " "): String = {
-    try {
-      var endFound = false
-      var result = ""
-      var firstTime = true
-      while (!endFound) {
-        val nextLine = input.readLine()
-        if (nextLine.trim().endsWith("\"") || (firstTime && !nextLine.startsWith("\""))) {
-          endFound = true
-        }
-        result = result + separator + nextLine
-        firstTime = false
-      }
-      result
-    } catch {
-      case e: Exception =>
-        println("Error reading model: " + e)
-        ""
-    }
-  }
-
-  private def readLine(): String = {
-    var repeat = true
-    var result = ""
-
-    while (repeat) {
-      result = input.readLine()
-      if (result.toLowerCase != "success") comment(result)
-
-      val warning = result.startsWith("WARNING")
-      if (warning) {
-        val msg = s"Z3 warning: $result"
-        reporter report InternalWarningMessage(msg)
-        logger warn msg
-      }
-
-      repeat = warning
-    }
-
-    result
-  }
-
   private def logToFile(str: String) {
     if (logfileWriter != null) {
       logfileWriter.println(str)
     }
-  }
-
-  private def writeLine(out: String) = {
-    logToFile(out)
-    output.println(out)
   }
 
   override def getLastModel(): String = lastModel


### PR DESCRIPTION
Do not merge. This PR is a proof of concept for using Z3's API from Silicon. On a few Viper examples that I tried it seems to work fine, with up to a 2x slowdown (e.g. 58s -> 2m). This is expected as Silicon is still pretty-printing all the commands as before, so there is room for optimizations.
* The `Z3_EXE` variable is no longer used.
* The code has not been optimized, and is e.g. quadratic in the number of sort and function definitions.
* Various hacks are used to still support clients who want to directly emit SMT-LIB2 commands (e.g. in a case we pretty print a term, match it with a regex, parse it with a SMT-LIB2 parser, use it to generate another SMT-LIB2 command, and finally pass the command to Z3, which will use its own parser).
* The PR overwrites the existing `Z3ProverStdIO` just to have a clear diff of the modifications.

What this PR doesn't do:
* [ ] Move the modifications to a new `Z3ProverLib` class, adding a command line option to choose between it and the usual `Z3ProverStdIO`.
* [ ] Rewrite clients of `Z3ProverStdIO` to rely less on `emit(String)` and more on a new `emitTerm(Term)` method.
* [ ] Implement a conversion from `Term` to Z3's AST without going through the SMT-LIB2 format. This will allow to remove hacks and conversions of `Term` types to `String`.
* [ ] Compile Z3 enabling the Java API. This means that the Z3 artifacts produced by Jenkins should include e.g. the `libz3.so`, `libz3java.so` and `z3.jar` files.