### PR TITLE
Fix encoding of path conditions as implications

### DIFF
--- a/src/main/scala/decider/PathConditions.scala
+++ b/src/main/scala/decider/PathConditions.scala
@@ -147,8 +147,10 @@ private trait LayeredPathConditionStackLike {
     for (layer <- layers.reverseIterator) {
       unconditionalTerms ++= layer.globalAssumptions
 
-      layer.branchCondition foreach { condition =>
-         implicationLHS = And(implicationLHS, condition)
+      layer.branchCondition match {
+        case Some(condition) =>
+          implicationLHS = And(implicationLHS, condition)
+        case None =>
       }
 
       conditionalTerms :+=

--- a/src/main/scala/decider/PathConditions.scala
+++ b/src/main/scala/decider/PathConditions.scala
@@ -142,12 +142,17 @@ private trait LayeredPathConditionStackLike {
   protected def conditionalized(layers: Stack[PathConditionStackLayer]): Seq[Term] = {
     var unconditionalTerms = Vector.empty[Term]
     var conditionalTerms = Vector.empty[Term]
+    var implicationLHS: Term = True()
 
-    for (layer <- layers) {
+    for (layer <- layers.reverseIterator) {
       unconditionalTerms ++= layer.globalAssumptions
 
+      layer.branchCondition foreach { condition =>
+         implicationLHS = And(implicationLHS, condition)
+      }
+
       conditionalTerms :+=
-        Implies(layer.branchCondition.getOrElse(True()), And(layer.nonGlobalAssumptions))
+        Implies(implicationLHS, And(layer.nonGlobalAssumptions))
     }
 
     unconditionalTerms ++ conditionalTerms


### PR DESCRIPTION

Currently when path conditions are encoded as implications, the previous path conditions do not appear LHS of the implication. For example, consider a path`P0` with assertion `A`  followed by `P1` with assertion `B`. The currently generated assertions are `P0 => A` and `P1 => B`. However, if the assertion `B` was generated due to being in the `P0` branch, then this is unsound (consider, for example, if `P1` is `True`; then `P1 => B` is just `B`).

This PR changes the behaviour to include the previous path conditions on the LHS; such that the assertion for P1 would be `(P0 && P1) => B` instead of `P1 => B`.

Fixes https://github.com/viperproject/silicon/issues/630.