### PR TITLE
Improve position information on reported errors

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -76,12 +76,14 @@ object evaluator extends EvaluationRules {
     if (es.isEmpty)
       Q(s, ts.reverse, v)
     else
+      // TODO: do not apply `pvef` here just yet!
       eval(s, es.head, pvef(es.head), v)((s1, t, v1) =>
         evals2(s1, es.tail, t :: ts, pvef, v1)(Q))
   }
 
   /** Wrapper Method for eval, for logging. See Executor.scala for explanation of analogue. **/
   @inline
+  @deprecated("Leads to innacurate position data, use `evals` instead", "11.02.2022")
   def eval(s: State, e: ast.Exp, pve: PartialVerificationError, v: Verifier)
           (Q: (State, Term, Verifier) => VerificationResult)
           : VerificationResult = {

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -355,40 +355,37 @@ object executor extends ExecutionRules {
         v.decider.assume(ts)
         Q(s1, v)
 
-      case inhale @ ast.Inhale(a) => a match {
+      case ast.Inhale(a) => a match {
         case _: ast.FalseLit =>
           /* We're done */
           Success()
         case _ =>
-          produce(s, freshSnap, a, InhaleFailed(inhale), v)((s1, v1) => {
+          produces(s, freshSnap, List(a), InhaleFailed, v)((s1, v1) => {
             v1.decider.prover.saturate(Verifier.config.z3SaturationTimeouts.afterInhale)
             Q(s1, v1)})
       }
 
-      case exhale @ ast.Exhale(a) =>
-        val pve = ExhaleFailed(exhale)
-        consume(s, a, pve, v)((s1, _, v1) =>
+      case ast.Exhale(a) =>
+        consumes(s, List(a), ExhaleFailed, v)((s1, _, v1) =>
           Q(s1, v1))
 
-      case assert @ ast.Assert(a: ast.FalseLit) =>
+      case ast.Assert(a: ast.FalseLit) =>
         /* "assert false" triggers a smoke check. If successful, we backtrack. */
         executionFlowController.tryOrFail0(s.copy(h = magicWandSupporter.getEvalHeap(s)), v)((s1, v1, QS) => {
           if (v1.decider.checkSmoke())
             QS(s1.copy(h = s.h), v1)
           else
-            createFailure(AssertFailed(assert) dueTo AssertionFalse(a), v1, s1, true)
+            createFailure(AssertFailed(a) dueTo AssertionFalse(a), v1, s1, true)
         })((_, _) => Success())
 
-      case assert @ ast.Assert(a) if Verifier.config.disableSubsumption() =>
+      case ast.Assert(a) if Verifier.config.disableSubsumption() =>
         val r =
-          consume(s, a, AssertFailed(assert), v)((_, _, _) =>
+          consumes(s, List(a), AssertFailed, v)((_, _, _) =>
             Success())
 
         r combine Q(s, v)
 
-      case assert @ ast.Assert(a) =>
-        val pve = AssertFailed(assert)
-
+      case ast.Assert(a) =>
         if (s.exhaleExt) {
           Predef.assert(s.h.values.isEmpty)
           Predef.assert(s.reserveHeaps.head.values.isEmpty)
@@ -397,11 +394,11 @@ object executor extends ExecutionRules {
            * hUsed (reserveHeaps.head) instead of consuming them. hUsed is later discarded and replaced
            * by s.h. By copying hUsed to s.h the contained permissions remain available inside the wand.
            */
-          consume(s, a, pve, v)((s2, _, v1) => {
+          consumes(s, List(a), AssertFailed, v)((s2, _, v1) => {
             Q(s2.copy(h = s2.reserveHeaps.head), v1)
           })
         } else
-          consume(s, a, pve, v)((s1, _, v1) => {
+          consumes(s, List(a), AssertFailed, v)((s1, _, v1) => {
             val s2 = s1.copy(h = s.h, reserveHeaps = s.reserveHeaps)
             Q(s2, v1)})
 


### PR DESCRIPTION
The idea is to keep around `pvef: ast.Exp => PartialVerificationError` before applying it, so that we can dig down to the actual expression which causes the error. Requires the corresponding PR in silver to be merged.