### PR TITLE
Add test suite for ADT plugin

### DIFF
--- a/src/test/scala/AdtPluginTests.scala
+++ b/src/test/scala/AdtPluginTests.scala
@@ -1,0 +1,31 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2021 ETH Zurich.
+
+
+package viper.silicon.tests
+
+import viper.silicon.Silicon
+import viper.silver.reporter.NoopReporter
+
+
+class AdtPluginTests extends SiliconTests {
+
+  override val testDirectories: Seq[String] = Seq("adt")
+
+  override val silicon: Silicon = {
+    val reporter = NoopReporter
+    val debugInfo = ("startedBy" -> "viper.silicon.AdtPluginTests") :: Nil
+    new Silicon(reporter, debugInfo)
+  }
+
+  override def verifiers = List(silicon)
+
+  override def configureVerifiersFromConfigMap(configMap: Map[String, Any]): Unit = {
+    val newConfigMap = configMap.updated("silicon:plugin", "viper.silver.plugin.standard.adt.AdtPlugin")
+    super.configureVerifiersFromConfigMap(newConfigMap)
+  }
+
+}


### PR DESCRIPTION
This PR adds a new test suite for the ADT plugin.

Should not be merged before [PR#574](https://github.com/viperproject/silver/pull/574), i.e not before the silver submodule is updated to include changes of PR#574. 