### PR TITLE
Declaring SortWrapper functions for backend types

### DIFF
--- a/src/main/resources/sortwrappers.smt2
+++ b/src/main/resources/sortwrappers.smt2
@@ -7,7 +7,7 @@
 ;   IntToSnap(x) = IntToSnap(y)
 ; implies that
 ;   x = y.
-(assert (forall ((x $S$)) (!
+(assert (forall ((x $T$)) (!
     (= x ($SortWrappers.$SnapTo$S$($SortWrappers.$S$To$Snap x)))
     :pattern (($SortWrappers.$S$To$Snap x))
     :qid |$Snap.$SnapTo$S$To$Snap|

--- a/src/main/scala/decider/TermToSMTLib2Converter.scala
+++ b/src/main/scala/decider/TermToSMTLib2Converter.scala
@@ -31,6 +31,10 @@ class TermToSMTLib2Converter
     super.pretty(defaultWidth, render(s))
   }
 
+  def convertSanitized(s: Sort): String = {
+    super.pretty(defaultWidth, doRender(s, true))
+  }
+
   protected def render(sort: Sort) = doRender(sort, false)
 
   protected def doRender(sort: Sort, alwaysSanitize: Boolean = false): Cont = sort match {

--- a/src/main/scala/verifier/DefaultMasterVerifier.scala
+++ b/src/main/scala/verifier/DefaultMasterVerifier.scala
@@ -25,9 +25,12 @@ import viper.silicon.supporters._
 import viper.silicon.supporters.functions.DefaultFunctionVerificationUnitProvider
 import viper.silicon.supporters.qps._
 import viper.silicon.utils.Counter
+import viper.silver.ast.{BackendFunc, BackendType}
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.cfg.silver.SilverCfg
 import viper.silver.reporter.{ConfigurationConfirmation, Reporter, VerificationResultMessage}
+
+import scala.collection.mutable
 
 /* TODO: Extract a suitable MasterVerifier interface, probably including
  *         - def verificationPoolManager: VerificationPoolManager)
@@ -395,6 +398,12 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
     sortWrapperDeclarationOrder foreach (component =>
       emitSortWrappers(component.sortsAfterAnalysis, sink))
 
+    val backendTypes = new mutable.HashSet[BackendType]
+    program.visit{
+      case t: BackendType => backendTypes.add(t)
+    }
+    emitSortWrappers(backendTypes map symbolConverter.toSort, sink)
+
     sink.comment("/" * 10 + " Symbols")
     symbolDeclarationOrder foreach (component =>
       component.declareSymbolsAfterAnalysis(sink))
@@ -424,7 +433,8 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
         sink.declare(fromSnapWrapper)
 
         preambleReader.emitParametricPreamble("/sortwrappers.smt2",
-                                              Map("$S$" -> termConverter.convert(sort)),
+                                              Map("$S$" -> termConverter.convertSanitized(sort),
+                                                  "$T$" -> termConverter.convert(sort)),
                                               sink)
       })
     }

--- a/src/main/scala/verifier/DefaultMasterVerifier.scala
+++ b/src/main/scala/verifier/DefaultMasterVerifier.scala
@@ -398,7 +398,7 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
     sortWrapperDeclarationOrder foreach (component =>
       emitSortWrappers(component.sortsAfterAnalysis, sink))
 
-    val backendTypes = new mutable.HashSet[BackendType]
+    val backendTypes = new mutable.LinkedHashSet[BackendType]
     program.visit{
       case t: BackendType => backendTypes.add(t)
     }


### PR DESCRIPTION
This PR fixes errors that occur when Silicon uses SortWrapper functions from and to backend types (float and bitvector); previously, these functions were not declared, and using the functions resulted in Z3 errors (Vytautas had an example where this happened; there is a corresponding branch in Silver that adds a test case for this). 

It adds code that checks which backend types are used, and declares the corresponding SortWrapper functions. The change in ``sortwrappers.smt2`` is because for backend type names, which can for example contain spaces (e.g. ``(_ FloatingPoint  8  24)``), we need to differentiate between the name of the type name itself (``$T$``) and a sanitized version of the type that does not contain spaces (``$S$``), which is used in the name of the SortWrapper function.