### PR TITLE
WIP: Report one error per path

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -237,7 +237,7 @@ class Silicon(val reporter: PluginAwareReporter, private var debugInfo: Seq[(Str
     /*verifier.bookkeeper.*/elapsedMillis = System.currentTimeMillis() - /*verifier.bookkeeper.*/startTime
 
     val failures =
-      results.flatMap(r => r :: r.allPrevious)
+      results.flatMap(r => r :: r.previous.toList)
              .collect{ case f: Failure => f } /* Ignore successes */
              .sortBy(_.message.pos match { /* Order failures according to source position */
                 case pos: ast.HasLineColumn => (pos.line, pos.column)

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -151,7 +151,7 @@ object brancher extends BranchingRules {
       })
     } else {
       Unreachable()
-    }) && {
+    }) combine {
 
       /* [BRANCH-PARALLELISATION] */
       if (parallelizeElseBranch) {

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -85,11 +85,7 @@ object executor extends ExecutionRules {
 
     if (edges.isEmpty) {
       Q(s, v)
-    } else
-      edges.foldLeft(Success(): VerificationResult) {
-        case (fatalResult: FatalResult, _) => fatalResult
-        case (_, edge) => follow(s, edge, v)(Q)
-      }
+    } else edges.foldLeft(Success(): VerificationResult)((result: VerificationResult, edge) => result combine follow(s, edge, v)(Q))
   }
 
   def exec(s: State, graph: SilverCfg, v: Verifier)

--- a/src/test/resources/recover/343.vpr
+++ b/src/test/resources/recover/343.vpr
@@ -1,0 +1,12 @@
+//https://github.com/viperproject/silicon/issues/343
+field f: Bool
+
+method test(x: Ref, b: Bool) {
+  if(b){
+      inhale acc(x.f)
+      label l
+  }
+//:: ExpectedOutput(assert.failed:assertion.false)
+//:: ExpectedOutput(assert.failed:labelled.state.not.reached)
+  assert old[l](x.f)
+}

--- a/src/test/resources/recover/403.vpr
+++ b/src/test/resources/recover/403.vpr
@@ -1,0 +1,12 @@
+//https://github.com/viperproject/silicon/issues/403
+field f: Int
+
+method wrong_error(b: Bool, x: Ref)
+    requires acc(x.f)
+{
+    exhale b ==> acc(x.f, 0/1)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert b
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert perm(x.f) == 1/2
+}

--- a/src/test/resources/recover/ifthenelse.vpr
+++ b/src/test/resources/recover/ifthenelse.vpr
@@ -1,0 +1,26 @@
+ field f : Int
+
+ method test1(x: Ref){
+ 	inhale acc(x.f, 1/3)
+ 	if (x.f < 3){
+ 		assert x.f < 3
+ 	} else {
+ 	    //:: ExpectedOutput(assert.failed:insufficient.permission)
+ 		assert acc(x.f, 2/3)
+ 	}
+ 	//:: ExpectedOutput(assert.failed:assertion.false)
+ 	assert x.f == 3
+ 	exhale acc(x.f, 1/3)
+  }
+
+method test2(x: Ref, y: Ref, a: Int){
+  if (a > 42){
+     inhale acc(x.f, 5/7)
+  } else {
+     inhale acc(y.f, 5/7)
+  }
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert perm(x.f) > 0/1
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert perm(y.f) > 0/1
+}

--- a/src/test/resources/recover/impCond.vpr
+++ b/src/test/resources/recover/impCond.vpr
@@ -1,0 +1,41 @@
+field f: Int
+method test1(b: Bool, x: Ref, y: Ref)
+    requires acc(x.f)
+{
+    //:: ExpectedOutput(assert.failed:insufficient.permission)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert b ? acc(y.f)  : x.f > 12
+}
+
+method test2(x: Ref, b: Bool)
+requires acc(x.f, 1/2)
+{
+    inhale b ==> acc(x.f, 1/2)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert perm(x.f) == 1/1
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert !b
+}
+field left: Int
+field right: Int
+predicate tuple(this: Ref){
+    acc(this.left) && acc(this.right)
+}
+
+method test3(this: Ref, b: Bool)
+{
+    inhale b ==> tuple(this)
+    //:: ExpectedOutput(unfold.failed:insufficient.permission)
+    unfold tuple(this)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert !b
+}
+method test4(this: Ref, b: Bool)
+requires tuple(this)
+{
+    exhale b ==> tuple(this)
+    //:: ExpectedOutput(unfold.failed:insufficient.permission)
+    unfold tuple(this)
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert b
+}


### PR DESCRIPTION
Another try at getting silicon to report one error per path, this time with fewer boilerplate code changes.
Again, this is meant to get feedback from @mschwerhoff .

Two tests still fail (report errors that, according to the annotations, should not be reported)
* [list_insert_tmp.vpr](https://github.com/viperproject/silver/blob/b2f9190a9794bcc31ce93f580c1aff2dbfcc2a07/src/test/resources/wands/examples/list_insert_tmp.vpr#L132)
* [QPWands.vpr](https://github.com/viperproject/silver/blob/83ff132b847fd97ef20e1b622167de706d52a29a/src/test/resources/wands/new_syntax/QPWands.vpr#L38)

I'm currently reading up on magic wands, as those are both magic wand related tests (right now I'm not yet sure if those errors should be reported or not..)