### PR TITLE
Z3 API / branch parallelization fix

### DIFF
--- a/src/main/scala/decider/TermToZ3APIConverter.scala
+++ b/src/main/scala/decider/TermToZ3APIConverter.scala
@@ -255,7 +255,11 @@ class TermToZ3APIConverter
         } else{
           val qvarExprs = vars.map(v => convert(v)).toArray
           val nonEmptyTriggers = triggers.filter(_.p.nonEmpty)
-          val patterns = if (nonEmptyTriggers.nonEmpty) nonEmptyTriggers.map(t => ctx.mkPattern(t.p.map(convertTerm): _*)).toArray else null
+          val patterns = if (nonEmptyTriggers.nonEmpty)
+              // Simplify trigger terms; Z3 does this automatically when used via stdio, and it sometimes makes
+              // triggers valid that would otherwise be rejected.
+              nonEmptyTriggers.map(t => ctx.mkPattern(t.p.map(trm => convertTerm(trm).simplify()): _*)).toArray
+            else null
           if (quant == Forall) {
             ctx.mkForall(qvarExprs, convertTerm(body), 1, patterns, null, ctx.mkSymbol(name), null)
           }else{

--- a/src/main/scala/decider/Z3ProverAPI.scala
+++ b/src/main/scala/decider/Z3ProverAPI.scala
@@ -43,7 +43,6 @@ object Z3ProverAPI {
 
   // All options taken from z3config.smt2 and split up according to argument type and time when it has to be set.
   // I removed all options that (no longer?) exist, since those result in errors from Z3.
-  // Removed options: TODO
   val randomizeSeedsOptions = Seq("random_seed")
   val initialOptions = Map("auto_config" -> "false", "type_check" -> "true")
   val boolParams = Map(

--- a/src/main/scala/decider/Z3ProverAPI.scala
+++ b/src/main/scala/decider/Z3ProverAPI.scala
@@ -43,22 +43,32 @@ object Z3ProverAPI {
 
   // All options taken from z3config.smt2 and split up according to argument type and time when it has to be set.
   // I removed all options that (no longer?) exist, since those result in errors from Z3.
+  // Removed options: TODO
   val randomizeSeedsOptions = Seq("random_seed")
   val initialOptions = Map("auto_config" -> "false", "type_check" -> "true")
   val boolParams = Map(
     "smt.delay_units" -> true,
+    "delay_units" -> true,
     "nnf.sk_hack" -> true,
     "smt.mbqi" -> false,
+    "mbqi" -> false,
     "nlsat.randomize" -> true,
     "nlsat.shuffle_vars" -> false,
     "smt.arith.random_initial_value" -> true,
+    "arith.random_initial_value" -> true,
+    "bv.reflect" -> true,
   )
-  val intParams = Map("smt.restart_strategy" -> 0,
+  val intParams = Map(
+    "smt.restart_strategy" -> 0,
+    "restart_strategy" -> 0,
     "smt.case_split" -> 3,
     "case_split" -> 3,
     "smt.delay_units_threshold" -> 16,
+    "delay_units_threshold" -> 16,
     "smt.qi.max_multi_patterns" -> 1000,
+    "qi.max_multi_patterns" -> 1000,
     "smt.phase_selection" -> 0,
+    "phase_selection" -> 0,
     "sat.random_seed" -> 0,
     "nlsat.seed" -> 0,
     "random_seed" -> 0,
@@ -69,7 +79,9 @@ object Z3ProverAPI {
   )
   val doubleParams = Map(
     "smt.restart_factor" -> 1.5,
+    "restart_factor" -> 1.5,
     "smt.qi.eager_threshold" -> 100.0,
+    "qi.eager_threshold" -> 100.0,
   )
 }
 

--- a/src/main/scala/interfaces/Verification.scala
+++ b/src/main/scala/interfaces/Verification.scala
@@ -37,7 +37,7 @@ sealed abstract class VerificationResult {
    *   println(other)
    * will invoke the function twice, which might not be what you really want!
    */
-  def combine(other: => VerificationResult): VerificationResult = {
+  def combine(other: => VerificationResult, alwaysWaitForOther: Boolean = false): VerificationResult = {
     if (this.continueVerification){
       val r: VerificationResult = other
       /* Result of combining a failure with a non failure should be a failure.
@@ -51,7 +51,14 @@ sealed abstract class VerificationResult {
           r.previous = (r.previous :+ this) ++ this.previous
           r
       }
-    } else this
+    } else {
+      if (alwaysWaitForOther) {
+        // force evaluation
+        val res: VerificationResult = other
+      }
+      this
+    }
+
   }
 }
 

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -127,7 +127,7 @@ object brancher extends BranchingRules {
             v1.decider.setCurrentBranchCondition(negatedCondition, negatedConditionExp)
 
             // TODO: we should saturate here to some degree; which option fits best?
-            v1.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
+            //v1.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
 
             fElse(v1.stateConsolidator.consolidateIfRetrying(s1, v1), v1)
           })
@@ -178,7 +178,7 @@ object brancher extends BranchingRules {
             // we have done other work during the join, need to reset
             v.decider.setPcs(pcsOfCurrentDecider)
             // TODO: we should saturate here to some degree; which option fits best?
-            v.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
+            //v.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
           }
         }else{
           rs = elseBranchFuture.get()

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -127,6 +127,7 @@ object brancher extends BranchingRules {
             v1.decider.setCurrentBranchCondition(negatedCondition, negatedConditionExp)
 
             // TODO: we should saturate here to some degree; which option fits best?
+            // Tried out afterContract, got reduced performance on a few examples, need to test probably.
             //v1.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
 
             fElse(v1.stateConsolidator.consolidateIfRetrying(s1, v1), v1)

--- a/src/main/scala/verifier/VerificationPoolManager.scala
+++ b/src/main/scala/verifier/VerificationPoolManager.scala
@@ -62,13 +62,11 @@ class VerificationPoolManager(master: MasterVerifier) extends StatefulComponent 
   }
 
   private def resetSlaveVerifierPool(): Unit = {
-    slaveVerifierExecutor.awaitQuiescence(10, TimeUnit.SECONDS)
     slaveVerifiers foreach (_.reset())
   }
 
   private def teardownSlaveVerifierPool(): Unit = {
     if (slaveVerifiers != null) {
-      slaveVerifierExecutor.awaitQuiescence(10, TimeUnit.SECONDS)
       slaveVerifiers foreach (_.stop())
 
       slaveVerifierExecutor.shutdown()


### PR DESCRIPTION
Fixing several small aspects of the Z3 API and branch parallelization changes:
- Simplifying triggers (this seems to happen implicitly when using stdio)
- Adding two versions of all smt.* settings, since this was necessary for smt.case_split (and so it might make a difference for the others as well)
- Forcing VerificationResult.combine to evaluate the second argument even if the first is a failure, s.t. verification cannot finish (and therefore workers cannot be killed) while some else branch is still being verified, which could lead to segfaults
- removed awaitQuiescence, since that not only waits, but volunteers the waiting thread as a worker, which will lead to an error, since the waiting thread is not a worker thread.