### PR TITLE
Fixes filtering of termination-related failures

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory
 import viper.silver.ast
 import viper.silver.frontend.{DefaultStates, SilFrontend}
 import viper.silver.reporter._
-import viper.silver.verifier.{AbstractVerificationError, DefaultDependency => SilDefaultDependency, Failure => SilFailure, Success => SilSuccess, TimeoutOccurred => SilTimeoutOccurred, VerificationResult => SilVerificationResult, Verifier => SilVerifier}
+import viper.silver.verifier.{AbstractVerificationError => SilAbstractVerificationError, DefaultDependency => SilDefaultDependency, Failure => SilFailure, Success => SilSuccess, TimeoutOccurred => SilTimeoutOccurred, VerificationResult => SilVerificationResult, Verifier => SilVerifier}
 import viper.silicon.common.config.Version
 import viper.silicon.interfaces.Failure
 import viper.silicon.logger.SymbExLogger
@@ -296,17 +296,17 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
   private def failureFilterAndGroupingCriterion(f: Failure): String = {
     // apply transformers if available:
     val transformedError = f.message match {
-      case e: AbstractVerificationError => e.transformedError()
+      case e: SilAbstractVerificationError => e.transformedError()
       case e => e
     }
     // create a string that identifies the given failure:
     transformedError.readableMessage(withId = true, withPosition = true)
   }
 
-  private def failureSortingCriterion(f: Failure): Tuple2[Int, Int] = {
+  private def failureSortingCriterion(f: Failure): (Int, Int) = {
     // apply transformers if available:
     val transformedError = f.message match {
-      case e: AbstractVerificationError => e.transformedError()
+      case e: SilAbstractVerificationError => e.transformedError()
       case e => e
     }
     transformedError.pos match { /* Order failures according to source position */


### PR DESCRIPTION
Assert stmts generated by the termination plugin have no position and no information.
Thus, the current filtering of failures introduces by PR #575 will filter these failures (see example added by [Silver PR #546](https://github.com/viperproject/silver/pull/546)).
This fix adapts the filtering mechanism to take error transformers into account.
@mschwerhoff: What is the convention with error transformers? Should they be applied as early as possible? I was not sure whether the failures should contain the untransformed errors (as it is now) or whether it would be fine to only return the transformed errors.