### PR TITLE
Upgrade SBT

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -4,4 +4,4 @@
 #
 # Copyright (c) 2011-2019 ETH Zurich.
 
-sbt.version=1.4.4
+sbt.version=1.6.2


### PR DESCRIPTION
Silicon does not build currently on arm64 macs due to https://github.com/sbt/sbt/issues/6162; upgrading to the latest version of SBT fixes this problem.