### PR TITLE
typo fix in proverConfigArgs' flag description

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -509,7 +509,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
   private val rawProverConfigArgs: ScallopOption[Map[String, String]] = opt[Map[String, String]]("proverConfigArgs",
     descr = (  "Configuration options which should be forwarded to the prover. "
              + "The expected format is \"<key>=<val> <key>=<val> ... <key>=<val>\", "
-             + "including the quotation marks. "
+             + "excluding the quotation marks. "
              + "The configuration options given here will override those from Silicon's prover preamble."),
     default = Some(Map()),
     noshort = true


### PR DESCRIPTION
Small typo in the description of the proverConfigArgs flag. It should be "excluding the quotation marks" instead of "including ...".