### PR TITLE
WIP: Report one Error per Path

### DIFF
--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -46,7 +46,7 @@ trait Decider {
    *         1. It passes State and Operations to the continuation
    *         2. The implementation reacts to a failing assertion by e.g. a state consolidation
    */
-  def assert(t: Term, timeout: Option[Int] = None)(Q:  Boolean => VerificationResult): VerificationResult
+  def assert(t: Term, timeout: Option[Int] = None)(Q:  Boolean => VerificationResultWrapper): VerificationResultWrapper
 
   def fresh(id: String, sort: Sort): Var
   def fresh(id: String, argSorts: Seq[Sort], resultSort: Sort): Function
@@ -199,8 +199,8 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     def check(t: Term, timeout: Int) = deciderAssert(t, Some(timeout))
 
     def assert(t: Term, timeout: Option[Int] = Verifier.config.assertTimeout.toOption)
-              (Q: Boolean => VerificationResult)
-              : VerificationResult = {
+              (Q: Boolean => VerificationResultWrapper)
+              : VerificationResultWrapper = {
 
       val success = deciderAssert(t, timeout)
 

--- a/src/main/scala/rules/HeuristicsSupporter.scala
+++ b/src/main/scala/rules/HeuristicsSupporter.scala
@@ -30,9 +30,9 @@ object heuristicsSupporter extends SymbolicExecutionRules {
   def tryOperation[O1]
                   (description: String)
                   (s: State, h: Heap, v: Verifier)
-                  (action: (State, Heap, Verifier, (State, O1, Verifier) => VerificationResult) => VerificationResult)
-                  (Q: (State, O1, Verifier) => VerificationResult)
-                  : VerificationResult = {
+                  (action: (State, Heap, Verifier, (State, O1, Verifier) => VerificationResultWrapper) => VerificationResultWrapper)
+                  (Q: (State, O1, Verifier) => VerificationResultWrapper)
+                  : VerificationResultWrapper = {
 
     tryWithReactions[O1](description)(s, h, v)(action, None)(Q)
   }
@@ -41,11 +41,11 @@ object heuristicsSupporter extends SymbolicExecutionRules {
   def tryOperation[O1, O2]
                   (description: String)
                   (s: State, h: Heap, v: Verifier)
-                  (action: (State, Heap, Verifier, (State, O1, O2, Verifier) => VerificationResult) => VerificationResult)
-                  (Q: (State, O1, O2, Verifier) => VerificationResult)
-                  : VerificationResult = {
+                  (action: (State, Heap, Verifier, (State, O1, O2, Verifier) => VerificationResultWrapper) => VerificationResultWrapper)
+                  (Q: (State, O1, O2, Verifier) => VerificationResultWrapper)
+                  : VerificationResultWrapper = {
 
-    val tupledAction = (s1: State, h1: Heap, v1: Verifier, QS: (State, (O1, O2), Verifier) => VerificationResult) =>
+    val tupledAction = (s1: State, h1: Heap, v1: Verifier, QS: (State, (O1, O2), Verifier) => VerificationResultWrapper) =>
       action(s1, h1, v1, (s2, o1: O1, o2: O2, v2) => QS(s2, (o1, o2), v2))
 
     val tupledQ = (s1: State, os: (O1, O2), v1: Verifier) => Q(s1, os._1, os._2, v1)
@@ -57,11 +57,11 @@ object heuristicsSupporter extends SymbolicExecutionRules {
   def tryOperation[O1, O2, O3]
                   (description: String)
                   (s: State, h: Heap, v: Verifier)
-                  (action: (State, Heap, Verifier, (State, O1, O2, O3, Verifier) => VerificationResult) => VerificationResult)
-                  (Q: (State, O1, O2, O3, Verifier) => VerificationResult)
-                  : VerificationResult = {
+                  (action: (State, Heap, Verifier, (State, O1, O2, O3, Verifier) => VerificationResultWrapper) => VerificationResultWrapper)
+                  (Q: (State, O1, O2, O3, Verifier) => VerificationResultWrapper)
+                  : VerificationResultWrapper = {
 
-    val tupledAction = (s1: State, h1: Heap, v1: Verifier, QS: (State, (O1, O2, O3), Verifier) => VerificationResult) =>
+    val tupledAction = (s1: State, h1: Heap, v1: Verifier, QS: (State, (O1, O2, O3), Verifier) => VerificationResultWrapper) =>
         action(s1, h1, v1, (s2, o1: O1, o2: O2, o3: O3, v2) => QS(s2, (o1, o2, o3), v2))
 
     val tupledQ = (s1: State, os: (O1, O2, O3), v1: Verifier) => Q(s1, os._1, os._2, os._3, v1)
@@ -73,11 +73,11 @@ object heuristicsSupporter extends SymbolicExecutionRules {
   def tryOperation[O1, O2, O3, O4]
                   (description: String)
                   (s: State, h: Heap, v: Verifier)
-                  (action: (State, Heap, Verifier, (State, O1, O2, O3, O4, Verifier) => VerificationResult) => VerificationResult)
-                  (Q: (State, O1, O2, O3, O4, Verifier) => VerificationResult)
-                  : VerificationResult = {
+                  (action: (State, Heap, Verifier, (State, O1, O2, O3, O4, Verifier) => VerificationResultWrapper) => VerificationResultWrapper)
+                  (Q: (State, O1, O2, O3, O4, Verifier) => VerificationResultWrapper)
+                  : VerificationResultWrapper = {
 
-    val tupledAction = (s1: State, h1: Heap, v1: Verifier, QS: (State, (O1, O2, O3, O4), Verifier) => VerificationResult) =>
+    val tupledAction = (s1: State, h1: Heap, v1: Verifier, QS: (State, (O1, O2, O3, O4), Verifier) => VerificationResultWrapper) =>
       action(s1, h1, v1, (s2, o1: O1, o2: O2, o3: O3, o4: O4, v2) => QS(s2, (o1, o2, o3, o4), v2))
 
     val tupledQ = (s1: State, os: (O1, O2, O3, O4), v1: Verifier) => Q(s1, os._1, os._2, os._3, os._4, v1)
@@ -94,10 +94,10 @@ object heuristicsSupporter extends SymbolicExecutionRules {
   private def tryWithReactions[O]
                               (description: String)
                               (_s: State, h: Heap, v: Verifier)
-                              (action: (State, Heap, Verifier, (State, O, Verifier) => VerificationResult) => VerificationResult,
-                               initialFailure: Option[Failure])
-                              (Q: (State, O, Verifier) => VerificationResult)
-                              : VerificationResult = {
+                              (action: (State, Heap, Verifier, (State, O, Verifier) => VerificationResultWrapper) => VerificationResultWrapper,
+                               initialFailure: Option[VerificationResultWrapper])
+                              (Q: (State, O, Verifier) => VerificationResultWrapper)
+                              : VerificationResultWrapper = {
 
     val myId = cnt; cnt += 1
     val baseIdent = "  "
@@ -169,12 +169,12 @@ object heuristicsSupporter extends SymbolicExecutionRules {
      * reset to 0 in the `QS`, which allows further (nested) heuristics.
      */
 
-    var reactionResult: VerificationResult = globalActionResult
+    var reactionResult: VerificationResultWrapper = globalActionResult
       /* A bit hacky, but having an initial result here simplifies things quite a bit */
 
     (globalActionResult: @unchecked) match {
       case _ if    localActionSuccess
-                || !globalActionResult.isFatal
+                || !globalActionResult.containsFatal
                 || !s.applyHeuristics
 //                || stack.size >= 10 * config.maxHeuristicsDepth() /* TODO: Ugly hack! Shouldn't be necessary */
                 || s.heuristicsDepth >= Verifier.config.maxHeuristicsDepth() => /* Quit trying heuristics */
@@ -185,9 +185,9 @@ object heuristicsSupporter extends SymbolicExecutionRules {
 ////            Thread.sleep(2500)
 //        }
 
-      case actionFailure: Failure =>
+      case _ if globalActionResult.containsFailure =>
         stack ::= myId
-
+        val actionFailure = globalActionResult.getFailures.last //TODO:J feels a bit janky
         say(s"action $myId failed (locally and globally)")
         say(s"description = $description")
         say(s"globalActionResult = $globalActionResult")
@@ -202,7 +202,7 @@ object heuristicsSupporter extends SymbolicExecutionRules {
 
         say(s"generated ${remainingReactions.length} possible reactions")
 
-        while (reactionResult.isFatal && remainingReactions.nonEmpty) {
+        while (reactionResult.containsFatal && remainingReactions.nonEmpty) {
           lnsay(s"trying next reaction (${triedReactions + 1} out of ${triedReactions + remainingReactions.length})")
 
           val s1 = s.copy(h = h,
@@ -219,7 +219,7 @@ object heuristicsSupporter extends SymbolicExecutionRules {
                 s2.reserveHeaps.map(v2.stateFormatter.format).foreach(str => say(str, 2))
                 QS(s2, h2, v2)})
             )((s1, h1, c2) => {
-                tryWithReactions(description)(s1, h1, c2)(action, initialFailure.orElse(Some(actionFailure)))(Q)})
+                tryWithReactions(description)(s1, h1, c2)(action, initialFailure.orElse(Some(VerificationResultWrapper(actionFailure))))(Q)})
 
           lnsay(s"returned from reaction ${triedReactions + 1} (out of ${triedReactions + remainingReactions.length})")
           say(s"reactionResult = $reactionResult")
@@ -239,17 +239,15 @@ object heuristicsSupporter extends SymbolicExecutionRules {
         say(s"reactionResult = $reactionResult")
     }
 
-    (reactionResult: @unchecked) match {
-      case _ if !reactionResult.isFatal =>
-        reactionResult
-
-      case _: Failure =>
-        initialFailure.getOrElse(globalActionResult)
+    if(reactionResult.containsFatal){
+      reactionResult
+    } else {
+      initialFailure.getOrElse(globalActionResult)
     }
   }
 
   def generateReactions(s: State, h: Heap, @unused v: Verifier, cause: Failure)
-                       : Seq[(State, Heap, Verifier) => ((State, Heap, Verifier) => VerificationResult) => VerificationResult] = {
+                       : Seq[(State, Heap, Verifier) => ((State, Heap, Verifier) => VerificationResultWrapper) => VerificationResultWrapper] = {
 
     val pve = HeuristicsFailed(ast.TrueLit()()) /* TODO: Use a meaningful node */
 
@@ -328,8 +326,8 @@ object heuristicsSupporter extends SymbolicExecutionRules {
 
   def packageWand(wand: ast.MagicWand, @unused pve: PartialVerificationError)
                  (s: State, h: Heap, v: Verifier)
-                 (Q: (State, Heap, Verifier) => VerificationResult)
-                 : VerificationResult = {
+                 (Q: (State, Heap, Verifier) => VerificationResultWrapper)
+                 : VerificationResultWrapper = {
 
       val packageStmt = ast.Package(wand, ast.Seqn(Seq(), Seq())())()
       exec(s.copy(h = h), packageStmt, v)((s1, v1) =>
@@ -338,8 +336,8 @@ object heuristicsSupporter extends SymbolicExecutionRules {
 
   def applyWand(wand: ast.MagicWand, bindings: Map[ast.AbstractLocalVar, Term], @unused pve: PartialVerificationError)
                (s: State, h: Heap, v: Verifier)
-               (Q: (State, Heap, Verifier) => VerificationResult)
-               : VerificationResult = {
+               (Q: (State, Heap, Verifier) => VerificationResultWrapper)
+               : VerificationResultWrapper = {
 
       val applyStmt = ast.Apply(wand)()
       exec(s.copy(g = Store(bindings), h = h), applyStmt, v)((s1, v1) => {
@@ -348,8 +346,8 @@ object heuristicsSupporter extends SymbolicExecutionRules {
 
   def unfoldPredicate(acc: ast.PredicateAccessPredicate, @unused pve: PartialVerificationError)
                      (s: State, h: Heap, v: Verifier)
-                     (Q: (State, Heap, Verifier) => VerificationResult)
-                     : VerificationResult = {
+                     (Q: (State, Heap, Verifier) => VerificationResultWrapper)
+                     : VerificationResultWrapper = {
 
       val unfoldStmt = ast.Unfold(acc)()
       exec(s.copy(h = h), unfoldStmt, v)((s1, v1) =>
@@ -358,8 +356,8 @@ object heuristicsSupporter extends SymbolicExecutionRules {
 
   def foldPredicate(acc: ast.PredicateAccessPredicate, @unused pve: PartialVerificationError)
                    (s: State, h: Heap, v: Verifier)
-                   (Q: (State, Heap, Verifier) => VerificationResult)
-                   : VerificationResult = {
+                   (Q: (State, Heap, Verifier) => VerificationResultWrapper)
+                   : VerificationResultWrapper = {
 
       val foldStmt = ast.Fold(acc)()
       exec(s.copy(h = h), foldStmt, v)((s1, v1) =>
@@ -368,8 +366,8 @@ object heuristicsSupporter extends SymbolicExecutionRules {
 
   def foldPredicate(predicate: ast.Predicate, tArgs: List[Term], tPerm: Term, pve: PartialVerificationError)
                    (s: State, h: Heap, v: Verifier)
-                   (Q: (State, Heap, Verifier) => VerificationResult)
-                   : VerificationResult = {
+                   (Q: (State, Heap, Verifier) => VerificationResultWrapper)
+                   : VerificationResultWrapper = {
 
     predicateSupporter.fold(s.copy(h = h), predicate, tArgs, tPerm, InsertionOrderedSet.empty, pve, v)((s1, v1) =>
       Q(s1, s1.h, v1))

--- a/src/main/scala/rules/LetSupporter.scala
+++ b/src/main/scala/rules/LetSupporter.scala
@@ -8,7 +8,7 @@ package viper.silicon.rules
 
 import viper.silver.ast
 import viper.silver.verifier.PartialVerificationError
-import viper.silicon.interfaces.VerificationResult
+import viper.silicon.interfaces.VerificationResultWrapper
 import viper.silicon.state.{State, Store}
 import viper.silicon.state.terms.Term
 import viper.silicon.verifier.Verifier
@@ -16,13 +16,13 @@ import viper.silicon.verifier.Verifier
 trait LetSupportRules extends SymbolicExecutionRules {
   def handle[E <: ast.Exp]
             (s: State, e: ast.Exp, pve: PartialVerificationError, v: Verifier)
-            (Q: (State, Store, E, Verifier) => VerificationResult)
-            : VerificationResult
+            (Q: (State, Store, E, Verifier) => VerificationResultWrapper)
+            : VerificationResultWrapper
 
   def handle[E <: ast.Exp]
             (s: State, let: ast.Let, pve: PartialVerificationError, v: Verifier)
-            (Q: (State, Store, E, Verifier) => VerificationResult)
-            : VerificationResult
+            (Q: (State, Store, E, Verifier) => VerificationResultWrapper)
+            : VerificationResultWrapper
 }
 
 object letSupporter extends LetSupportRules {
@@ -30,8 +30,8 @@ object letSupporter extends LetSupportRules {
 
   def handle[E <: ast.Exp]
             (s: State, e: ast.Exp, pve: PartialVerificationError, v: Verifier)
-            (Q: (State, Store, E, Verifier) => VerificationResult)
-            : VerificationResult = {
+            (Q: (State, Store, E, Verifier) => VerificationResultWrapper)
+            : VerificationResultWrapper = {
 
     e match {
       case let: ast.Let => handle(s, Nil, let, pve, v)(Q)
@@ -41,8 +41,8 @@ object letSupporter extends LetSupportRules {
 
   def handle[E <: ast.Exp]
             (s: State, let: ast.Let, pve: PartialVerificationError, v: Verifier)
-            (Q: (State, Store, E, Verifier) => VerificationResult)
-            : VerificationResult = {
+            (Q: (State, Store, E, Verifier) => VerificationResultWrapper)
+            : VerificationResultWrapper = {
 
     handle(s, Nil, let, pve, v)(Q)
   }
@@ -53,8 +53,8 @@ object letSupporter extends LetSupportRules {
                      let: ast.Let,
                      pve: PartialVerificationError,
                      v: Verifier)
-                    (Q: (State, Store, E, Verifier) => VerificationResult)
-                    : VerificationResult = {
+                    (Q: (State, Store, E, Verifier) => VerificationResultWrapper)
+                    : VerificationResultWrapper = {
 
     val ast.Let(x, exp, body) = let
 

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -10,7 +10,7 @@ import viper.silver.ast
 import viper.silver.verifier.PartialVerificationError
 import viper.silver.verifier.reasons.InsufficientPermission
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
-import viper.silicon.interfaces.VerificationResult
+import viper.silicon.interfaces.VerificationResultWrapper
 import viper.silicon.resources.PredicateID
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -25,8 +25,8 @@ trait PredicateSupportRules extends SymbolicExecutionRules {
            constrainableWildcards: InsertionOrderedSet[Var],
            pve: PartialVerificationError,
            v: Verifier)
-          (Q: (State, Verifier) => VerificationResult)
-          : VerificationResult
+          (Q: (State, Verifier) => VerificationResultWrapper)
+          : VerificationResultWrapper
 
   def unfold(s: State,
              predicate: ast.Predicate,
@@ -36,8 +36,8 @@ trait PredicateSupportRules extends SymbolicExecutionRules {
              pve: PartialVerificationError,
              v: Verifier,
              pa: ast.PredicateAccess /* TODO: Make optional */)
-            (Q: (State, Verifier) => VerificationResult)
-            : VerificationResult
+            (Q: (State, Verifier) => VerificationResultWrapper)
+            : VerificationResultWrapper
 }
 
 object predicateSupporter extends PredicateSupportRules {
@@ -51,8 +51,8 @@ object predicateSupporter extends PredicateSupportRules {
            constrainableWildcards: InsertionOrderedSet[Var],
            pve: PartialVerificationError,
            v: Verifier)
-          (Q: (State, Verifier) => VerificationResult)
-          : VerificationResult = {
+          (Q: (State, Verifier) => VerificationResultWrapper)
+          : VerificationResultWrapper = {
 
     val body = predicate.body.get /* Only non-abstract predicates can be unfolded */
     val gIns = s.g + Store(predicate.formalArgs map (_.localVar) zip tArgs)
@@ -111,8 +111,8 @@ object predicateSupporter extends PredicateSupportRules {
              pve: PartialVerificationError,
              v: Verifier,
              pa: ast.PredicateAccess)
-            (Q: (State, Verifier) => VerificationResult)
-            : VerificationResult = {
+            (Q: (State, Verifier) => VerificationResultWrapper)
+            : VerificationResultWrapper = {
 
     val gIns = s.g + Store(predicate.formalArgs map (_.localVar) zip tArgs)
     val body = predicate.body.get /* Only non-abstract predicates can be unfolded */

--- a/src/main/scala/supporters/MethodSupporter.scala
+++ b/src/main/scala/supporters/MethodSupporter.scala
@@ -72,7 +72,7 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
           new java.io.File(s"${Verifier.config.tempDirectory()}/${method.name}.dot"))
       }
 
-      val result =
+      val result: VerificationResultWrapper =
         /* Combined the well-formedness check and the execution of the body, which are two separate
          * rules in Smans' paper.
          */
@@ -86,14 +86,14 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
                   val sepIdentifier = SymbExLogger.currentLog().insert(impLog)
                   produces(s4, freshSnap, posts, ContractNotWellformed, v3)((_, _) => {
                     SymbExLogger.currentLog().collapse(null, sepIdentifier)
-                    Success()})})
+                    VerificationResultWrapper(Success())})})
             && {
                executionFlowController.locally(s2a, v2)((s3, v3) =>  {
                   exec(s3, body, v3)((s4, v4) =>
                     consumes(s4, posts, postViolated, v4)((_, _, _) =>
-                      Success()))}) }  )})})
+                      VerificationResultWrapper(Success())))}) }  )})})
 
-      Seq(result)
+     result.verificationResults
     }
 
     /* Lifetime */

--- a/src/main/scala/supporters/PredicateVerificationUnit.scala
+++ b/src/main/scala/supporters/PredicateVerificationUnit.scala
@@ -96,18 +96,19 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
                          oldHeaps = OldHeaps())
       val err = PredicateNotWellformed(predicate)
 
-      val result = predicate.body match {
+      val result: VerificationResultWrapper = predicate.body match {
         case None =>
-          Success()
+          VerificationResultWrapper(Success())
         case Some(body) =>
           /*    locallyXXX {
                 magicWandSupporter.checkWandsAreSelfFraming(σ.γ, σ.h, predicate, c)}
           &&*/  executionFlowController.locally(s, v)((s1, _) => {
                   produce(s1, freshSnap, body, err, v)((_, _) =>
-                    Success())})
+                    VerificationResultWrapper(Success()))})
       }
 
-      Seq(result)
+      result.verificationResults
+
     }
 
     /* Predicate supporter generates no sorts */

--- a/src/main/scala/supporters/qps/CfgSupporter.scala
+++ b/src/main/scala/supporters/qps/CfgSupporter.scala
@@ -56,9 +56,9 @@ trait DefaultCfgVerificationUnitProvider extends VerifierComponent { v: Verifier
       val result = {
         executionFlowController.locally(s, v)((s3, v3) =>  {
           exec(s3, cfg, v3)((_, _) =>
-            Success())}) }
+            VerificationResultWrapper(Success()))}) }
 
-      Seq(result)
+      result.verificationResults
     }
 
     /* Lifetime */

--- a/src/test/resources/recover/343.vpr
+++ b/src/test/resources/recover/343.vpr
@@ -1,0 +1,12 @@
+//https://github.com/viperproject/silicon/issues/343
+field f: Bool
+
+method test(x: Ref, b: Bool) {
+  if(b){
+      inhale acc(x.f)
+      label l
+  }
+//:: ExpectedOutput(assert.failed:assertion.false)
+//:: ExpectedOutput(assert.failed:labelled.state.not.reached)
+  assert old[l](x.f)
+}

--- a/src/test/resources/recover/403.vpr
+++ b/src/test/resources/recover/403.vpr
@@ -1,0 +1,12 @@
+//https://github.com/viperproject/silicon/issues/403
+field f: Int
+
+method wrong_error(b: Bool, x: Ref)
+    requires acc(x.f)
+{
+    exhale b ==> acc(x.f, 0/1)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert b
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert perm(x.f) == 1/2
+}

--- a/src/test/resources/recover/ifthenelse.vpr
+++ b/src/test/resources/recover/ifthenelse.vpr
@@ -1,0 +1,26 @@
+ field f : Int
+
+ method test1(x: Ref){
+ 	inhale acc(x.f, 1/3)
+ 	if (x.f < 3){
+ 		assert x.f < 3
+ 	} else {
+ 	    //:: ExpectedOutput(assert.failed:insufficient.permission)
+ 		assert acc(x.f, 2/3)
+ 	}
+ 	//:: ExpectedOutput(assert.failed:assertion.false)
+ 	assert x.f == 3
+ 	exhale acc(x.f, 1/3)
+  }
+
+method test2(x: Ref, y: Ref, a: Int){
+  if (a > 42){
+     inhale acc(x.f, 5/7)
+  } else {
+     inhale acc(y.f, 5/7)
+  }
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert perm(x.f) > 0/1
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert perm(y.f) > 0/1
+}

--- a/src/test/resources/recover/impCond.vpr
+++ b/src/test/resources/recover/impCond.vpr
@@ -1,0 +1,41 @@
+field f: Int
+method test1(b: Bool, x: Ref, y: Ref)
+    requires acc(x.f)
+{
+    //:: ExpectedOutput(assert.failed:insufficient.permission)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert b ? acc(y.f)  : x.f > 12
+}
+
+method test2(x: Ref, b: Bool)
+requires acc(x.f, 1/2)
+{
+    inhale b ==> acc(x.f, 1/2)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert perm(x.f) == 1/1
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert !b
+}
+field left: Int
+field right: Int
+predicate tuple(this: Ref){
+    acc(this.left) && acc(this.right)
+}
+
+method test3(this: Ref, b: Bool)
+{
+    inhale b ==> tuple(this)
+    //:: ExpectedOutput(unfold.failed:insufficient.permission)
+    unfold tuple(this)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert !b
+}
+method test4(this: Ref, b: Bool)
+requires tuple(this)
+{
+    exhale b ==> tuple(this)
+    //:: ExpectedOutput(unfold.failed:insufficient.permission)
+    unfold tuple(this)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert b
+}


### PR DESCRIPTION
This is a draft PR meant to get some feedback from @mschwerhoff (of course, others are welcome to comment as well!)

This PR contains a wrapper for the verificationresults, so that instead of short circuiting when silicon branches, the results from both branches can be reported.

Todo/Questions:

- [ ] Some of the original tests don't pass anymore because it now reports more errors, should I also adapt those?
- [ ] Add a couple more tests