### PR TITLE
Improves Silicon in ignoring files

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -172,10 +172,14 @@ class Silicon(val reporter: PluginAwareReporter, private var debugInfo: Seq[(Str
     /* If available, save the filename corresponding to the program under verification in Verifier.inputFile.
      * See also src/test/scala/SiliconTests.scala, where the analogous happens if Silicon is executed while
      * running the test suite.
+     * Do not save the filename if the filename corresponds to the dummy one or `--ignoreFile` has been specified.
+     * Clients assume that the filename is ignored if `--ignoreFile` is used but calling `Paths.get` on it effectively
+     * tries to parse the given string as path. For example, the following string causes an exception on Windows (and
+     * only on Windows): `_programID_d:\a\test`
      *
      * TODO: Figure out what happens when ViperServer is used. */
     config.file.foreach(filename => {
-      if (filename != Silicon.dummyInputFilename) {
+      if (filename != Silicon.dummyInputFilename && !config.ignoreFile.getOrElse(false)) {
         viper.silicon.verifier.Verifier.inputFile = Some(Paths.get(filename))
       }
     })


### PR DESCRIPTION
Fixes #552 

Two test cases fail locally:
```
[info] - quantifiedpermissions/third_party/back.vpr [Silicon-Silver] *** FAILED *** (2 milliseconds)
[info]   java.nio.file.NoSuchFileException: /Users/arquintlinard/ETH/PhD/silver/target/scala-2.13/test-classes/quantifiedpermissions/third_party/back.vpr
[info]   at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
[info]   at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
[info]   at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
[info]   at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
[info]   at java.base/java.nio.file.Files.newByteChannel(Files.java:375)
[info]   at java.base/java.nio.file.Files.newByteChannel(Files.java:426)
[info]   at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
[info]   at java.base/java.nio.file.Files.newInputStream(Files.java:160)
[info]   at viper.silver.frontend.DefaultFrontend.reset(Frontend.scala:197)
[info]   at viper.silver.frontend.DefaultFrontend.reset$(Frontend.scala:193)
[info]   ...
[info] - quantifiedpermissions/third_party/blom01.vpr [Silicon-Silver] *** FAILED *** (1 millisecond)
[info]   java.nio.file.NoSuchFileException: /Users/arquintlinard/ETH/PhD/silver/target/scala-2.13/test-classes/quantifiedpermissions/third_party/blom01.vpr
[info]   at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
[info]   at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
[info]   at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
[info]   at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:218)
[info]   at java.base/java.nio.file.Files.newByteChannel(Files.java:375)
[info]   at java.base/java.nio.file.Files.newByteChannel(Files.java:426)
[info]   at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
[info]   at java.base/java.nio.file.Files.newInputStream(Files.java:160)
[info]   at viper.silver.frontend.DefaultFrontend.reset(Frontend.scala:197)
[info]   at viper.silver.frontend.DefaultFrontend.reset$(Frontend.scala:193)
[info]   ...
```
No idea what is going wrong here as these two file paths exist on disk. I'll check whether CI goes through