### PR TITLE
Change double quotes to curly braces as delimeters for composite command line options

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -54,7 +54,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
 
   private val smtlibOptionsConverter: ValueConverter[Map[String, String]] = new ValueConverter[Map[String, String]] {
     def parse(s: List[(String, List[String])]): Either[String, Option[Map[String, String]]] = s match {
-      case (_, str :: Nil) :: Nil if str.head == '"' && str.last == '"' =>
+      case (_, str :: Nil) :: Nil if str.head == '{' && str.last == '}' =>
         val config = toMap(
           str.substring(1, str.length - 1) /* Drop leading and trailing quotation mark */
              .split(' ') /* Separate individual key=value pairs */
@@ -374,8 +374,8 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
 
   val z3ConfigArgs: ScallopOption[Map[String, String]] = opt[Map[String, String]]("z3ConfigArgs",
     descr = (  "Configuration options which should be forwarded to Z3. "
-             + "The expected format is \"<key>=<val> <key>=<val> ... <key>=<val>\", "
-             + "including the quotation marks. "
+             + "The expected format is {<key>=<val> <key>=<val> ... <key>=<val>}, "
+             + "including the { } brackets. For example: \"{model=true model_validate=true}\""
              + "The configuration options given here will override those from Silicon's Z3 preamble."),
     default = Some(Map()),
     noshort = true


### PR DESCRIPTION
This PR changes the expected format of arguments passed to ```--z3ConfigArgs```. 

We used to use double quotes, but this caused problems with escaping the ```"``` characters in case the silicon command itself had to be passed as a string. In particular, the only way I found to use this option on macOS in bash and zsh was like this: 

```
java -cp silicon.jar viper.silicon.SiliconRunner --z3ConfigArgs "\"model.partial=true\"" example.vpr
```
However, I still couldn't figure out how to encode the escapements themselves s.t. they could be added to the Viper IDE configuration. It seems that avoiding double quotes in the first place would simplify things quite a bit.

Therefore, I propose the following syntax: 
```
--z3ConfigArgs {arg1=val1 arg2=val2 ...}
``` 

I tested this on my local machine with macOS; I would appreciate it if you could try it out on Windows and Linux as well before merging this PR (not urgent). 