### PR TITLE
Check injectivity inhale

### DIFF
--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -799,7 +799,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
         /* TODO: Can we omit/simplify the injectivity check in certain situations? */
         val receiverInjectivityCheck =
-          if (Verifier.config.checkInjectivity()) {
+          if (!Verifier.config.assumeInjectivityOnInhale()) {
             quantifiedChunkSupporter.injectivityAxiom(
               qvars     = qvars,
               // TODO: Adding ResourceTriggerFunction requires a summarising snapshot map of the current heap

--- a/src/test/resources/issue387/va3.vpr
+++ b/src/test/resources/issue387/va3.vpr
@@ -9,6 +9,7 @@ predicate P01(x: Ref, n: Int) {
      acc(x.ss)
   && |x.ss| == n
   && 3 <= n
+  && (forall i: Int, j: Int :: i >= 0 && i < |x.ss| && j >= 0 && j < |x.ss| && i != j ==> x.ss[i] != x.ss[j])
   && (forall j: Int :: 0 <= j && j < 3 ==> acc(x.ss[j].f))
   && (forall j: Int :: 3 <= j && j < n ==> acc(x.ss[j].f))
 }

--- a/src/test/resources/issue387/va6.vpr
+++ b/src/test/resources/issue387/va6.vpr
@@ -3,6 +3,7 @@ field f: Int
 predicate P02(xs: Seq[Ref], n: Int) {
      |xs| == n
   && 3 <= n
+  && (forall i: Int, j: Int :: i >= 0 && i < |xs| && j >= 0 && j < |xs| && i != j ==> xs[i] != xs[j])
   && (forall j: Int :: 0 <= j && j < 3 ==> acc(xs[j].f))
   && (forall j: Int :: 3 <= j && j < n ==> acc(xs[j].f))
 }


### PR DESCRIPTION
Injectivity is now checked instead of assumed when inhaling quantified permissions.