### PR TITLE
Scope for functions, predicates, and methods (of ASTs)

### DIFF
--- a/src/main/scala/verifier/DefaultMasterVerifier.scala
+++ b/src/main/scala/verifier/DefaultMasterVerifier.scala
@@ -471,7 +471,7 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
 
   private def setErrorScope(results: Seq[VerificationResult], scope: Member): Seq[VerificationResult] = {
     results.foreach {
-      case Failure(err) => err.scope = Some(scope)
+      case f: Failure => f.message.scope = Some(scope)
       case _ =>
     }
     results


### PR DESCRIPTION
ViperServer prefers to use the `scope` field of AbstractError to associate errors with particular program members. This PR sets the `scope` field accordingly.