### PR TITLE
Removing global state

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -178,7 +178,7 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
      * TODO: Figure out what happens when ViperServer is used. */
     config.file.foreach(filename => {
       if (filename != Silicon.dummyInputFilename && !config.ignoreFile.getOrElse(false)) {
-        viper.silicon.verifier.Verifier.inputFile = Some(Paths.get(filename))
+        //viper.silicon.verifier.Verifier.inputFile = Some(Paths.get(filename))
       }
     })
 
@@ -373,8 +373,14 @@ class SiliconFrontend(override val reporter: Reporter,
   }
 }
 
-object SiliconRunner extends SiliconFrontend(StdIOReporter()) {
+object SiliconRunner extends SiliconRunnerInstance {
   def main(args: Array[String]): Unit = {
+    runMain(args)
+  }
+}
+
+class SiliconRunnerInstance extends SiliconFrontend(StdIOReporter()) {
+  def runMain(args: Array[String]): Unit = {
     var exitCode = 1 /* Only 0 indicates no error - we're pessimistic here */
 
     try {
@@ -427,6 +433,6 @@ object SiliconRunner extends SiliconFrontend(StdIOReporter()) {
          */
     }
 
-    sys.exit(exitCode)
+    //sys.exit(exitCode)
   }
 }

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -9,6 +9,7 @@ package viper.silicon
 import java.nio.file.Paths
 import java.text.SimpleDateFormat
 import java.util.concurrent.{Callable, Executors, TimeUnit, TimeoutException}
+
 import scala.collection.immutable.ArraySeq
 import scala.util.{Left, Right}
 import ch.qos.logback.classic.{Level, Logger}
@@ -20,11 +21,12 @@ import viper.silver.reporter._
 import viper.silver.verifier.{AbstractVerificationError => SilAbstractVerificationError, Failure => SilFailure, Success => SilSuccess, TimeoutOccurred => SilTimeoutOccurred, VerificationResult => SilVerificationResult, Verifier => SilVerifier}
 import viper.silicon.interfaces.Failure
 import viper.silicon.logger.SymbExLogger
-import viper.silicon.reporting.condenseToViperResult
+import viper.silicon.reporting.{MultiRunRecorders, condenseToViperResult}
 import viper.silicon.verifier.DefaultMasterVerifier
-import viper.silicon.decider.{Z3ProverStdIO, Cvc5ProverStdIO}
+import viper.silicon.decider.{Cvc5ProverStdIO, Z3ProverStdIO}
 import viper.silver.cfg.silver.SilverCfg
 import viper.silver.logger.ViperStdOutLogger
+
 import scala.util.chaining._
 
 object Silicon {
@@ -178,7 +180,7 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
      * TODO: Figure out what happens when ViperServer is used. */
     config.file.foreach(filename => {
       if (filename != Silicon.dummyInputFilename && !config.ignoreFile.getOrElse(false)) {
-        //viper.silicon.verifier.Verifier.inputFile = Some(Paths.get(filename))
+        MultiRunRecorders.source = Some(filename)
       }
     })
 

--- a/src/main/scala/extensions/TryBlockParserPlugin.scala
+++ b/src/main/scala/extensions/TryBlockParserPlugin.scala
@@ -6,13 +6,13 @@
 
 package viper.silicon.extensions
 
-import viper.silver.parser.FastParser._
-import viper.silver.parser.ParserExtension
+import viper.silver.parser.{FastParser, ParserExtension}
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 
-class TryBlockParserPlugin extends SilverPlugin with ParserPluginTemplate {
+class TryBlockParserPlugin(fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
   import fastparse._
-  import viper.silver.parser.FastParser.whitespace
+  import viper.silver.parser.FastParserCompanion.whitespace
+  import fp.{FP, block}
 
 
   private val tryKeyword = "try"

--- a/src/main/scala/extensions/TryBlockParserPlugin.scala
+++ b/src/main/scala/extensions/TryBlockParserPlugin.scala
@@ -6,13 +6,13 @@
 
 package viper.silicon.extensions
 
-import viper.silver.parser.{FastParser, ParserExtension}
+import viper.silver.parser.FastParser
 import viper.silver.plugin.{ParserPluginTemplate, SilverPlugin}
 
 class TryBlockParserPlugin(fp: FastParser) extends SilverPlugin with ParserPluginTemplate {
   import fastparse._
   import viper.silver.parser.FastParserCompanion.whitespace
-  import fp.{FP, block}
+  import fp.{FP, block, ParserExtension}
 
 
   private val tryKeyword = "try"

--- a/src/main/scala/interfaces/Preamble.scala
+++ b/src/main/scala/interfaces/Preamble.scala
@@ -34,8 +34,6 @@ trait PreambleContributor[+SO, +SY, +AX] extends StatefulComponent {
 
   def axiomsAfterAnalysis: Iterable[AX]
   def emitAxiomsAfterAnalysis(sink: ProverLike): Unit
-
-  def updateGlobalStateAfterAnalysis(): Unit
 }
 
 trait VerifyingPreambleContributor[+SO, +SY, +AX, U <: ast.Node]
@@ -50,6 +48,4 @@ trait VerifyingPreambleContributor[+SO, +SY, +AX, U <: ast.Node]
 
   def axiomsAfterVerification: Iterable[AX]
   def emitAxiomsAfterVerification(sink: ProverLike): Unit
-
-  def contributeToGlobalStateAfterVerification(): Unit
 }

--- a/src/main/scala/interfaces/Verification.scala
+++ b/src/main/scala/interfaces/Verification.scala
@@ -7,13 +7,13 @@
 package viper.silicon.interfaces
 
 import viper.silicon.interfaces.state.Chunk
-import viper.silicon.reporting.{Converter, ExtractedModel, ExtractedModelEntry, GenericDomainInterpreter, 
-  ModelInterpreter, ExtractedFunction, DomainEntry, VarEntry, RefEntry, NullRefEntry, UnprocessedModelEntry}
+import viper.silicon.reporting.{Converter, DomainEntry, ExtractedFunction, ExtractedModel, ExtractedModelEntry, GenericDomainInterpreter, ModelInterpreter, NullRefEntry, RefEntry, UnprocessedModelEntry, VarEntry}
 import viper.silicon.state.{State, Store}
-import viper.silver.verifier.{Counterexample, FailureContext, Model, VerificationError, ValueEntry, ApplicationEntry, ConstantEntry}
+import viper.silver.verifier.{ApplicationEntry, ConstantEntry, Counterexample, FailureContext, Model, ValueEntry, VerificationError}
 import viper.silicon.state.terms.Term
 import viper.silicon.verifier.Verifier
 import viper.silver.ast
+import viper.silver.ast.Program
 
 /*
  * Results
@@ -144,11 +144,12 @@ case class SiliconVariableCounterexample(internalStore: Store, nativeModel: Mode
 case class SiliconMappedCounterexample(internalStore: Store,
                                        heap: Iterable[Chunk],
                                        oldHeaps: State.OldHeaps,
-                                       nativeModel: Model)
+                                       nativeModel: Model,
+                                       program: Program)
     extends SiliconCounterexample {
 
   val converter: Converter =
-    Converter(nativeModel, internalStore, heap, oldHeaps, Verifier.program)
+    Converter(nativeModel, internalStore, heap, oldHeaps, program)
 
   val model: Model = nativeModel
   val interpreter: ModelInterpreter[ExtractedModelEntry, Seq[ExtractedModelEntry]] = GenericDomainInterpreter(converter)
@@ -226,6 +227,6 @@ case class SiliconMappedCounterexample(internalStore: Store,
   }
 
   override def withStore(s: Store): SiliconCounterexample = {
-    SiliconMappedCounterexample(s, heap, oldHeaps, nativeModel)
+    SiliconMappedCounterexample(s, heap, oldHeaps, nativeModel, program)
   }
 }

--- a/src/main/scala/reporting/Converter.scala
+++ b/src/main/scala/reporting/Converter.scala
@@ -622,7 +622,7 @@ object Converter {
       } catch {
         case _: Throwable => Seq()
       }
-      val translatedFunctions = x._1.functions.map(y => translateFunction(model, heap, y, x._2))
+      val translatedFunctions = x._1.functions.map(y => translateFunction(model, heap, y, x._2, program))
       DomainEntry(x._1.name, types, translatedFunctions)
     }).toSeq
   }
@@ -634,7 +634,7 @@ object Converter {
     val funcs = program.collect {
       case f: ast.Function => f
     }
-    funcs.map(x => translateFunction(model, heap, x, silicon.toMap(Nil))).toSeq
+    funcs.map(x => translateFunction(model, heap, x, silicon.toMap(Nil), program)).toSeq
   }
 
   def errorfunc(problem: String): ExtractedFunction =
@@ -648,7 +648,7 @@ object Converter {
     * @param genmap map of generic types to concrete types
     * @return
     */
-  def translateFunction(model: Model, heap: ExtractedHeap, func: ast.FuncLike, genmap: Map[ast.TypeVar, ast.Type]): ExtractedFunction = {
+  def translateFunction(model: Model, heap: ExtractedHeap, func: ast.FuncLike, genmap: Map[ast.TypeVar, ast.Type], program: ast.Program): ExtractedFunction = {
     def toSort(typ: ast.Type): Either[Throwable, Sort] = Try(symbolConverter.toSort(typ)).toEither
     def toSortWithSubstitutions(typ: ast.Type, typeErrorMsg: String): Either[String, Sort] = {
       toSort(typ)
@@ -675,7 +675,7 @@ object Converter {
 
     val smtfunc = func match {
       case t: ast.Function => symbolConverter.toFunction(t).id
-      case t: ast.DomainFunc => symbolConverter.toFunction(t, argSort :+ resSort).id
+      case t: ast.DomainFunc => symbolConverter.toFunction(t, argSort :+ resSort, program).id
       case t: ast.BackendFunc => symbolConverter.toFunction(t).id
     }
     val kek = smtfunc.toString

--- a/src/main/scala/reporting/MultiRunRecorder.scala
+++ b/src/main/scala/reporting/MultiRunRecorder.scala
@@ -96,6 +96,11 @@ object MultiRunRecorders extends StatefulComponent {
   private val sinks = mutable.ArrayBuffer.empty[PrintWriter]
 
   protected def config: Config = Verifier.config
+
+  /**
+   The source is set by the Silicon verifier (in method [[viper.silicon.Silicon.verify]]) after parsing and type
+   checking but before consistency checks and verification.
+   */
   var source: Option[String] = None
 
   protected def sink(name: String): PrintWriter = {

--- a/src/main/scala/reporting/MultiRunRecorder.scala
+++ b/src/main/scala/reporting/MultiRunRecorder.scala
@@ -96,7 +96,7 @@ object MultiRunRecorders extends StatefulComponent {
   private val sinks = mutable.ArrayBuffer.empty[PrintWriter]
 
   protected def config: Config = Verifier.config
-  protected def source: Option[String] = ??? // Verifier.inputFile.map(_.toString)
+  var source: Option[String] = None
 
   protected def sink(name: String): PrintWriter = {
     val writer =

--- a/src/main/scala/reporting/MultiRunRecorder.scala
+++ b/src/main/scala/reporting/MultiRunRecorder.scala
@@ -96,7 +96,7 @@ object MultiRunRecorders extends StatefulComponent {
   private val sinks = mutable.ArrayBuffer.empty[PrintWriter]
 
   protected def config: Config = Verifier.config
-  protected def source: Option[String] = Verifier.inputFile.map(_.toString)
+  protected def source: Option[String] = ??? // Verifier.inputFile.map(_.toString)
 
   protected def sink(name: String): PrintWriter = {
     val writer =

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -101,7 +101,7 @@ object chunkSupporter extends ChunkSupportRules {
                       (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                       : VerificationResult = {
 
-    val id = ChunkIdentifier(resource, Verifier.program)
+    val id = ChunkIdentifier(resource, s.program)
     if (s.exhaleExt) {
       val failure = createFailure(ve, v, s)
       magicWandSupporter.transfer(s, perms, failure, v)(consumeGreedy(_, _, id, args, _, _))((s1, optCh, v1) =>
@@ -213,7 +213,7 @@ object chunkSupporter extends ChunkSupportRules {
                           (Q: (State, Term, Verifier) => VerificationResult)
                           : VerificationResult = {
 
-    val id = ChunkIdentifier(resource, Verifier.program)
+    val id = ChunkIdentifier(resource, s.program)
 
     findChunk[NonQuantifiedChunk](h.values, id, args, v) match {
       case Some(ch) if v.decider.check(IsPositive(ch.perm), Verifier.config.checkTimeout()) =>

--- a/src/main/scala/rules/MagicWandSupporter.scala
+++ b/src/main/scala/rules/MagicWandSupporter.scala
@@ -106,7 +106,7 @@ object magicWandSupporter extends SymbolicExecutionRules {
                  (Q: (State, MagicWandChunk, Verifier) => VerificationResult)
                  : VerificationResult = {
     evaluateWandArguments(s, wand, pve, v)((s1, ts, v1) =>
-      Q(s1, MagicWandChunk(MagicWandIdentifier(wand, Verifier.program), s1.g.values, ts, snap, FullPerm()), v1)
+      Q(s1, MagicWandChunk(MagicWandIdentifier(wand, s.program), s1.g.values, ts, snap, FullPerm()), v1)
     )
   }
 
@@ -117,7 +117,7 @@ object magicWandSupporter extends SymbolicExecutionRules {
                            (Q: (State, Seq[Term], Verifier) => VerificationResult)
                            : VerificationResult = {
     val s1 = s.copy(exhaleExt = false)
-    val es = wand.subexpressionsToEvaluate(Verifier.program)
+    val es = wand.subexpressionsToEvaluate(s.program)
 
     evals(s1, es, _ => pve, v)((s2, ts, v1) => {
       Q(s2.copy(exhaleExt = s.exhaleExt), ts, v1)
@@ -289,15 +289,15 @@ object magicWandSupporter extends SymbolicExecutionRules {
       }
 
       val preMark = v3.decider.setPathConditionMark()
-      if (s4.qpMagicWands.contains(MagicWandIdentifier(wand, Verifier.program))) {
-        val bodyVars = wand.subexpressionsToEvaluate(Verifier.program)
+      if (s4.qpMagicWands.contains(MagicWandIdentifier(wand, s.program))) {
+        val bodyVars = wand.subexpressionsToEvaluate(s.program)
         val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v.symbolConverter.toSort(bodyVars(i).typ)))
         evals(s4, bodyVars, _ => pve, v3)((s5, args, v4) => {
           val (sm, smValueDef) =
             quantifiedChunkSupporter.singletonSnapshotMap(s5, wand, args, MagicWandSnapshot(freshSnapRoot, snap), v4)
           v4.decider.prover.comment("Definitional axioms for singleton-SM's value")
           v4.decider.assume(smValueDef)
-          val ch = quantifiedChunkSupporter.createSingletonQuantifiedChunk(formalVars, wand, args, FullPerm(), sm)
+          val ch = quantifiedChunkSupporter.createSingletonQuantifiedChunk(formalVars, wand, args, FullPerm(), sm, s.program)
           appendToResults(s5, ch, v4.decider.pcs.after(preMark), v4)
           Success()
         })

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -141,7 +141,7 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                     (Q: (State, Term, Verifier) => VerificationResult)
                     : VerificationResult = {
 
-    val id = ChunkIdentifier(resource, Verifier.program)
+    val id = ChunkIdentifier(resource, s.program)
     val relevantChunks = findChunksWithID[NonQuantifiedChunk](h.values, id).toSeq
 
     if (relevantChunks.isEmpty) {
@@ -186,7 +186,7 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                                               (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                                               : VerificationResult = {
 
-    val id = ChunkIdentifier(resource, Verifier.program)
+    val id = ChunkIdentifier(resource, s.program)
     val relevantChunks = findChunksWithID[NonQuantifiedChunk](h.values, id).toSeq
 
     summarise(s, relevantChunks, resource, args, v)((s1, snap, _, permSum, v1) =>
@@ -208,7 +208,7 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                                    (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                                    : VerificationResult = {
 
-    val id = ChunkIdentifier(resource, Verifier.program)
+    val id = ChunkIdentifier(resource, s.program)
     val relevantChunks = ListBuffer[NonQuantifiedChunk]()
     val otherChunks = ListBuffer[Chunk]()
     h.values foreach {

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -60,7 +60,7 @@ object predicateSupporter extends PredicateSupportRules {
                     smDomainNeeded = true)
               .scalePermissionFactor(tPerm)
     consume(s1, body, pve, v)((s1a, snap, v1) => {
-      val predTrigger = App(Verifier.predicateData(predicate).triggerFunction,
+      val predTrigger = App(s1a.predicateData(predicate).triggerFunction,
                             snap.convert(terms.sorts.Snap) +: tArgs)
       v1.decider.assume(predTrigger)
       val s2 = s1a.setConstrainable(constrainableWildcards, false)
@@ -73,7 +73,7 @@ object predicateSupporter extends PredicateSupportRules {
         v1.decider.assume(smValueDef)
         val ch =
           quantifiedChunkSupporter.createSingletonQuantifiedChunk(
-            formalArgs, predicate, tArgs, tPerm, sm)
+            formalArgs, predicate, tArgs, tPerm, sm, s.program)
         val h3 = s2.h + ch
         val smDef = SnapshotMapDefinition(predicate, sm, Seq(smValueDef), Seq())
         val smCache = {
@@ -135,7 +135,7 @@ object predicateSupporter extends PredicateSupportRules {
         produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
           val predicateTrigger =
-            App(Verifier.predicateData(predicate).triggerFunction,
+            App(s4.predicateData(predicate).triggerFunction,
                 snap.convert(terms.sorts.Snap) +: tArgs)
           v2.decider.assume(predicateTrigger)
           Q(s4.copy(g = s.g,
@@ -151,7 +151,7 @@ object predicateSupporter extends PredicateSupportRules {
         produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
           val predicateTrigger =
-            App(Verifier.predicateData(predicate).triggerFunction, snap +: tArgs)
+            App(s4.predicateData(predicate).triggerFunction, snap +: tArgs)
           v2.decider.assume(predicateTrigger)
           val s5 = s4.copy(g = s.g,
                            permissionScalingFactor = s.permissionScalingFactor)

--- a/src/main/scala/rules/StateConsolidator.scala
+++ b/src/main/scala/rules/StateConsolidator.scala
@@ -236,7 +236,7 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
          for each field. Nearly identical to what the evaluator does for perm(x.f) if f is
          a QP field */
       chunksPerField.foldLeft(si) { case (si, (fieldName, fieldChunks)) =>
-        val field = Verifier.program.findField(fieldName)
+        val field = s.program.findField(fieldName)
         val (sn, smDef, pmDef) =
           quantifiedChunkSupporter.heapSummarisingMaps(si, field, args, fieldChunks, v)
         val trigger = FieldTrigger(field.name, smDef.sm, receiver)

--- a/src/main/scala/rules/SymbolicExecutionRules.scala
+++ b/src/main/scala/rules/SymbolicExecutionRules.scala
@@ -38,7 +38,7 @@ trait SymbolicExecutionRules {
           case VariablesModel =>
             SiliconVariableCounterexample(s.g, nativeModel)
           case MappedModel =>
-            SiliconMappedCounterexample(s.g, s.h.values, s.oldHeaps, nativeModel)
+            SiliconMappedCounterexample(s.g, s.h.values, s.oldHeaps, nativeModel, s.program)
         }
         val finalCE = ceTrafo match {
           case Some(trafo) => trafo.f(ce)

--- a/src/main/scala/state/State.scala
+++ b/src/main/scala/state/State.scala
@@ -13,11 +13,15 @@ import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.decider.RecordedPathConditions
 import viper.silicon.state.State.OldHeaps
 import viper.silicon.state.terms.{Term, Var}
-import viper.silicon.supporters.functions.{FunctionRecorder, NoopFunctionRecorder}
+import viper.silicon.supporters.PredicateData
+import viper.silicon.supporters.functions.{FunctionData, FunctionRecorder, NoopFunctionRecorder}
 import viper.silicon.{Map, Stack}
 
 final case class State(g: Store = Store(),
                        h: Heap = Heap(),
+                       program: ast.Program,
+                       predicateData: Map[ast.Predicate, PredicateData],
+                       functionData: Map[ast.Function, FunctionData],
                        oldHeaps: OldHeaps = Map.empty,
 
                        parallelizeBranches: Boolean = false,
@@ -121,7 +125,10 @@ object State {
   def merge(s1: State, s2: State): State = {
     s1 match {
       /* Decompose state s1 */
-      case State(g1, h1, oldHeaps1,
+      case State(g1, h1, program,
+                 predicateData,
+                 functionData,
+                 oldHeaps1,
                  parallelizeBranches1,
                  recordVisited1, visited1,
                  methodCfg1, invariantContexts1,
@@ -142,7 +149,10 @@ object State {
 
         /* Decompose state s2: most values must match those of s1 */
         s2 match {
-          case State(`g1`, `h1`, `oldHeaps1`,
+          case State(`g1`, `h1`,
+                     `program`,
+                     `predicateData`, `functionData`,
+                     `oldHeaps1`,
                      `parallelizeBranches1`,
                      `recordVisited1`, `visited1`,
                      `methodCfg1`, `invariantContexts1`,

--- a/src/main/scala/state/SymbolConverter.scala
+++ b/src/main/scala/state/SymbolConverter.scala
@@ -15,8 +15,8 @@ trait SymbolConverter {
 
   def toSortSpecificId(name: String, sorts: Seq[Sort]): Identifier
 
-  def toFunction(function: ast.DomainFunc): terms.DomainFun
-  def toFunction(function: ast.DomainFunc, sorts: Seq[Sort]): terms.DomainFun
+  def toFunction(function: ast.DomainFunc, prog: ast.Program): terms.DomainFun
+  def toFunction(function: ast.DomainFunc, sorts: Seq[Sort], prog: ast.Program): terms.DomainFun
 
   def toFunction(function: ast.BackendFunc): terms.SMTFun
 
@@ -53,11 +53,11 @@ class DefaultSymbolConverter extends SymbolConverter {
   def toSortSpecificId(name: String, sorts: Seq[Sort]): Identifier =
     Identifier(name + sorts.mkString("[",",","]"))
 
-  def toFunction(function: ast.DomainFunc): terms.DomainFun = {
+  def toFunction(function: ast.DomainFunc, program: ast.Program): terms.DomainFun = {
     val inSorts = function.formalArgs map (_.typ) map toSort
     val outSort = toSort(function.typ)
 
-    toFunction(function, inSorts :+ outSort)
+    toFunction(function, inSorts :+ outSort, program)
   }
 
   def toFunction(function: ast.BackendFunc): terms.SMTFun = {
@@ -69,12 +69,12 @@ class DefaultSymbolConverter extends SymbolConverter {
     terms.SMTFun(id, inSorts, outSort)
   }
 
-  def toFunction(function: ast.DomainFunc, sorts: Seq[Sort]): terms.DomainFun = {
+  def toFunction(function: ast.DomainFunc, sorts: Seq[Sort], program: ast.Program): terms.DomainFun = {
     assert(sorts.nonEmpty, "Expected at least one sort, but found none")
 
     val inSorts = sorts.init
     val outSort = sorts.last
-    val domainFunc = Verifier.program.findDomainFunctionOptionally(function.name)
+    val domainFunc = program.findDomainFunctionOptionally(function.name)
     val id = if (domainFunc.isEmpty) Identifier(function.name) else toSortSpecificId(function.name, Seq(outSort))
 
     terms.DomainFun(id, inSorts, outSort)

--- a/src/main/scala/state/Terms.scala
+++ b/src/main/scala/state/Terms.scala
@@ -1987,8 +1987,8 @@ object ResourceTriggerFunction {
   def apply(predicate: ast.Predicate, sm: Term, args: Seq[Term]): PredicateTrigger =
     PredicateTrigger(predicate.name, sm, args)
 
-  def apply(wand: ast.MagicWand, sm: Term, args: Seq[Term]): PredicateTrigger = {
-    val wandId = MagicWandIdentifier(wand, Verifier.program).toString
+  def apply(wand: ast.MagicWand, sm: Term, args: Seq[Term], program: ast.Program): PredicateTrigger = {
+    val wandId = MagicWandIdentifier(wand, program).toString
 
     PredicateTrigger(wandId, sm, args)
   }
@@ -2011,8 +2011,8 @@ object ResourceLookup {
   def apply(predicate: ast.Predicate, sm: Term, args: Seq[Term]): PredicateLookup =
     PredicateLookup(predicate.name, sm, args)
 
-  def apply(wand: ast.MagicWand, sm: Term, args: Seq[Term]): PredicateLookup = {
-    val wandId = MagicWandIdentifier(wand, Verifier.program).toString
+  def apply(wand: ast.MagicWand, sm: Term, args: Seq[Term], program: ast.Program): PredicateLookup = {
+    val wandId = MagicWandIdentifier(wand, program).toString
 
     PredicateLookup(wandId, sm, args)
   }
@@ -2035,8 +2035,8 @@ object ResourcePermissionLookup {
   def apply(predicate: ast.Predicate, sm: Term, args: Seq[Term]): PredicatePermLookup =
     PredicatePermLookup(predicate.name, sm, args)
 
-  def apply(wand: ast.MagicWand, sm: Term, args: Seq[Term]): PredicatePermLookup = {
-    val wandId = MagicWandIdentifier(wand, Verifier.program).toString
+  def apply(wand: ast.MagicWand, sm: Term, args: Seq[Term], program: ast.Program): PredicatePermLookup = {
+    val wandId = MagicWandIdentifier(wand, program).toString
 
     PredicatePermLookup(wandId, sm, args)
   }

--- a/src/main/scala/state/Terms.scala
+++ b/src/main/scala/state/Terms.scala
@@ -1971,13 +1971,13 @@ object fromSnapTree extends ((Term, Int) => Seq[Term]) {
 }
 
 object ResourceTriggerFunction {
-  def apply(resource: ast.Resource, sm: Term, args: Seq[Term]): Term = {
+  def apply(resource: ast.Resource, sm: Term, args: Seq[Term], program: ast.Program): Term = {
     resource match {
       case f: ast.Field =>
         assert(args.size == 1)
         apply(f, sm, args.head)
       case p: ast.Predicate => apply(p, sm, args)
-      case w: ast.MagicWand => apply(w, sm, args)
+      case w: ast.MagicWand => apply(w, sm, args, program)
     }
   }
 
@@ -1995,13 +1995,13 @@ object ResourceTriggerFunction {
 }
 
 object ResourceLookup {
-  def apply(resource: ast.Resource, sm: Term, args: Seq[Term]): Term = {
+  def apply(resource: ast.Resource, sm: Term, args: Seq[Term], program: ast.Program): Term = {
     resource match {
       case f: ast.Field =>
         assert(args.size == 1)
         apply(f, sm, args.head)
       case p: ast.Predicate => apply(p, sm, args)
-      case w: ast.MagicWand => apply(w, sm, args)
+      case w: ast.MagicWand => apply(w, sm, args, program)
     }
   }
 
@@ -2019,13 +2019,13 @@ object ResourceLookup {
 }
 
 object ResourcePermissionLookup {
-  def apply(resource: ast.Resource, sm: Term, args: Seq[Term]): Term = {
+  def apply(resource: ast.Resource, sm: Term, args: Seq[Term], program: ast.Program): Term = {
     resource match {
       case f: ast.Field =>
         assert(args.size == 1)
         apply(f, sm, args.head)
       case p: ast.Predicate => apply(p, sm, args)
-      case w: ast.MagicWand => apply(w, sm, args)
+      case w: ast.MagicWand => apply(w, sm, args, program)
     }
   }
 

--- a/src/main/scala/supporters/BuiltinDomainsContributor.scala
+++ b/src/main/scala/supporters/BuiltinDomainsContributor.scala
@@ -206,7 +206,7 @@ private object utils {
         program
 
       case fastparse.Parsed.Failure(msg, index, _) =>
-        val (line, col) = lc.apply(index)
+        val (line, col) = lc.getPos(index)
         sys.error(s"Failure: $msg, at ${viper.silver.ast.FilePosition(fromPath, line, col)}")
         //? val pos = extra.input.prettyIndex(index).split(":").map(_.toInt)
         //? sys.error(s"Failure: $msg, at ${viper.silver.ast.FilePosition(fromPath, pos(0), pos(1))}")

--- a/src/main/scala/supporters/BuiltinDomainsContributor.scala
+++ b/src/main/scala/supporters/BuiltinDomainsContributor.scala
@@ -8,6 +8,7 @@ package viper.silicon.supporters
 
 import java.io.File
 import java.net.URL
+
 import scala.annotation.unused
 import scala.reflect.ClassTag
 import viper.silver.ast
@@ -16,6 +17,7 @@ import viper.silicon.interfaces.PreambleContributor
 import viper.silicon.interfaces.decider.ProverLike
 import viper.silicon.state.DefaultSymbolConverter
 import viper.silicon.state.terms._
+import viper.silver.ast.LineCol
 
 abstract class BuiltinDomainsContributor extends PreambleContributor[Sort, DomainFun, Term] {
   type BuiltinDomainType <: ast.GenericType
@@ -87,7 +89,7 @@ abstract class BuiltinDomainsContributor extends PreambleContributor[Sort, Domai
     val sourceDomainInstantiations = sourceDomainInstantiationsWithType.map(x => x._2)
 
     collectSorts(sourceDomainTypeInstances)
-    collectFunctions(sourceDomainInstantiations)
+    collectFunctions(sourceDomainInstantiations, program)
     collectAxioms(sourceDomainInstantiationsWithType)
   }
 
@@ -109,10 +111,10 @@ abstract class BuiltinDomainsContributor extends PreambleContributor[Sort, Domai
     })
   }
 
-  protected def collectFunctions(domains: Set[ast.Domain]): Unit = {
+  protected def collectFunctions(domains: Set[ast.Domain], program: ast.Program): Unit = {
     domains foreach (
       _.functions foreach (df =>
-        collectedFunctions += symbolConverter.toFunction(df)))
+        collectedFunctions += symbolConverter.toFunction(df, program)))
   }
 
   protected def collectAxioms(domains: Set[(ast.DomainType, ast.Domain)]): Unit = {
@@ -190,7 +192,9 @@ private object utils {
         source.close()
       }
 
-    viper.silver.parser.FastParser.parse(content, fromPath) match {
+    val fp = new viper.silver.parser.FastParser()
+    val lc = new LineCol(fp)
+    fp.parse(content, fromPath) match {
       case fastparse.Parsed.Success(parsedProgram: viper.silver.parser.PProgram, _) =>
         assert(parsedProgram.errors.isEmpty, s"Unexpected parsing errors: ${parsedProgram.errors}")
 
@@ -202,7 +206,7 @@ private object utils {
         program
 
       case fastparse.Parsed.Failure(msg, index, _) =>
-        val (line, col) = ast.LineCol(index)
+        val (line, col) = lc.apply(index)
         sys.error(s"Failure: $msg, at ${viper.silver.ast.FilePosition(fromPath, line, col)}")
         //? val pos = extra.input.prettyIndex(index).split(":").map(_.toInt)
         //? sys.error(s"Failure: $msg, at ${viper.silver.ast.FilePosition(fromPath, pos(0), pos(1))}")

--- a/src/main/scala/supporters/BuiltinDomainsContributor.scala
+++ b/src/main/scala/supporters/BuiltinDomainsContributor.scala
@@ -129,7 +129,7 @@ abstract class BuiltinDomainsContributor extends PreambleContributor[Sort, Domai
      * are preserved.
      */
     val domainName = f"${d.domainName}[${d.typVarsMap.values.map(t => symbolConverter.toSort(t)).mkString(",")}]"
-    domainTranslator.translateAxiom(ax, symbolConverter.toSort).transform {
+    domainTranslator.translateAxiom(ax, symbolConverter.toSort, true).transform {
       case q@Quantification(_,_,_,_,name,_) if name != "" =>
         q.copy(name = f"${domainName}_${name}")
       case Equals(t1, t2) => BuiltinEquals(t1, t2)

--- a/src/main/scala/supporters/Domains.scala
+++ b/src/main/scala/supporters/Domains.scala
@@ -132,15 +132,16 @@ class DefaultDomainsContributor(symbolConverter: SymbolConverter,
 }
 
 trait DomainsTranslator[R] {
-  def translateAxiom(ax: ast.DomainAxiom, toSort: ast.Type => Sort): R
+  def translateAxiom(ax: ast.DomainAxiom, toSort: ast.Type => Sort, builtin: Boolean = false): R
 }
 
 class DefaultDomainsTranslator()
     extends DomainsTranslator[Term]
        with ExpressionTranslator {
 
-  def translateAxiom(ax: ast.DomainAxiom, toSort: ast.Type => Sort): Term = {
-    translate(toSort)(ax.exp) match {
+  def translateAxiom(ax: ast.DomainAxiom, toSort: ast.Type => Sort, builtin: Boolean = false): Term = {
+    isBuiltin = builtin
+    val res = translate(toSort)(ax.exp) match {
       case terms.Quantification(q, vars, body, triggers, "", _) =>
         val qid = ax match {
           case axiom: NamedDomainAxiom => s"prog.${axiom.name}"
@@ -151,5 +152,7 @@ class DefaultDomainsTranslator()
 
       case other => other
     }
+    isBuiltin = false
+    res
   }
 }

--- a/src/main/scala/supporters/Domains.scala
+++ b/src/main/scala/supporters/Domains.scala
@@ -14,7 +14,7 @@ import viper.silicon.interfaces.PreambleContributor
 import viper.silicon.interfaces.decider.ProverLike
 import viper.silicon.state.{SymbolConverter, terms}
 import viper.silicon.state.terms.{Distinct, DomainFun, Sort, Symbol, Term}
-import viper.silver.ast.NamedDomainAxiom
+import viper.silver.ast.{NamedDomainAxiom, Program}
 
 trait DomainsContributor[SO, SY, AX, UA] extends PreambleContributor[SO, SY, AX] {
   def uniquenessAssumptionsAfterAnalysis: Iterable[UA]
@@ -56,7 +56,7 @@ class DefaultDomainsContributor(symbolConverter: SymbolConverter,
       necessaryDomainTypes map (cdt => domainNameMap(cdt.domainName).instantiate(cdt, program))
 
     collectDomainSorts(necessaryDomainTypes)
-    collectDomainMembers(instantiatedDomains)
+    collectDomainMembers(instantiatedDomains, program)
   }
 
   private def collectDomainSorts(domainTypes: Iterable[ast.DomainType]): Unit = {
@@ -68,7 +68,7 @@ class DefaultDomainsContributor(symbolConverter: SymbolConverter,
     })
   }
 
-  private def collectDomainMembers(instantiatedDomains: Set[ast.Domain]): Unit = {
+  private def collectDomainMembers(instantiatedDomains: Set[ast.Domain], program: ast.Program): Unit = {
     /* Since domain member instances come with Silver types, but the corresponding prover
      * declarations work with Silicon sorts, it can happen that two instances with different types
      * result in the same function declaration because the types are mapped to the same sort(s).
@@ -84,7 +84,7 @@ class DefaultDomainsContributor(symbolConverter: SymbolConverter,
 
     instantiatedDomains foreach (domain => {
       domain.functions foreach (function => {
-        val fct = symbolConverter.toFunction(function)
+        val fct = symbolConverter.toFunction(function, program)
 
         collectedFunctions += fct
 

--- a/src/main/scala/supporters/ExpressionTranslator.scala
+++ b/src/main/scala/supporters/ExpressionTranslator.scala
@@ -19,7 +19,7 @@ trait ExpressionTranslator {
    *       was done before - but that is less efficient and creates lots of additional noise output
    *       in the prover log.
    */
-  protected def program: ast.Program
+  protected var isBuiltin: Boolean = false
 
   protected def translate(toSort: ast.Type => Sort)
                          (exp: ast.Exp)
@@ -126,8 +126,7 @@ trait ExpressionTranslator {
         val tArgs = args map f
         val inSorts = tArgs map (_.sort)
         val outSort = toSort(exp.typ)
-        val domainFunc = program.findDomainFunctionOptionally(funcName)
-        val id = if (domainFunc.isEmpty) Identifier(funcName) else Identifier(funcName + Seq(outSort).mkString("[",",","]"))
+        val id = if (isBuiltin) Identifier(funcName) else Identifier(funcName + Seq(outSort).mkString("[",",","]"))
         val df = Fun(id, inSorts, outSort)
         App(df, tArgs)
 

--- a/src/main/scala/supporters/ExpressionTranslator.scala
+++ b/src/main/scala/supporters/ExpressionTranslator.scala
@@ -19,6 +19,7 @@ trait ExpressionTranslator {
    *       was done before - but that is less efficient and creates lots of additional noise output
    *       in the prover log.
    */
+  protected def program: ast.Program
 
   protected def translate(toSort: ast.Type => Sort)
                          (exp: ast.Exp)
@@ -125,7 +126,7 @@ trait ExpressionTranslator {
         val tArgs = args map f
         val inSorts = tArgs map (_.sort)
         val outSort = toSort(exp.typ)
-        val domainFunc = Verifier.program.findDomainFunctionOptionally(funcName)
+        val domainFunc = program.findDomainFunctionOptionally(funcName)
         val id = if (domainFunc.isEmpty) Identifier(funcName) else Identifier(funcName + Seq(outSort).mkString("[",",","]"))
         val df = Fun(id, inSorts, outSort)
         App(df, tArgs)

--- a/src/main/scala/supporters/PredicateVerificationUnit.scala
+++ b/src/main/scala/supporters/PredicateVerificationUnit.scala
@@ -50,7 +50,7 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
   object predicateSupporter extends PredicateVerificationUnit with StatefulComponent {
     import viper.silicon.rules.producer._
 
-    private var predicateData: Map[ast.Predicate, PredicateData] = Map.empty
+    /*private*/ var predicateData: Map[ast.Predicate, PredicateData] = Map.empty
 
     def data = predicateData
     def units = predicateData.keys.toSeq
@@ -78,10 +78,6 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
     /* Predicate supporter generates no axioms */
     val axiomsAfterAnalysis: Iterable[Term] = Seq.empty
     def emitAxiomsAfterAnalysis(sink: ProverLike): Unit = ()
-
-    def updateGlobalStateAfterAnalysis(): Unit = {
-      Verifier.predicateData = predicateData
-    }
 
     /* Verification and subsequent preamble contribution */
 
@@ -123,10 +119,6 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
     /* Predicate supporter generates no axioms */
     val axiomsAfterVerification: Iterable[Term] = Seq.empty
     def emitAxiomsAfterVerification(sink: ProverLike): Unit = ()
-
-    def contributeToGlobalStateAfterVerification(): Unit = {
-      Verifier.predicateData = predicateData
-    }
 
     /* Lifetime */
 

--- a/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
+++ b/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
@@ -25,7 +25,7 @@ class HeapAccessReplacingExpressionTranslator(symbolConverter: SymbolConverter,
     extends ExpressionTranslator
        with LazyLogging {
 
-  private var program: ast.Program = _
+  protected var program: ast.Program = _
   @unused private var func: ast.Function = _
   private var data: FunctionData = _
   private var ignoreAccessPredicates = false

--- a/src/main/scala/verifier/DefaultMasterVerifier.scala
+++ b/src/main/scala/verifier/DefaultMasterVerifier.scala
@@ -135,7 +135,7 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
 
   /* Program verification */
 
-  def verify(originalProgram: ast.Program, cfgs: Seq[SilverCfg]): List[VerificationResult] = {
+  def verify(originalProgram: ast.Program, cfgs: Seq[SilverCfg], inputFile: Option[String]): List[VerificationResult] = {
     /** Trigger computation is currently not thread-safe; hence, all triggers are computed
       * up-front, before the program is verified in parallel.
       * This is done bottom-up to ensure that nested quantifiers are transformed as well
@@ -165,7 +165,7 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
 
     allProvers.comment("Started: " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(System.currentTimeMillis()) /*bookkeeper.formattedStartTime*/)
     allProvers.comment("Silicon.version: " + Silicon.version)
-    //allProvers.comment(s"Input file: ${Verifier.inputFile.getOrElse("<unknown>")}")
+    allProvers.comment(s"Input file: ${inputFile.getOrElse("<unknown>")}")
     allProvers.comment(s"Verifier id: $uniqueId")
     allProvers.comment("-" * 60)
     allProvers.comment("Begin preamble")

--- a/src/main/scala/verifier/DefaultMasterVerifier.scala
+++ b/src/main/scala/verifier/DefaultMasterVerifier.scala
@@ -271,13 +271,16 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
      ++ methodVerificationResults)
   }
 
-  private def createInitialState(member: ast.Member, program: ast.Program,
-                                 functionData: Map[ast.Function, FunctionData], predicateData: Map[ast.Predicate, PredicateData]): State = {
+  private def createInitialState(member: ast.Member,
+                                 program: ast.Program,
+                                 functionData: Map[ast.Function, FunctionData],
+                                 predicateData: Map[ast.Predicate, PredicateData]): State = {
     val quantifiedFields = InsertionOrderedSet(ast.utility.QuantifiedPermissions.quantifiedFields(member, program))
     val quantifiedPredicates = InsertionOrderedSet(ast.utility.QuantifiedPermissions.quantifiedPredicates(member, program))
     val quantifiedMagicWands = InsertionOrderedSet(ast.utility.QuantifiedPermissions.quantifiedMagicWands(member, program)).map(MagicWandIdentifier(_, program))
 
-    State(program=program, functionData = functionData,
+    State(program = program,
+          functionData = functionData,
           predicateData = predicateData,
           qpFields = quantifiedFields,
           qpPredicates = quantifiedPredicates,
@@ -287,14 +290,19 @@ class DefaultMasterVerifier(config: Config, override val reporter: Reporter)
           isMethodVerification = member.isInstanceOf[ast.Member])
   }
 
-  private def createInitialState(@unused cfg: SilverCfg, program: ast.Program,
-                                 functionData: Map[ast.Function, FunctionData], predicateData: Map[ast.Predicate, PredicateData]): State = {
+  private def createInitialState(@unused cfg: SilverCfg,
+                                 program: ast.Program,
+                                 functionData: Map[ast.Function, FunctionData],
+                                 predicateData: Map[ast.Predicate, PredicateData]): State = {
     val quantifiedFields = InsertionOrderedSet(program.fields)
     val quantifiedPredicates = InsertionOrderedSet(program.predicates)
     val quantifiedMagicWands = InsertionOrderedSet[MagicWandIdentifier]() // TODO: Implement support for quantified magic wands.
 
-    State(program=program, functionData = functionData,
-      predicateData = predicateData, qpFields = quantifiedFields,
+    State(
+      program = program,
+      functionData = functionData,
+      predicateData = predicateData,
+      qpFields = quantifiedFields,
       qpPredicates = quantifiedPredicates,
       qpMagicWands = quantifiedMagicWands,
       predicateSnapMap = predSnapGenerator.snapMap,

--- a/src/main/scala/verifier/Verifier.scala
+++ b/src/main/scala/verifier/Verifier.scala
@@ -46,8 +46,6 @@ trait Verifier {
     || Verifier.config.numberOfErrorsToReport() == 0);
 }
 
-/* TODO: Replace getters and setters by public vars
-   TODO: Add a description to each var that explain when it is expected to be set */
 object Verifier {
   val PRE_STATE_LABEL = "old"
   val MAGIC_WAND_LHS_STATE_LABEL = ast.LabelledOld.LhsOldLabel
@@ -55,6 +53,11 @@ object Verifier {
   private var _config: Config = _
   def config: Config = _config
   /*private*/ def config_=(config: Config): Unit = { _config = config }
+}
+
+/* TODO: Replace getters and setters by public vars
+   TODO: Add a description to each var that explain when it is expected to be set */
+class VerifierState {
 
   private var _program: ast.Program = _
   def program: ast.Program = _program

--- a/src/main/scala/verifier/Verifier.scala
+++ b/src/main/scala/verifier/Verifier.scala
@@ -55,27 +55,4 @@ object Verifier {
   /*private*/ def config_=(config: Config): Unit = { _config = config }
 }
 
-/* TODO: Replace getters and setters by public vars
-   TODO: Add a description to each var that explain when it is expected to be set */
-class VerifierState {
-
-  private var _program: ast.Program = _
-  def program: ast.Program = _program
-  /*private*/ def program_=(program: ast.Program): Unit = { _program = program }
-
-  private var _inputFile: Option[Path] = None
-  def inputFile: Option[Path] = _inputFile
-  /*private*/ def inputFile_=(file: Option[Path]): Unit = { _inputFile = file }
-
-  private var _predicateData: Map[ast.Predicate, PredicateData] = _
-  def predicateData: Map[ast.Predicate, PredicateData] = _predicateData
-  /*private*/ def predicateData_=(predicateData: Map[ast.Predicate, PredicateData]): Unit =
-    { _predicateData = predicateData }
-
-  private var _functionData: Map[ast.Function, FunctionData] = _
-  def functionData: Map[ast.Function, FunctionData] = _functionData
-  /*private*/ def functionData_=(functionData: Map[ast.Function, FunctionData]): Unit =
-  { _functionData = functionData }
-}
-
 trait VerifierComponent { this: Verifier => }

--- a/src/test/scala/CounterexampleTests.scala
+++ b/src/test/scala/CounterexampleTests.scala
@@ -174,9 +174,10 @@ case class ExpectedCounterexampleAnnotation(id: OutputAnnotationId, file: Path, 
   * same syntax as in Viper)
   */
 class CounterexampleParser(fp: FastParser) {
+  import fp.{accessPred, eqExp}
 
   def expectedCounterexample[_: P]: P[ExpectedCounterexample] =
-    (Start ~ "(" ~ (fp.accessPred | fp.eqExp).rep(0, ",") ~ ")" ~ End)
+    (Start ~ "(" ~ (accessPred | eqExp).rep(0, ",") ~ ")" ~ End)
       .map(ExpectedCounterexample)
 }
 

--- a/src/test/scala/PortableSiliconTests.scala
+++ b/src/test/scala/PortableSiliconTests.scala
@@ -100,7 +100,7 @@ class PortableSiliconTests extends SilSuite with StatisticalTestSuite {
     /* If needed, Silicon reads the filename of the program under verification from Verifier.inputFile.
     When the test suite is executed (sbt test/testOnly), Verifier.inputFile is set here. When Silicon is
     run from the command line, Verifier.inputFile is set in src/main/scala/Silicon.scala. */
-    viper.silicon.verifier.Verifier.inputFile = Some(files.head)
+    //viper.silicon.verifier.Verifier.inputFile = Some(files.head)
 
     val fe = new SiliconFrontend(NoopReporter)//SiliconFrontendWithUnitTesting()
     fe.init(verifier)

--- a/src/test/scala/PortableSiliconTests.scala
+++ b/src/test/scala/PortableSiliconTests.scala
@@ -97,11 +97,6 @@ class PortableSiliconTests extends SilSuite with StatisticalTestSuite {
   override def frontend(verifier: Verifier, files: Seq[Path]): SiliconFrontend = {
     require(files.length == 1, "tests should consist of exactly one file")
 
-    /* If needed, Silicon reads the filename of the program under verification from Verifier.inputFile.
-    When the test suite is executed (sbt test/testOnly), Verifier.inputFile is set here. When Silicon is
-    run from the command line, Verifier.inputFile is set in src/main/scala/Silicon.scala. */
-    //viper.silicon.verifier.Verifier.inputFile = Some(files.head)
-
     val fe = new SiliconFrontend(NoopReporter)//SiliconFrontendWithUnitTesting()
     fe.init(verifier)
     fe.reset(files.head)

--- a/src/test/scala/SiliconTests.scala
+++ b/src/test/scala/SiliconTests.scala
@@ -31,7 +31,7 @@ class SiliconTests extends SilSuite {
     /* If needed, Silicon reads the filename of the program under verification from Verifier.inputFile.
     When the test suite is executed (sbt test/testOnly), Verifier.inputFile is set here. When Silicon is
     run from the command line, Verifier.inputFile is set in src/main/scala/Silicon.scala. */
-    viper.silicon.verifier.Verifier.inputFile = Some(files.head)
+    //viper.silicon.verifier.Verifier.inputFile = Some(files.head)
 
     val fe = new SiliconFrontend(NoopReporter)
     fe.init(verifier)

--- a/src/test/scala/SiliconTests.scala
+++ b/src/test/scala/SiliconTests.scala
@@ -28,11 +28,6 @@ class SiliconTests extends SilSuite {
   override def frontend(verifier: Verifier, files: Seq[Path]): SiliconFrontend = {
     require(files.length == 1, "tests should consist of exactly one file")
 
-    /* If needed, Silicon reads the filename of the program under verification from Verifier.inputFile.
-    When the test suite is executed (sbt test/testOnly), Verifier.inputFile is set here. When Silicon is
-    run from the command line, Verifier.inputFile is set in src/main/scala/Silicon.scala. */
-    //viper.silicon.verifier.Verifier.inputFile = Some(files.head)
-
     val fe = new SiliconFrontend(NoopReporter)
     fe.init(verifier)
     fe.reset(files.head)

--- a/src/test/scala/SymbExLoggerTests.scala
+++ b/src/test/scala/SymbExLoggerTests.scala
@@ -27,7 +27,7 @@ class SymbExLoggerTests extends SilSuite {
     /* If needed, Silicon reads the filename of the program under verification from Verifier.inputFile.
     When the test suite is executed (sbt test/testOnly), Verifier.inputFile is set here. When Silicon is
     run from the command line, Verifier.inputFile is set in src/main/scala/Silicon.scala. */
-    viper.silicon.verifier.Verifier.inputFile = Some(files.head)
+    //viper.silicon.verifier.Verifier.inputFile = Some(files.head)
 
     // For Unit-Testing of the Symbolic Execution Logging, the name of the file
     // to be tested must be known, which is why it's passed here to the SymbExLogger-Object.

--- a/src/test/scala/SymbExLoggerTests.scala
+++ b/src/test/scala/SymbExLoggerTests.scala
@@ -24,11 +24,6 @@ class SymbExLoggerTests extends SilSuite {
   override def frontend(verifier: Verifier, files: Seq[Path]): Frontend = {
     require(files.length == 1, "tests should consist of exactly one file")
 
-    /* If needed, Silicon reads the filename of the program under verification from Verifier.inputFile.
-    When the test suite is executed (sbt test/testOnly), Verifier.inputFile is set here. When Silicon is
-    run from the command line, Verifier.inputFile is set in src/main/scala/Silicon.scala. */
-    //viper.silicon.verifier.Verifier.inputFile = Some(files.head)
-
     // For Unit-Testing of the Symbolic Execution Logging, the name of the file
     // to be tested must be known, which is why it's passed here to the SymbExLogger-Object.
     // SymbExLogger.reset() cleans the logging object (only relevant for verifying multiple


### PR DESCRIPTION
Removing global state in order to be able to run multiple instances of Silicon in parallel (which several frontends would like to do). Depends on Silver PR https://github.com/viperproject/silver/pull/600

We're making the following changes:

- Adapting to Silver changes, in particular, the fact that FastParser is no longer a global object
- Moving Verifier.program, Verifier.functionData, and Verifier.predicateData to the State class, and passing them from there through the code where needed.
- Verifier.inputFile is removed completely. We're explicitly setting it in the MultiRunRecorder and passing it to the runVerifier method; it's not used anywhere else.

Note that Verifier.config remains global, since I'm assuming that we don't want to run Silicon with different settings at the same time, and it's referenced all over the place