### PR TITLE
Add option pushTimeout to specify timeout for prover `(push)`

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -194,7 +194,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
   )
 
   val assertTimeout: ScallopOption[Int] = opt[Int]("assertTimeout",
-    descr = ("Timeout (in ms) per SMT solver assertion (default: 0, i.e. no timeout)."
+    descr = ("Timeout (in ms) per SMT solver assertion (default: 0, i.e. no timeout). "
             + s"Ignored when using the ${Cvc5ProverStdIO.name} prover."),
     default = None,
     noshort = true
@@ -206,7 +206,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
              + "check doesn't, at least not directly. However, failing checks might result in "
              + "performance degradation, e.g. when a dead program path is nevertheless explored, "
              + "and indirectly in verification failures due to incompletenesses, e.g. when "
-             + "the held permission amount is too coarsely underapproximated (default: 10)."
+             + "the held permission amount is too coarsely underapproximated (default: 10). "
              + s"Ignored when using the ${Cvc5ProverStdIO.name} prover."),
     default = Some(10),
     noshort = true
@@ -219,6 +219,13 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
              +  "either be disabled (weights or base timeout of 0) or forced with no timeout "
              + "(positive weight and base timeout)."),
     default = Some(100),
+    noshort = true
+  )
+
+  val pushTimeout: ScallopOption[Int] = opt[Int]("pushTimeout",
+    descr = (  "Timeout (in ms) per push operation in the SMT solver. (default: 0, i.e. no timeout). "
+             + s"Ignored when using the ${Cvc5ProverStdIO.name} prover."),
+    default = Some(0),
     noshort = true
   )
 

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -109,7 +109,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       val layeredStack = other.asInstanceOf[LayeredPathConditionStack]
       layeredStack.layers.reverse.foreach(l => {
         l.assumptions foreach prover.assume
-        prover.push()
+        prover.push(timeout = Verifier.config.pushTimeout.toOption)
       })
     }
 
@@ -180,7 +180,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       //val commentRecord = new CommentRecord("push", null, null)
       //val sepIdentifier = SymbExLogger.currentLog().openScope(commentRecord)
       pathConditions.pushScope()
-      _prover.push()
+      _prover.push(timeout = Verifier.config.pushTimeout.toOption)
       //SymbExLogger.currentLog().closeScope(sepIdentifier)
     }
 

--- a/src/main/scala/decider/ProverStdIO.scala
+++ b/src/main/scala/decider/ProverStdIO.scala
@@ -240,11 +240,10 @@ abstract class ProverStdIO(uniqueId: String,
 
   protected def assertUsingPushPop(goal: String, timeout: Option[Int]): (Boolean, Long) = {
     push()
+    setTimeout(timeout)
 
     writeLine("(assert (not " + goal + "))")
     readSuccess()
-
-    setTimeout(timeout)
 
     val startTime = System.currentTimeMillis()
     writeLine("(check-sat)")
@@ -295,12 +294,12 @@ abstract class ProverStdIO(uniqueId: String,
   }
 
   protected def assertUsingSoftConstraints(goal: String, timeout: Option[Int]): (Boolean, Long) = {
+    setTimeout(timeout)
+
     val guard = fresh("grd", Nil, sorts.Bool)
 
     writeLine(s"(assert (=> $guard (not $goal)))")
     readSuccess()
-
-    setTimeout(timeout)
 
     val startTime = System.currentTimeMillis()
     writeLine(s"(check-sat $guard)")

--- a/src/main/scala/decider/ProverStdIO.scala
+++ b/src/main/scala/decider/ProverStdIO.scala
@@ -174,7 +174,8 @@ abstract class ProverStdIO(uniqueId: String,
     }
   }
 
-  def push(n: Int = 1): Unit = {
+  def push(n: Int = 1, timeout: Option[Int] = None): Unit = {
+    setTimeout(timeout)
     pushPopScopeDepth += n
     val cmd = (if (n == 1) "(push)" else "(push " + n + ")") + " ; " + pushPopScopeDepth
     writeLine(cmd)
@@ -226,11 +227,9 @@ abstract class ProverStdIO(uniqueId: String,
   def assert(goal: String, timeout: Option[Int]): Boolean = {
 //    bookkeeper.assertionCounter += 1
 
-    setTimeout(timeout)
-
     val (result, duration) = Verifier.config.assertionMode() match {
-      case Config.AssertionMode.SoftConstraints => assertUsingSoftConstraints(goal)
-      case Config.AssertionMode.PushPop => assertUsingPushPop(goal)
+      case Config.AssertionMode.SoftConstraints => assertUsingSoftConstraints(goal, timeout)
+      case Config.AssertionMode.PushPop => assertUsingPushPop(goal, timeout)
     }
 
     comment(s"${viper.silver.reporter.format.formatMillisReadably(duration)}")
@@ -239,11 +238,13 @@ abstract class ProverStdIO(uniqueId: String,
     result
   }
 
-  protected def assertUsingPushPop(goal: String): (Boolean, Long) = {
+  protected def assertUsingPushPop(goal: String, timeout: Option[Int]): (Boolean, Long) = {
     push()
 
     writeLine("(assert (not " + goal + "))")
     readSuccess()
+
+    setTimeout(timeout)
 
     val startTime = System.currentTimeMillis()
     writeLine("(check-sat)")
@@ -293,11 +294,13 @@ abstract class ProverStdIO(uniqueId: String,
     lastModel != null && !lastModel.contains("model is not available")
   }
 
-  protected def assertUsingSoftConstraints(goal: String): (Boolean, Long) = {
+  protected def assertUsingSoftConstraints(goal: String, timeout: Option[Int]): (Boolean, Long) = {
     val guard = fresh("grd", Nil, sorts.Bool)
 
     writeLine(s"(assert (=> $guard (not $goal)))")
     readSuccess()
+
+    setTimeout(timeout)
 
     val startTime = System.currentTimeMillis()
     writeLine(s"(check-sat $guard)")

--- a/src/main/scala/decider/Z3ProverAPI.scala
+++ b/src/main/scala/decider/Z3ProverAPI.scala
@@ -249,10 +249,10 @@ class Z3ProverAPI(uniqueId: String,
   protected def assertUsingPushPop(goal: Term, timeout: Option[Int]): (Boolean, Long) = {
     endPreamblePhase()
     push()
+    setTimeout(timeout)
 
     val negatedGoal = ctx.mkNot(termConverter.convert(goal).asInstanceOf[BoolExpr])
     prover.add(negatedGoal)
-    setTimeout(timeout)
     val startTime = System.currentTimeMillis()
     val res = prover.check()
     val endTime = System.currentTimeMillis()

--- a/src/main/scala/decider/Z3ProverAPI.scala
+++ b/src/main/scala/decider/Z3ProverAPI.scala
@@ -175,8 +175,9 @@ class Z3ProverAPI(uniqueId: String,
     }
   }
 
-  def push(n: Int = 1): Unit = {
+  def push(n: Int = 1, timeout: Option[Int] = None): Unit = {
     endPreamblePhase()
+    setTimeout(timeout)
     pushPopScopeDepth += n
     if (n == 1) {
       // the normal case; we handle this without invoking a bunch of higher order functions
@@ -233,12 +234,11 @@ class Z3ProverAPI(uniqueId: String,
 
   def assert(goal: Term, timeout: Option[Int]): Boolean = {
     endPreamblePhase()
-    setTimeout(timeout)
 
     try {
       val (result, _) = Verifier.config.assertionMode() match {
-        case Config.AssertionMode.SoftConstraints => assertUsingSoftConstraints(goal)
-        case Config.AssertionMode.PushPop => assertUsingPushPop(goal)
+        case Config.AssertionMode.SoftConstraints => assertUsingSoftConstraints(goal, timeout)
+        case Config.AssertionMode.PushPop => assertUsingPushPop(goal, timeout)
       }
       result
     } catch {
@@ -246,12 +246,13 @@ class Z3ProverAPI(uniqueId: String,
     }
   }
 
-  protected def assertUsingPushPop(goal: Term): (Boolean, Long) = {
+  protected def assertUsingPushPop(goal: Term, timeout: Option[Int]): (Boolean, Long) = {
     endPreamblePhase()
     push()
 
     val negatedGoal = ctx.mkNot(termConverter.convert(goal).asInstanceOf[BoolExpr])
     prover.add(negatedGoal)
+    setTimeout(timeout)
     val startTime = System.currentTimeMillis()
     val res = prover.check()
     val endTime = System.currentTimeMillis()
@@ -286,8 +287,10 @@ class Z3ProverAPI(uniqueId: String,
     }
   }
 
-  protected def assertUsingSoftConstraints(goal: Term): (Boolean, Long) = {
+  protected def assertUsingSoftConstraints(goal: Term, timeout: Option[Int]): (Boolean, Long) = {
     endPreamblePhase()
+    setTimeout(timeout)
+
     val guard = fresh("grd", Nil, sorts.Bool)
     val guardApp = App(guard, Nil)
     val goalImplication = Implies(guardApp, goal)

--- a/src/main/scala/interfaces/decider/Prover.scala
+++ b/src/main/scala/interfaces/decider/Prover.scala
@@ -48,7 +48,7 @@ trait Prover extends ProverLike with StatefulComponent {
 
   def pushPopScopeDepth: Int
 
-  def push(n: Int = 1): Unit
+  def push(n: Int = 1, timeout: Option[Int] = None): Unit
 
   def pop(n: Int = 1): Unit
 }


### PR DESCRIPTION
Workaround for #535.

I went with `default = Some(0)` over `None`, meaning `(push)` has no timeout even when the option is not specified, and a finite value is set via `Config.proverTimeout`. (I don't have a strong argument whether it should inherit that value)