### PR TITLE
Bugfix, invert base and variant mean columns in compare_benchmarks.py.

### DIFF
--- a/utils/scripts/compare_benchmarks.py
+++ b/utils/scripts/compare_benchmarks.py
@@ -96,7 +96,7 @@ def main():
       baseline[[input_headers.file, input_headers.outputs, input_headers.mean]], 
       how='outer', 
       on=input_headers.file,
-      suffixes=('_base', '_var'))
+      suffixes=('_var', '_base'))
 
     comparison = comparison.set_index(input_headers.file)
 


### PR DESCRIPTION
Previously, the Mean (B) column showed the Mean data from the variant file, and the Mean (V) column the data from the base file.

With the original version, a negative ΔMean actually showed that the variant is slower than the baseline, so a decrease in performance.

[base.csv](https://github.com/viperproject/silicon/files/6350374/base.csv)
[variant.csv](https://github.com/viperproject/silicon/files/6350377/variant.csv)

Comparing base and variant using the original version:

[ORIGINAL-variant.csv__vs-base.csv](https://github.com/viperproject/silicon/files/6350376/ORIGINAL-variant.csv__vs-base.csv)

Comparing base and variant using the fixed version:

[FIXED-variant.csv__vs-base.csv](https://github.com/viperproject/silicon/files/6350375/FIXED-variant.csv__vs-base.csv)







