### PR TITLE
Add a flag to disable code emitting heap-dependent trigger expressions

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -606,6 +606,13 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
+  val disableHeapDependentTriggers: ScallopOption[Boolean] = opt[Boolean]("disableHeapDependentTriggers",
+    descr = ("Disable emitting heap-dependent triggers (and the snapshot maps required for them. " +
+      "Typically improves performance at the cost of expressiveness for triggers."),
+    default = Some(false),
+    noshort = true
+  )
+
   val disableCaches: ScallopOption[Boolean] = opt[Boolean]("disableCaches",
     descr = "Disables various caches in Silicon's state.",
     default = Some(false),

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -325,7 +325,7 @@ object consumer extends ConsumptionRules {
             val (smDef1, smCache1) =
               quantifiedChunkSupporter.summarisingSnapshotMap(
                 s2, field, Seq(`?r`), relevantChunks, v2)
-            v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
+            //v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
 //            v2.decider.assume(PermAtMost(tPerm, FullPerm()))
             val loss = PermTimes(tPerm, s2.permissionScalingFactor)
             quantifiedChunkSupporter.consumeSingleLocation(
@@ -356,7 +356,7 @@ object consumer extends ConsumptionRules {
             val (smDef1, smCache1) =
               quantifiedChunkSupporter.summarisingSnapshotMap(
                 s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
-            v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
+            //v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
 
             val loss = PermTimes(tPerm, s2.permissionScalingFactor)
             quantifiedChunkSupporter.consumeSingleLocation(
@@ -406,7 +406,7 @@ object consumer extends ConsumptionRules {
           val (smDef1, smCache1) =
             quantifiedChunkSupporter.summarisingSnapshotMap(
               s1, wand, formalVars, relevantChunks, v1)
-          v1.decider.assume(PredicateTrigger(MagicWandIdentifier(wand, s.program).toString, smDef1.sm, tArgs))
+          //v1.decider.assume(PredicateTrigger(MagicWandIdentifier(wand, s.program).toString, smDef1.sm, tArgs))
 
           val loss = PermTimes(FullPerm(), s1.permissionScalingFactor)
           quantifiedChunkSupporter.consumeSingleLocation(

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -320,16 +320,16 @@ object consumer extends ConsumptionRules {
 
         eval(s, eRcvr, pve, v)((s1, tRcvr, v1) =>
           eval(s1, ePerm, pve, v1)((s2, tPerm, v2) => {
-            val (relevantChunks, _) =
-              quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s2.h, BasicChunkIdentifier(field.name))
-            val (smDef1, smCache1) =
-              quantifiedChunkSupporter.summarisingSnapshotMap(
-                s2, field, Seq(`?r`), relevantChunks, v2)
+            //val (relevantChunks, _) =
+            //  quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s2.h, BasicChunkIdentifier(field.name))
+            //val (smDef1, smCache1) =
+            //  quantifiedChunkSupporter.summarisingSnapshotMap(
+            //    s2, field, Seq(`?r`), relevantChunks, v2)
             //v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
 //            v2.decider.assume(PermAtMost(tPerm, FullPerm()))
             val loss = PermTimes(tPerm, s2.permissionScalingFactor)
             quantifiedChunkSupporter.consumeSingleLocation(
-              s2.copy(smCache = smCache1),
+              s2, //.copy(smCache = smCache1),
               h,
               Seq(`?r`),
               Seq(tRcvr),
@@ -351,16 +351,16 @@ object consumer extends ConsumptionRules {
 
         evals(s, eArgs, _ => pve, v)((s1, tArgs, v1) =>
           eval(s1, ePerm, pve, v1)((s2, tPerm, v2) => {
-            val (relevantChunks, _) =
-              quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s.h, BasicChunkIdentifier(predname))
-            val (smDef1, smCache1) =
-              quantifiedChunkSupporter.summarisingSnapshotMap(
-                s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
+            //val (relevantChunks, _) =
+            //  quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s.h, BasicChunkIdentifier(predname))
+            //val (smDef1, smCache1) =
+            //  quantifiedChunkSupporter.summarisingSnapshotMap(
+            //    s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
             //v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
 
             val loss = PermTimes(tPerm, s2.permissionScalingFactor)
             quantifiedChunkSupporter.consumeSingleLocation(
-              s2.copy(smCache = smCache1),
+              s2, //.copy(smCache = smCache1),
               h,
               formalVars,
               tArgs,
@@ -401,16 +401,16 @@ object consumer extends ConsumptionRules {
         val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v.symbolConverter.toSort(bodyVars(i).typ)))
 
         evals(s, bodyVars, _ => pve, v)((s1, tArgs, v1) => {
-          val (relevantChunks, _) =
-            quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s1.h, MagicWandIdentifier(wand, s.program))
-          val (smDef1, smCache1) =
-            quantifiedChunkSupporter.summarisingSnapshotMap(
-              s1, wand, formalVars, relevantChunks, v1)
+          //val (relevantChunks, _) =
+          //  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s1.h, MagicWandIdentifier(wand, s.program))
+          //val (smDef1, smCache1) =
+          //  quantifiedChunkSupporter.summarisingSnapshotMap(
+          //    s1, wand, formalVars, relevantChunks, v1)
           //v1.decider.assume(PredicateTrigger(MagicWandIdentifier(wand, s.program).toString, smDef1.sm, tArgs))
 
           val loss = PermTimes(FullPerm(), s1.permissionScalingFactor)
           quantifiedChunkSupporter.consumeSingleLocation(
-            s1.copy(smCache = smCache1),
+            s1, //.copy(smCache = smCache1),
             h,
             formalVars,
             tArgs,

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -320,16 +320,21 @@ object consumer extends ConsumptionRules {
 
         eval(s, eRcvr, pve, v)((s1, tRcvr, v1) =>
           eval(s1, ePerm, pve, v1)((s2, tPerm, v2) => {
-            //val (relevantChunks, _) =
-            //  quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s2.h, BasicChunkIdentifier(field.name))
-            //val (smDef1, smCache1) =
-            //  quantifiedChunkSupporter.summarisingSnapshotMap(
-            //    s2, field, Seq(`?r`), relevantChunks, v2)
-            //v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
-//            v2.decider.assume(PermAtMost(tPerm, FullPerm()))
+            val s2p = if (!Verifier.config.disableHeapDependentTriggers()){
+              val (relevantChunks, _) =
+                quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s2.h, BasicChunkIdentifier(field.name))
+              val (smDef1, smCache1) =
+                quantifiedChunkSupporter.summarisingSnapshotMap(
+                  s2, field, Seq(`?r`), relevantChunks, v2)
+              v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
+              //            v2.decider.assume(PermAtMost(tPerm, FullPerm()))
+              s2.copy(smCache = smCache1)
+            } else {
+              s2
+            }
             val loss = PermTimes(tPerm, s2.permissionScalingFactor)
             quantifiedChunkSupporter.consumeSingleLocation(
-              s2, //.copy(smCache = smCache1),
+              s2p,
               h,
               Seq(`?r`),
               Seq(tRcvr),
@@ -351,16 +356,21 @@ object consumer extends ConsumptionRules {
 
         evals(s, eArgs, _ => pve, v)((s1, tArgs, v1) =>
           eval(s1, ePerm, pve, v1)((s2, tPerm, v2) => {
-            //val (relevantChunks, _) =
-            //  quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s.h, BasicChunkIdentifier(predname))
-            //val (smDef1, smCache1) =
-            //  quantifiedChunkSupporter.summarisingSnapshotMap(
-            //    s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
-            //v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
+            val s2p = if (!Verifier.config.disableHeapDependentTriggers()){
+              val (relevantChunks, _) =
+                quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s.h, BasicChunkIdentifier(predname))
+              val (smDef1, smCache1) =
+                quantifiedChunkSupporter.summarisingSnapshotMap(
+                  s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
+              v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
+              s2.copy(smCache = smCache1)
+            } else {
+              s2
+            }
 
             val loss = PermTimes(tPerm, s2.permissionScalingFactor)
             quantifiedChunkSupporter.consumeSingleLocation(
-              s2, //.copy(smCache = smCache1),
+              s2p,
               h,
               formalVars,
               tArgs,
@@ -401,16 +411,20 @@ object consumer extends ConsumptionRules {
         val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v.symbolConverter.toSort(bodyVars(i).typ)))
 
         evals(s, bodyVars, _ => pve, v)((s1, tArgs, v1) => {
-          //val (relevantChunks, _) =
-          //  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s1.h, MagicWandIdentifier(wand, s.program))
-          //val (smDef1, smCache1) =
-          //  quantifiedChunkSupporter.summarisingSnapshotMap(
-          //    s1, wand, formalVars, relevantChunks, v1)
-          //v1.decider.assume(PredicateTrigger(MagicWandIdentifier(wand, s.program).toString, smDef1.sm, tArgs))
-
+          val s1p = if (!Verifier.config.disableHeapDependentTriggers()){
+            val (relevantChunks, _) =
+              quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s1.h, MagicWandIdentifier(wand, s.program))
+            val (smDef1, smCache1) =
+              quantifiedChunkSupporter.summarisingSnapshotMap(
+                s1, wand, formalVars, relevantChunks, v1)
+            v1.decider.assume(PredicateTrigger(MagicWandIdentifier(wand, s.program).toString, smDef1.sm, tArgs))
+            s1.copy(smCache = smCache1)
+          } else {
+            s1
+          }
           val loss = PermTimes(FullPerm(), s1.permissionScalingFactor)
           quantifiedChunkSupporter.consumeSingleLocation(
-            s1, //.copy(smCache = smCache1),
+            s1p,
             h,
             formalVars,
             tArgs,

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -203,7 +203,7 @@ object evaluator extends EvaluationRules {
                */
               v1.decider.assume(fvfDef.valueDefinitions)
               val trigger = FieldTrigger(fa.field.name, fvfDef.sm, tRcvr)
-              v1.decider.assume(trigger)
+              //v1.decider.assume(trigger)
               if (s1.triggerExp) {
                 val fvfLookup = Lookup(fa.field.name, fvfDef.sm, tRcvr)
                 val fr1 = s1.functionRecorder.recordSnapshot(fa, v1.decider.pcs.branchConditions, fvfLookup)
@@ -230,7 +230,7 @@ object evaluator extends EvaluationRules {
                   optQVarsInstantiations = None,
                   v = v1)
               val trigger = FieldTrigger(fa.field.name, smDef1.sm, tRcvr)
-              v1.decider.assume(trigger)
+              //v1.decider.assume(trigger)
               val permCheck =
                 if (s1.triggerExp) {
                   True()
@@ -445,7 +445,7 @@ object evaluator extends EvaluationRules {
                   val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v1.symbolConverter.toSort(bodyVars(i).typ)))
                   val (s2, smDef, pmDef) =
                     quantifiedChunkSupporter.heapSummarisingMaps(s1, wand, formalVars, relevantChunks, v1)
-                  v1.decider.assume(PredicateTrigger(identifier.toString, smDef.sm, args))
+                  //v1.decider.assume(PredicateTrigger(identifier.toString, smDef.sm, args))
                   (s2, PredicatePermLookup(identifier.toString, pmDef.pm, args))
 
                 case field: ast.Field =>
@@ -453,7 +453,7 @@ object evaluator extends EvaluationRules {
                     quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](h, identifier)
                   val (s2, smDef, pmDef) =
                     quantifiedChunkSupporter.heapSummarisingMaps(s1, field, Seq(`?r`), relevantChunks, v1)
-                  v1.decider.assume(FieldTrigger(field.name, smDef.sm, args.head))
+                  //v1.decider.assume(FieldTrigger(field.name, smDef.sm, args.head))
                   val currentPermAmount = PermLookup(field.name, pmDef.pm, args.head)
                   v1.decider.prover.comment(s"perm($resacc)  ~~>  assume upper permission bound")
                   v1.decider.assume(PermAtMost(currentPermAmount, FullPerm()))
@@ -466,7 +466,7 @@ object evaluator extends EvaluationRules {
                     quantifiedChunkSupporter.heapSummarisingMaps(
                       s1, predicate, s1.predicateFormalVarMap(predicate), relevantChunks, v1)
                   val trigger = PredicateTrigger(predicate.name, smDef.sm, args)
-                  v1.decider.assume(trigger)
+                  //v1.decider.assume(trigger)
                   (s2, PredicatePermLookup(identifier.toString, pmDef.pm, args))
               }
             } else {
@@ -767,7 +767,7 @@ object evaluator extends EvaluationRules {
                          * to the function arguments and the predicate snapshot
                          * (see 'predicateTriggers' in FunctionData.scala).
                          */
-                      v4.decider.assume(App(s.predicateData(predicate).triggerFunction, snap.convert(terms.sorts.Snap) +: tArgs))
+                      //v4.decider.assume(App(s.predicateData(predicate).triggerFunction, snap.convert(terms.sorts.Snap) +: tArgs))
                       val body = predicate.body.get /* Only non-abstract predicates can be unfolded */
                       val s7 = s6.scalePermissionFactor(tPerm)
                       val insg = s7.g + Store(predicate.formalArgs map (_.localVar) zip tArgs)
@@ -1342,7 +1342,7 @@ object evaluator extends EvaluationRules {
         Success()
       })
     }
-    v.decider.assume(triggerAxioms)
+    //v.decider.assume(triggerAxioms)
     Q(s, triggers, v)
   }
 

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -202,7 +202,7 @@ object evaluator extends EvaluationRules {
                * which is protected by a trigger term that we currently don't have.
                */
               v1.decider.assume(fvfDef.valueDefinitions)
-              val trigger = FieldTrigger(fa.field.name, fvfDef.sm, tRcvr)
+              //val trigger = FieldTrigger(fa.field.name, fvfDef.sm, tRcvr)
               //v1.decider.assume(trigger)
               if (s1.triggerExp) {
                 val fvfLookup = Lookup(fa.field.name, fvfDef.sm, tRcvr)
@@ -216,7 +216,7 @@ object evaluator extends EvaluationRules {
                   case true =>
                     val fvfLookup = Lookup(fa.field.name, fvfDef.sm, tRcvr)
                     val fr1 = s1.functionRecorder.recordSnapshot(fa, v1.decider.pcs.branchConditions, fvfLookup).recordFvfAndDomain(fvfDef)
-                    val s2 = s1.copy(functionRecorder = fr1, possibleTriggers = if (s1.recordPossibleTriggers) s1.possibleTriggers + (fa -> trigger) else s1.possibleTriggers)
+                    val s2 = s1.copy(functionRecorder = fr1) //, possibleTriggers = if (s1.recordPossibleTriggers) s1.possibleTriggers + (fa -> trigger) else s1.possibleTriggers)
                     Q(s2, fvfLookup, v1)}
               }
             case _ =>
@@ -229,7 +229,7 @@ object evaluator extends EvaluationRules {
                   optSmDomainDefinitionCondition =  None,
                   optQVarsInstantiations = None,
                   v = v1)
-              val trigger = FieldTrigger(fa.field.name, smDef1.sm, tRcvr)
+              //val trigger = FieldTrigger(fa.field.name, smDef1.sm, tRcvr)
               //v1.decider.assume(trigger)
               val permCheck =
                 if (s1.triggerExp) {
@@ -443,16 +443,16 @@ object evaluator extends EvaluationRules {
                     quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](h, identifier)
                   val bodyVars = wand.subexpressionsToEvaluate(s.program)
                   val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v1.symbolConverter.toSort(bodyVars(i).typ)))
-                  val (s2, smDef, pmDef) =
-                    quantifiedChunkSupporter.heapSummarisingMaps(s1, wand, formalVars, relevantChunks, v1)
+                  val (s2, pmDef) =
+                    quantifiedChunkSupporter.permSummarisingMaps(s1, wand, formalVars, relevantChunks, v1)
                   //v1.decider.assume(PredicateTrigger(identifier.toString, smDef.sm, args))
                   (s2, PredicatePermLookup(identifier.toString, pmDef.pm, args))
 
                 case field: ast.Field =>
                   val (relevantChunks, _) =
                     quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](h, identifier)
-                  val (s2, smDef, pmDef) =
-                    quantifiedChunkSupporter.heapSummarisingMaps(s1, field, Seq(`?r`), relevantChunks, v1)
+                  val (s2, pmDef) =
+                    quantifiedChunkSupporter.permSummarisingMaps(s1, field, Seq(`?r`), relevantChunks, v1)
                   //v1.decider.assume(FieldTrigger(field.name, smDef.sm, args.head))
                   val currentPermAmount = PermLookup(field.name, pmDef.pm, args.head)
                   v1.decider.prover.comment(s"perm($resacc)  ~~>  assume upper permission bound")
@@ -1326,17 +1326,23 @@ object evaluator extends EvaluationRules {
 
     exps foreach {
       case fa: ast.FieldAccess =>
+        /*
         val (axioms, trigs, _) = generateFieldTrigger(fa, s, pve, v)
         triggers = triggers ++ trigs
         triggerAxioms = triggerAxioms ++ axioms
+         */
       case pa: ast.PredicateAccess =>
+        /*
         val (axioms, trigs, _) = generatePredicateTrigger(pa, s, pve, v)
         triggers = triggers ++ trigs
         triggerAxioms = triggerAxioms ++ axioms
+         */
       case wand: ast.MagicWand =>
+        /*
         val (axioms, trigs, _) = generateWandTrigger(wand, s, pve, v)
         triggers = triggers ++ trigs
         triggerAxioms = triggerAxioms ++ axioms
+         */
       case e => evalTrigger(s, Seq(e), pve, v)((_, t, _) => {
         triggers = triggers ++ t
         Success()

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -202,8 +202,10 @@ object evaluator extends EvaluationRules {
                * which is protected by a trigger term that we currently don't have.
                */
               v1.decider.assume(fvfDef.valueDefinitions)
-              //val trigger = FieldTrigger(fa.field.name, fvfDef.sm, tRcvr)
-              //v1.decider.assume(trigger)
+              if (!Verifier.config.disableHeapDependentTriggers()){
+                val trigger = FieldTrigger(fa.field.name, fvfDef.sm, tRcvr)
+                v1.decider.assume(trigger)
+              }
               if (s1.triggerExp) {
                 val fvfLookup = Lookup(fa.field.name, fvfDef.sm, tRcvr)
                 val fr1 = s1.functionRecorder.recordSnapshot(fa, v1.decider.pcs.branchConditions, fvfLookup)
@@ -216,7 +218,11 @@ object evaluator extends EvaluationRules {
                   case true =>
                     val fvfLookup = Lookup(fa.field.name, fvfDef.sm, tRcvr)
                     val fr1 = s1.functionRecorder.recordSnapshot(fa, v1.decider.pcs.branchConditions, fvfLookup).recordFvfAndDomain(fvfDef)
-                    val s2 = s1.copy(functionRecorder = fr1) //, possibleTriggers = if (s1.recordPossibleTriggers) s1.possibleTriggers + (fa -> trigger) else s1.possibleTriggers)
+                    val possTriggers = if (!Verifier.config.disableHeapDependentTriggers() && s1.recordPossibleTriggers)
+                      s1.possibleTriggers + (fa -> FieldTrigger(fa.field.name, fvfDef.sm, tRcvr))
+                    else
+                      s1.possibleTriggers
+                    val s2 = s1.copy(functionRecorder = fr1, possibleTriggers = possTriggers)
                     Q(s2, fvfLookup, v1)}
               }
             case _ =>
@@ -229,8 +235,10 @@ object evaluator extends EvaluationRules {
                   optSmDomainDefinitionCondition =  None,
                   optQVarsInstantiations = None,
                   v = v1)
-              //val trigger = FieldTrigger(fa.field.name, smDef1.sm, tRcvr)
-              //v1.decider.assume(trigger)
+              if (!Verifier.config.disableHeapDependentTriggers()){
+                val trigger = FieldTrigger(fa.field.name, smDef1.sm, tRcvr)
+                v1.decider.assume(trigger)
+              }
               val permCheck =
                 if (s1.triggerExp) {
                   True()
@@ -443,17 +451,33 @@ object evaluator extends EvaluationRules {
                     quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](h, identifier)
                   val bodyVars = wand.subexpressionsToEvaluate(s.program)
                   val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v1.symbolConverter.toSort(bodyVars(i).typ)))
-                  val (s2, pmDef) =
-                    quantifiedChunkSupporter.permSummarisingMaps(s1, wand, formalVars, relevantChunks, v1)
-                  //v1.decider.assume(PredicateTrigger(identifier.toString, smDef.sm, args))
+                  val (s2, pmDef) = if (!Verifier.config.disableHeapDependentTriggers()) {
+                    val (s2, smDef, pmDef) = quantifiedChunkSupporter.heapSummarisingMaps(s1, wand, formalVars, relevantChunks, v1)
+                    v1.decider.assume(PredicateTrigger(identifier.toString, smDef.sm, args))
+                    (s2, pmDef)
+                  } else {
+                    val (pmDef, pmCache) =
+                      quantifiedChunkSupporter.summarisingPermissionMap(
+                        s1, wand, formalVars, relevantChunks, null, v1)
+
+                    (s1.copy(pmCache = pmCache), pmDef)
+                  }
                   (s2, PredicatePermLookup(identifier.toString, pmDef.pm, args))
 
                 case field: ast.Field =>
                   val (relevantChunks, _) =
                     quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](h, identifier)
-                  val (s2, pmDef) =
-                    quantifiedChunkSupporter.permSummarisingMaps(s1, field, Seq(`?r`), relevantChunks, v1)
-                  //v1.decider.assume(FieldTrigger(field.name, smDef.sm, args.head))
+                  val (s2, pmDef) = if (!Verifier.config.disableHeapDependentTriggers()) {
+                    val (s2, smDef, pmDef) = quantifiedChunkSupporter.heapSummarisingMaps(s1, field, Seq(`?r`), relevantChunks, v1)
+                    v1.decider.assume(FieldTrigger(field.name, smDef.sm, args.head))
+                    (s2, pmDef)
+                  } else {
+                    val (pmDef, pmCache) =
+                      quantifiedChunkSupporter.summarisingPermissionMap(
+                        s1, field, Seq(`?r`), relevantChunks, null, v1)
+
+                    (s1.copy(pmCache = pmCache), pmDef)
+                  }
                   val currentPermAmount = PermLookup(field.name, pmDef.pm, args.head)
                   v1.decider.prover.comment(s"perm($resacc)  ~~>  assume upper permission bound")
                   v1.decider.assume(PermAtMost(currentPermAmount, FullPerm()))
@@ -465,8 +489,10 @@ object evaluator extends EvaluationRules {
                   val (s2, smDef, pmDef) =
                     quantifiedChunkSupporter.heapSummarisingMaps(
                       s1, predicate, s1.predicateFormalVarMap(predicate), relevantChunks, v1)
-                  val trigger = PredicateTrigger(predicate.name, smDef.sm, args)
-                  //v1.decider.assume(trigger)
+                  if (!Verifier.config.disableHeapDependentTriggers()){
+                    val trigger = PredicateTrigger(predicate.name, smDef.sm, args)
+                    v1.decider.assume(trigger)
+                  }
                   (s2, PredicatePermLookup(identifier.toString, pmDef.pm, args))
               }
             } else {
@@ -767,7 +793,9 @@ object evaluator extends EvaluationRules {
                          * to the function arguments and the predicate snapshot
                          * (see 'predicateTriggers' in FunctionData.scala).
                          */
-                      //v4.decider.assume(App(s.predicateData(predicate).triggerFunction, snap.convert(terms.sorts.Snap) +: tArgs))
+                      if (!Verifier.config.disableHeapDependentTriggers()){
+                        v4.decider.assume(App(s.predicateData(predicate).triggerFunction, snap.convert(terms.sorts.Snap) +: tArgs))
+                      }
                       val body = predicate.body.get /* Only non-abstract predicates can be unfolded */
                       val s7 = s6.scalePermissionFactor(tPerm)
                       val insg = s7.g + Store(predicate.formalArgs map (_.localVar) zip tArgs)
@@ -1325,30 +1353,25 @@ object evaluator extends EvaluationRules {
     var triggerAxioms: Seq[Term] = Seq()
 
     exps foreach {
-      case fa: ast.FieldAccess =>
-        /*
+      case fa: ast.FieldAccess if !Verifier.config.disableHeapDependentTriggers() =>
         val (axioms, trigs, _) = generateFieldTrigger(fa, s, pve, v)
         triggers = triggers ++ trigs
         triggerAxioms = triggerAxioms ++ axioms
-         */
-      case pa: ast.PredicateAccess =>
-        /*
+      case pa: ast.PredicateAccess if !Verifier.config.disableHeapDependentTriggers() =>
         val (axioms, trigs, _) = generatePredicateTrigger(pa, s, pve, v)
         triggers = triggers ++ trigs
         triggerAxioms = triggerAxioms ++ axioms
-         */
-      case wand: ast.MagicWand =>
-        /*
+      case wand: ast.MagicWand if !Verifier.config.disableHeapDependentTriggers() =>
         val (axioms, trigs, _) = generateWandTrigger(wand, s, pve, v)
         triggers = triggers ++ trigs
         triggerAxioms = triggerAxioms ++ axioms
-         */
       case e => evalTrigger(s, Seq(e), pve, v)((_, t, _) => {
         triggers = triggers ++ t
         Success()
       })
     }
-    //v.decider.assume(triggerAxioms)
+    if (!Verifier.config.disableHeapDependentTriggers())
+      v.decider.assume(triggerAxioms)
     Q(s, triggers, v)
   }
 

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -315,7 +315,7 @@ object executor extends ExecutionRules {
             val (smDef1, smCache1) =
               quantifiedChunkSupporter.summarisingSnapshotMap(
                 s2, field, Seq(`?r`), relevantChunks, v1)
-            v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
+            //v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
             v2.decider.clearModel()
             val result = quantifiedChunkSupporter.removePermissions(
               s2.copy(smCache = smCache1),
@@ -334,7 +334,7 @@ object executor extends ExecutionRules {
                 v1.decider.prover.comment("Definitional axioms for singleton-FVF's value")
                 v1.decider.assume(smValueDef)
                 val ch = quantifiedChunkSupporter.createSingletonQuantifiedChunk(Seq(`?r`), field, Seq(tRcvr), FullPerm(), sm, s.program)
-                v1.decider.assume(FieldTrigger(field.name, sm, tRcvr))
+                //v1.decider.assume(FieldTrigger(field.name, sm, tRcvr))
                 Q(s3.copy(h = h3 + ch), v2)
               case (Incomplete(_), s3, _) =>
                 createFailure(pve dueTo InsufficientPermission(fa), v2, s3)}}))
@@ -516,7 +516,7 @@ object executor extends ExecutionRules {
               val (smDef1, smCache1) =
                 quantifiedChunkSupporter.summarisingSnapshotMap(
                   s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
-              v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
+              //v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
               smCache1
             } else {
               s2.smCache
@@ -563,7 +563,7 @@ object executor extends ExecutionRules {
                 val (smDef, smCache) =
                   quantifiedChunkSupporter.summarisingSnapshotMap(
                     s2, wand, formalVars, relevantChunks, v1)
-                v1.decider.assume(PredicateTrigger(ch.id.toString, smDef.sm, ch.singletonArgs.get))
+                //v1.decider.assume(PredicateTrigger(ch.id.toString, smDef.sm, ch.singletonArgs.get))
                 smCache
               case _ => s2.smCache
             }

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -312,13 +312,18 @@ object executor extends ExecutionRules {
               quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s2.h, BasicChunkIdentifier(field.name))
             val hints = quantifiedChunkSupporter.extractHints(None, Seq(tRcvr))
             val chunkOrderHeuristics = quantifiedChunkSupporter.hintBasedChunkOrderHeuristic(hints)
-            //val (smDef1, smCache1) =
-            //  quantifiedChunkSupporter.summarisingSnapshotMap(
-            //    s2, field, Seq(`?r`), relevantChunks, v1)
-            //v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
+            val s2p = if (!Verifier.config.disableHeapDependentTriggers()){
+              val (smDef1, smCache1) =
+                quantifiedChunkSupporter.summarisingSnapshotMap(
+                  s2, field, Seq(`?r`), relevantChunks, v1)
+              v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
+              s2.copy(smCache = smCache1)
+            } else {
+              s2
+            }
             v2.decider.clearModel()
             val result = quantifiedChunkSupporter.removePermissions(
-              s2, //.copy(smCache = smCache1),
+              s2p,
               relevantChunks,
               Seq(`?r`),
               `?r` === tRcvr,
@@ -334,7 +339,8 @@ object executor extends ExecutionRules {
                 v1.decider.prover.comment("Definitional axioms for singleton-FVF's value")
                 v1.decider.assume(smValueDef)
                 val ch = quantifiedChunkSupporter.createSingletonQuantifiedChunk(Seq(`?r`), field, Seq(tRcvr), FullPerm(), sm, s.program)
-                //v1.decider.assume(FieldTrigger(field.name, sm, tRcvr))
+                if (!Verifier.config.disableHeapDependentTriggers())
+                  v1.decider.assume(FieldTrigger(field.name, sm, tRcvr))
                 Q(s3.copy(h = h3 + ch), v2)
               case (Incomplete(_), s3, _) =>
                 createFailure(pve dueTo InsufficientPermission(fa), v2, s3)}}))
@@ -510,14 +516,14 @@ object executor extends ExecutionRules {
         evals(s, eArgs, _ => pve, v)((s1, tArgs, v1) =>
           eval(s1, ePerm, pve, v1)((s2, tPerm, v2) => {
 
-            val smCache1 = if (s2.qpPredicates.contains(predicate)) {
-              //val (relevantChunks, _) =
-              //  quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s2.h, BasicChunkIdentifier(predicateName))
-              //val (smDef1, smCache1) =
-              //  quantifiedChunkSupporter.summarisingSnapshotMap(
-              //    s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
-              //v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
-              s2.smCache
+            val smCache1 = if (s2.qpPredicates.contains(predicate) && !Verifier.config.disableHeapDependentTriggers()) {
+              val (relevantChunks, _) =
+                quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s2.h, BasicChunkIdentifier(predicateName))
+              val (smDef1, smCache1) =
+                quantifiedChunkSupporter.summarisingSnapshotMap(
+                  s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
+              v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
+              smCache1
             } else {
               s2.smCache
             }
@@ -555,16 +561,16 @@ object executor extends ExecutionRules {
             assert(s2.reserveHeaps.length == s.reserveHeaps.length)
 
             val smCache3 = chWand match {
-              case ch: QuantifiedMagicWandChunk =>
-                //val (relevantChunks, _) =
-                //  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s2.h, ch.id)
-                //val bodyVars = wand.subexpressionsToEvaluate(s.program)
-                //val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v1.symbolConverter.toSort(bodyVars(i).typ)))
-                //val (smDef, smCache) =
-                //  quantifiedChunkSupporter.summarisingSnapshotMap(
-                //    s2, wand, formalVars, relevantChunks, v1)
-                //v1.decider.assume(PredicateTrigger(ch.id.toString, smDef.sm, ch.singletonArgs.get))
-                s2.smCache
+              case ch: QuantifiedMagicWandChunk if !Verifier.config.disableHeapDependentTriggers() =>
+                val (relevantChunks, _) =
+                  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s2.h, ch.id)
+                val bodyVars = wand.subexpressionsToEvaluate(s.program)
+                val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v1.symbolConverter.toSort(bodyVars(i).typ)))
+                val (smDef, smCache) =
+                  quantifiedChunkSupporter.summarisingSnapshotMap(
+                    s2, wand, formalVars, relevantChunks, v1)
+                v1.decider.assume(PredicateTrigger(ch.id.toString, smDef.sm, ch.singletonArgs.get))
+                smCache
               case _ => s2.smCache
             }
 

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -312,13 +312,13 @@ object executor extends ExecutionRules {
               quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s2.h, BasicChunkIdentifier(field.name))
             val hints = quantifiedChunkSupporter.extractHints(None, Seq(tRcvr))
             val chunkOrderHeuristics = quantifiedChunkSupporter.hintBasedChunkOrderHeuristic(hints)
-            val (smDef1, smCache1) =
-              quantifiedChunkSupporter.summarisingSnapshotMap(
-                s2, field, Seq(`?r`), relevantChunks, v1)
+            //val (smDef1, smCache1) =
+            //  quantifiedChunkSupporter.summarisingSnapshotMap(
+            //    s2, field, Seq(`?r`), relevantChunks, v1)
             //v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr))
             v2.decider.clearModel()
             val result = quantifiedChunkSupporter.removePermissions(
-              s2.copy(smCache = smCache1),
+              s2, //.copy(smCache = smCache1),
               relevantChunks,
               Seq(`?r`),
               `?r` === tRcvr,
@@ -511,13 +511,13 @@ object executor extends ExecutionRules {
           eval(s1, ePerm, pve, v1)((s2, tPerm, v2) => {
 
             val smCache1 = if (s2.qpPredicates.contains(predicate)) {
-              val (relevantChunks, _) =
-                quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s2.h, BasicChunkIdentifier(predicateName))
-              val (smDef1, smCache1) =
-                quantifiedChunkSupporter.summarisingSnapshotMap(
-                  s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
+              //val (relevantChunks, _) =
+              //  quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](s2.h, BasicChunkIdentifier(predicateName))
+              //val (smDef1, smCache1) =
+              //  quantifiedChunkSupporter.summarisingSnapshotMap(
+              //    s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
               //v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
-              smCache1
+              s2.smCache
             } else {
               s2.smCache
             }
@@ -556,15 +556,15 @@ object executor extends ExecutionRules {
 
             val smCache3 = chWand match {
               case ch: QuantifiedMagicWandChunk =>
-                val (relevantChunks, _) =
-                  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s2.h, ch.id)
-                val bodyVars = wand.subexpressionsToEvaluate(s.program)
-                val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v1.symbolConverter.toSort(bodyVars(i).typ)))
-                val (smDef, smCache) =
-                  quantifiedChunkSupporter.summarisingSnapshotMap(
-                    s2, wand, formalVars, relevantChunks, v1)
+                //val (relevantChunks, _) =
+                //  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](s2.h, ch.id)
+                //val bodyVars = wand.subexpressionsToEvaluate(s.program)
+                //val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v1.symbolConverter.toSort(bodyVars(i).typ)))
+                //val (smDef, smCache) =
+                //  quantifiedChunkSupporter.summarisingSnapshotMap(
+                //    s2, wand, formalVars, relevantChunks, v1)
                 //v1.decider.assume(PredicateTrigger(ch.id.toString, smDef.sm, ch.singletonArgs.get))
-                smCache
+                s2.smCache
               case _ => s2.smCache
             }
 

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -60,8 +60,8 @@ object predicateSupporter extends PredicateSupportRules {
                     smDomainNeeded = true)
               .scalePermissionFactor(tPerm)
     consume(s1, body, pve, v)((s1a, snap, v1) => {
-      val predTrigger = App(s1a.predicateData(predicate).triggerFunction,
-                            snap.convert(terms.sorts.Snap) +: tArgs)
+      //val predTrigger = App(s1a.predicateData(predicate).triggerFunction,
+      //                      snap.convert(terms.sorts.Snap) +: tArgs)
       //v1.decider.assume(predTrigger)
       val s2 = s1a.setConstrainable(constrainableWildcards, false)
       if (s2.qpPredicates.contains(predicate)) {
@@ -77,14 +77,14 @@ object predicateSupporter extends PredicateSupportRules {
         val h3 = s2.h + ch
         val smDef = SnapshotMapDefinition(predicate, sm, Seq(smValueDef), Seq())
         val smCache = {
-          val (relevantChunks, _) =
-            quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](h3, BasicChunkIdentifier(predicate.name))
-          val (smDef1, smCache1) =
-            quantifiedChunkSupporter.summarisingSnapshotMap(
-              s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v1)
+          //val (relevantChunks, _) =
+          //  quantifiedChunkSupporter.splitHeap[QuantifiedPredicateChunk](h3, BasicChunkIdentifier(predicate.name))
+          //val (smDef1, smCache1) =
+          //  quantifiedChunkSupporter.summarisingSnapshotMap(
+          //    s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v1)
           //v1.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
 
-          smCache1
+          s2.smCache
         }
 
         val s3 = s2.copy(g = s.g,
@@ -134,9 +134,9 @@ object predicateSupporter extends PredicateSupportRules {
                    .setConstrainable(constrainableWildcards, false)
         produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
-          val predicateTrigger =
-            App(s4.predicateData(predicate).triggerFunction,
-                snap.convert(terms.sorts.Snap) +: tArgs)
+          //val predicateTrigger =
+          //  App(s4.predicateData(predicate).triggerFunction,
+          //      snap.convert(terms.sorts.Snap) +: tArgs)
           //v2.decider.assume(predicateTrigger)
           Q(s4.copy(g = s.g,
                     permissionScalingFactor = s.permissionScalingFactor),
@@ -150,8 +150,8 @@ object predicateSupporter extends PredicateSupportRules {
                    .setConstrainable(constrainableWildcards, false)
         produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
-          val predicateTrigger =
-            App(s4.predicateData(predicate).triggerFunction, snap +: tArgs)
+          //val predicateTrigger =
+          //  App(s4.predicateData(predicate).triggerFunction, snap +: tArgs)
           //v2.decider.assume(predicateTrigger)
           val s5 = s4.copy(g = s.g,
                            permissionScalingFactor = s.permissionScalingFactor)

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -62,7 +62,7 @@ object predicateSupporter extends PredicateSupportRules {
     consume(s1, body, pve, v)((s1a, snap, v1) => {
       val predTrigger = App(s1a.predicateData(predicate).triggerFunction,
                             snap.convert(terms.sorts.Snap) +: tArgs)
-      v1.decider.assume(predTrigger)
+      //v1.decider.assume(predTrigger)
       val s2 = s1a.setConstrainable(constrainableWildcards, false)
       if (s2.qpPredicates.contains(predicate)) {
         val predSnap = snap.convert(s2.predicateSnapMap(predicate))
@@ -82,7 +82,7 @@ object predicateSupporter extends PredicateSupportRules {
           val (smDef1, smCache1) =
             quantifiedChunkSupporter.summarisingSnapshotMap(
               s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v1)
-          v1.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
+          //v1.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs))
 
           smCache1
         }
@@ -137,7 +137,7 @@ object predicateSupporter extends PredicateSupportRules {
           val predicateTrigger =
             App(s4.predicateData(predicate).triggerFunction,
                 snap.convert(terms.sorts.Snap) +: tArgs)
-          v2.decider.assume(predicateTrigger)
+          //v2.decider.assume(predicateTrigger)
           Q(s4.copy(g = s.g,
                     permissionScalingFactor = s.permissionScalingFactor),
             v2)})
@@ -152,7 +152,7 @@ object predicateSupporter extends PredicateSupportRules {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
           val predicateTrigger =
             App(s4.predicateData(predicate).triggerFunction, snap +: tArgs)
-          v2.decider.assume(predicateTrigger)
+          //v2.decider.assume(predicateTrigger)
           val s5 = s4.copy(g = s.g,
                            permissionScalingFactor = s.permissionScalingFactor)
           Q(s5, v2)})})

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -299,17 +299,17 @@ object producer extends ProductionRules {
           val ch =
             quantifiedChunkSupporter.createSingletonQuantifiedChunk(formalVars, wand, args, FullPerm(), sm, s.program)
           val h2 = s1.h + ch
-          val (relevantChunks, _) =
-            quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](h2, ch.id)
-          val (smDef1, smCache1) =
-            quantifiedChunkSupporter.summarisingSnapshotMap(
-              s1, wand, formalVars, relevantChunks, v1)
+          //val (relevantChunks, _) =
+          //  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](h2, ch.id)
+          //val (smDef1, smCache1) =
+          //  quantifiedChunkSupporter.summarisingSnapshotMap(
+          //    s1, wand, formalVars, relevantChunks, v1)
           //v1.decider.assume(PredicateTrigger(ch.id.toString, smDef1.sm, args))
           val smDef = SnapshotMapDefinition(wand, sm, Seq(smValueDef), Seq())
           val s2 =
             s1.copy(h = h2,
                     functionRecorder = s1.functionRecorder.recordFvfAndDomain(smDef),
-                    smCache = smCache1,
+                    //smCache = smCache1,
                     conservedPcs = conservedPcs)
           Q(s2, v1)})
 

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -278,8 +278,9 @@ object producer extends ProductionRules {
                 val snap1 = snap.convert(sorts.Snap)
                 val ch = BasicChunk(PredicateID, BasicChunkIdentifier(predicate.name), tArgs, snap1, gain)
                 chunkSupporter.produce(s2, s2.h, ch, v2)((s3, h3, v3) => {
-                  if (Verifier.config.enablePredicateTriggersOnInhale() && s3.functionRecorder == NoopFunctionRecorder) {
-                    //v3.decider.assume(App(s3.predicateData(predicate).triggerFunction, snap1 +: tArgs))
+                  if (Verifier.config.enablePredicateTriggersOnInhale() && s3.functionRecorder == NoopFunctionRecorder
+                    && !Verifier.config.disableHeapDependentTriggers()) {
+                    v3.decider.assume(App(s3.predicateData(predicate).triggerFunction, snap1 +: tArgs))
                   }
                   Q(s3.copy(h = h3), v3)})
               }})))
@@ -287,7 +288,7 @@ object producer extends ProductionRules {
       case wand: ast.MagicWand if s.qpMagicWands.contains(MagicWandIdentifier(wand, s.program)) =>
         val bodyVars = wand.subexpressionsToEvaluate(s.program)
         val formalVars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v.symbolConverter.toSort(bodyVars(i).typ)))
-        evals(s, bodyVars, _ => pve, v)((s1, args, v1) => {
+        evals(s, bodyVars, _ => pve, v)((s1, args,v1) => {
           val (sm, smValueDef) =
             quantifiedChunkSupporter.singletonSnapshotMap(s1, wand, args, sf(sorts.Snap, v1), v1)
           v1.decider.prover.comment("Definitional axioms for singleton-SM's value")
@@ -299,17 +300,22 @@ object producer extends ProductionRules {
           val ch =
             quantifiedChunkSupporter.createSingletonQuantifiedChunk(formalVars, wand, args, FullPerm(), sm, s.program)
           val h2 = s1.h + ch
-          //val (relevantChunks, _) =
-          //  quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](h2, ch.id)
-          //val (smDef1, smCache1) =
-          //  quantifiedChunkSupporter.summarisingSnapshotMap(
-          //    s1, wand, formalVars, relevantChunks, v1)
-          //v1.decider.assume(PredicateTrigger(ch.id.toString, smDef1.sm, args))
+          val smCache1 = if(!Verifier.config.disableHeapDependentTriggers()){
+            val (relevantChunks, _) =
+              quantifiedChunkSupporter.splitHeap[QuantifiedMagicWandChunk](h2, ch.id)
+            val (smDef1, smCache1) =
+              quantifiedChunkSupporter.summarisingSnapshotMap(
+                s1, wand, formalVars, relevantChunks, v1)
+            v1.decider.assume(PredicateTrigger(ch.id.toString, smDef1.sm, args))
+            smCache1
+          } else {
+            s1.smCache
+          }
           val smDef = SnapshotMapDefinition(wand, sm, Seq(smValueDef), Seq())
           val s2 =
             s1.copy(h = h2,
                     functionRecorder = s1.functionRecorder.recordFvfAndDomain(smDef),
-                    //smCache = smCache1,
+                    smCache = smCache1,
                     conservedPcs = conservedPcs)
           Q(s2, v1)})
 

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -279,7 +279,7 @@ object producer extends ProductionRules {
                 val ch = BasicChunk(PredicateID, BasicChunkIdentifier(predicate.name), tArgs, snap1, gain)
                 chunkSupporter.produce(s2, s2.h, ch, v2)((s3, h3, v3) => {
                   if (Verifier.config.enablePredicateTriggersOnInhale() && s3.functionRecorder == NoopFunctionRecorder) {
-                    v3.decider.assume(App(s3.predicateData(predicate).triggerFunction, snap1 +: tArgs))
+                    //v3.decider.assume(App(s3.predicateData(predicate).triggerFunction, snap1 +: tArgs))
                   }
                   Q(s3.copy(h = h3), v3)})
               }})))
@@ -304,7 +304,7 @@ object producer extends ProductionRules {
           val (smDef1, smCache1) =
             quantifiedChunkSupporter.summarisingSnapshotMap(
               s1, wand, formalVars, relevantChunks, v1)
-          v1.decider.assume(PredicateTrigger(ch.id.toString, smDef1.sm, args))
+          //v1.decider.assume(PredicateTrigger(ch.id.toString, smDef1.sm, args))
           val smDef = SnapshotMapDefinition(wand, sm, Seq(smValueDef), Seq())
           val s2 =
             s1.copy(h = h2,

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -454,7 +454,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           s"qp.fvfDomDef${v.counter(this).next()}",
           isGlobal = true))
 
-    (sm, valueDefinitions :+ resourceTriggerDefinition, optDomainDefinition)
+    (sm, valueDefinitions /*:+ resourceTriggerDefinition*/, optDomainDefinition)
   }
 
   private def summarise_predicate_or_wand(s: State,
@@ -535,7 +535,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           isGlobal = true
         ))
 
-    (sm, valueDefinitions :+ resourceTriggerDefinition, optDomainDefinition)
+    (sm, valueDefinitions /*:+ resourceTriggerDefinition*/, optDomainDefinition)
   }
 
   private def summarisePerm(s: State,
@@ -572,7 +572,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         s"qp.resTrgDef${v.counter(this).next()}",
         isGlobal = true)
 
-    (pm, Seq(valueDefinitions, resourceTriggerDefinition))
+    (pm, Seq(valueDefinitions /*, resourceTriggerDefinition*/))
   }
 
   def summarisingPermissionMap(s: State,
@@ -866,7 +866,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             val trigger = ResourceTriggerFunction(resource, smDef1.sm, codomainVars, s.program)
             val qvarsToInv = inv.qvarsToInversesOf(codomainVars)
             val condOfInv = tCond.replace(qvarsToInv)
-            v.decider.assume(Forall(codomainVars, Implies(condOfInv, trigger), Trigger(inv.inversesOf(codomainVars)))) //effectiveTriggers map (t => Trigger(t.p map (_.replace(qvarsToInv))))))
+            //v.decider.assume(Forall(codomainVars, Implies(condOfInv, trigger), Trigger(inv.inversesOf(codomainVars)))) //effectiveTriggers map (t => Trigger(t.p map (_.replace(qvarsToInv))))))
             val s1 =
               s.copy(h = h1,
                      functionRecorder = s.functionRecorder.recordFieldInv(inv),
@@ -910,7 +910,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val (smDef1, smCache1) =
       quantifiedChunkSupporter.summarisingSnapshotMap(
         s, resource, formalQVars, relevantChunks, v)
-    v.decider.assume(resourceTriggerFactory(smDef1.sm))
+    //v.decider.assume(resourceTriggerFactory(smDef1.sm))
 
     val smDef2 = SnapshotMapDefinition(resource, sm, Seq(smValueDef), Seq())
     val s1 = s.copy(h = h1,
@@ -997,7 +997,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val receiverInjectivityCheck =
           quantifiedChunkSupporter.injectivityAxiom(
             qvars     = qvars,
-            condition = And(tCond, ResourceTriggerFunction(resource, smDef1.sm, tArgs, s.program)),
+            condition = tCond, // And(tCond, ResourceTriggerFunction(resource, smDef1.sm, tArgs, s.program)),
             perms     = tPerm,
             arguments = tArgs,
             triggers  = Nil,
@@ -1012,11 +1012,14 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             v.decider.prover.comment("Definitional axioms for inverse functions")
             v.decider.assume(inverseFunctions.definitionalAxioms)
 
+            /*
             v.decider.assume(
               Forall(
                 formalQVars,
                 Implies(condOfInvOfLoc, ResourceTriggerFunction(resource, smDef1.sm, formalQVars, s.program)),
                 Trigger(inverseFunctions.inversesOf(formalQVars))))
+
+             */
 
             /* TODO: Try to unify the upcoming if/else-block, their code is rather similar */
             if (s.exhaleExt) {

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -435,16 +435,19 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           isGlobal = true)
       })
 
-    /*
-    val resourceTriggerDefinition =
-      Forall(
-        codomainQVar,
-        And(relevantChunks map (chunk => FieldTrigger(field.name, chunk.snapshotMap, codomainQVar))),
-        Trigger(Lookup(field.name, sm, codomainQVar)),
-        s"qp.fvfResTrgDef${v.counter(this).next()}",
-        isGlobal = true)
+    val resourceAndValueDefinitions = if (!Verifier.config.disableHeapDependentTriggers()){
+      val resourceTriggerDefinition =
+        Forall(
+          codomainQVar,
+          And(relevantChunks map (chunk => FieldTrigger(field.name, chunk.snapshotMap, codomainQVar))),
+          Trigger(Lookup(field.name, sm, codomainQVar)),
+          s"qp.fvfResTrgDef${v.counter(this).next()}",
+          isGlobal = true)
+      valueDefinitions :+ resourceTriggerDefinition
+    } else {
+      valueDefinitions
+    }
 
-     */
 
     val optDomainDefinition =
       optSmDomainDefinitionCondition.map(condition =>
@@ -457,7 +460,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           s"qp.fvfDomDef${v.counter(this).next()}",
           isGlobal = true))
 
-    (sm, valueDefinitions /*:+ resourceTriggerDefinition*/, optDomainDefinition)
+    (sm, resourceAndValueDefinitions, optDomainDefinition)
   }
 
   private def summarise_predicate_or_wand(s: State,
@@ -518,16 +521,18 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           isGlobal = true)
       })
 
-    /*
-    val resourceTriggerDefinition =
-      Forall(
-        qvar,
-        And(relevantChunks map (chunk => ResourceTriggerFunction(resource, chunk.snapshotMap, Seq(qvar), s.program))),
-        Trigger(ResourceLookup(resource, sm, Seq(qvar), s.program)),
-        s"qp.psmResTrgDef${v.counter(this).next()}",
-        isGlobal = true)
-
-     */
+    val resourceAndValueDefinitions = if (!Verifier.config.disableHeapDependentTriggers()){
+      val resourceTriggerDefinition =
+        Forall(
+          qvar,
+          And(relevantChunks map (chunk => ResourceTriggerFunction(resource, chunk.snapshotMap, Seq(qvar), s.program))),
+          Trigger(ResourceLookup(resource, sm, Seq(qvar), s.program)),
+          s"qp.psmResTrgDef${v.counter(this).next()}",
+          isGlobal = true)
+      valueDefinitions :+ resourceTriggerDefinition
+    } else {
+      valueDefinitions
+    }
 
     val optDomainDefinition =
       transformedOptSmDomainDefinitionCondition.map(condition =>
@@ -541,7 +546,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           isGlobal = true
         ))
 
-    (sm, valueDefinitions /*:+ resourceTriggerDefinition*/, optDomainDefinition)
+    (sm, resourceAndValueDefinitions, optDomainDefinition)
   }
 
   private def summarisePerm(s: State,
@@ -564,7 +569,27 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         s"qp.resPrmSumDef${v.counter(this).next()}",
         isGlobal = true)
 
-    (pm, Seq(valueDefinitions /*, resourceTriggerDefinition*/))
+    val resourceAndValueDefinitions = if (!Verifier.config.disableHeapDependentTriggers()){
+      val resourceTriggerFunction = ResourceTriggerFunction(resource, smDef.sm, codomainQVars, s.program)
+
+      // TODO: Quantify over snapshot if resource is predicate.
+      //       Also check other places where a similar quantifier is constructed.
+      val resourceTriggerDefinition =
+      Forall(
+        codomainQVars,
+        And(resourceTriggerFunction +:
+          relevantChunks.map(chunk =>
+            ResourceTriggerFunction(resource, chunk.snapshotMap, codomainQVars, s.program))),
+        Trigger(ResourcePermissionLookup(resource, pm, codomainQVars, s.program)),
+        s"qp.resTrgDef${v.counter(this).next()}",
+        isGlobal = true)
+
+      Seq(valueDefinitions, resourceTriggerDefinition)
+    } else {
+      Seq(valueDefinitions)
+    }
+
+    (pm, resourceAndValueDefinitions)
   }
 
   def summarisingPermissionMap(s: State,
@@ -705,13 +730,14 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     (s2, smDef, pmDef)
   }
 
+  /*
+   * Like heapSummarisingMaps, but does not define any snapshot maps.
+   */
   def permSummarisingMaps(s: State,
                           resource: ast.Resource,
                           codomainQVars: Seq[Var],
                           relevantChunks: Seq[QuantifiedBasicChunk],
-                          v: Verifier,
-                          optSmDomainDefinitionCondition: Option[Term] = None,
-                          optQVarsInstantiations: Option[Seq[Term]] = None)
+                          v: Verifier)
   : (State, PermMapDefinition) = {
 
     val s1 = s
@@ -861,30 +887,37 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               )
             })
 
-            // TODO: Why not formalQVars? Used as codomainVars, see above.
-            val codomainVars =
-              resource match {
-                case _: ast.Field => Seq(`?r`)
-                case p: ast.Predicate => s.predicateFormalVarMap(p)
-                case w: ast.MagicWand =>
-                  val bodyVars = w.subexpressionsToEvaluate(s.program)
-                  bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v.symbolConverter.toSort(bodyVars(i).typ)))
-              }
             val h1 = s.h + ch
-            //val (relevantChunks, _) =
-            //  quantifiedChunkSupporter.splitHeap[QuantifiedBasicChunk](h1, ch.id)
-            //val (smDef1, smCache1) =
-            //  quantifiedChunkSupporter.summarisingSnapshotMap(
-            //    s, resource, codomainVars, relevantChunks, v)
-            //val trigger = ResourceTriggerFunction(resource, smDef1.sm, codomainVars, s.program)
-            //val qvarsToInv = inv.qvarsToInversesOf(codomainVars)
-            //val condOfInv = tCond.replace(qvarsToInv)
-            //v.decider.assume(Forall(codomainVars, Implies(condOfInv, trigger), Trigger(inv.inversesOf(codomainVars)))) //effectiveTriggers map (t => Trigger(t.p map (_.replace(qvarsToInv))))))
+
+            val smCache1 = if (!Verifier.config.disableHeapDependentTriggers()){
+              // TODO: Why not formalQVars? Used as codomainVars, see above.
+              val codomainVars =
+                resource match {
+                  case _: ast.Field => Seq(`?r`)
+                  case p: ast.Predicate => s.predicateFormalVarMap(p)
+                  case w: ast.MagicWand =>
+                    val bodyVars = w.subexpressionsToEvaluate(s.program)
+                    bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v.symbolConverter.toSort(bodyVars(i).typ)))
+                }
+
+              val (relevantChunks, _) =
+                quantifiedChunkSupporter.splitHeap[QuantifiedBasicChunk](h1, ch.id)
+              val (smDef1, smCache1) =
+                quantifiedChunkSupporter.summarisingSnapshotMap(
+                  s, resource, codomainVars, relevantChunks, v)
+              val trigger = ResourceTriggerFunction(resource, smDef1.sm, codomainVars, s.program)
+              val qvarsToInv = inv.qvarsToInversesOf(codomainVars)
+              val condOfInv = tCond.replace(qvarsToInv)
+              v.decider.assume(Forall(codomainVars, Implies(condOfInv, trigger), Trigger(inv.inversesOf(codomainVars)))) //effectiveTriggers map (t => Trigger(t.p map (_.replace(qvarsToInv))))))
+              smCache1
+            } else {
+              s.smCache
+            }
             val s1 =
               s.copy(h = h1,
                      functionRecorder = s.functionRecorder.recordFieldInv(inv),
-                     conservedPcs = conservedPcs)
-                     //smCache = smCache1)
+                     conservedPcs = conservedPcs,
+                     smCache = smCache1)
             Q(s1, v)
           case false =>
             createFailure(pve dueTo notInjectiveReason, v, s)}
@@ -918,18 +951,24 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val pcs = interpreter.buildPathConditionsForChunk(ch, resourceDescription.instanceProperties)
     v.decider.assume(pcs)
 
-    //val (relevantChunks, _) =
-    //  quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](h1, ch.id )
-    //val (smDef1, smCache1) =
-    //  quantifiedChunkSupporter.summarisingSnapshotMap(
-    //    s, resource, formalQVars, relevantChunks, v)
-    //v.decider.assume(resourceTriggerFactory(smDef1.sm))
+    val smCache1 = if (!Verifier.config.disableHeapDependentTriggers()){
+      val (relevantChunks, _) =
+        quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](h1, ch.id )
+      val (smDef1, smCache1) =
+        quantifiedChunkSupporter.summarisingSnapshotMap(
+          s, resource, formalQVars, relevantChunks, v)
+      v.decider.assume(resourceTriggerFactory(smDef1.sm))
+      smCache1
+    } else {
+      s.smCache
+    }
+
 
     val smDef2 = SnapshotMapDefinition(resource, sm, Seq(smValueDef), Seq())
     val s1 = s.copy(h = h1,
                     conservedPcs = conservedPcs,
-                    functionRecorder = s.functionRecorder.recordFvfAndDomain(smDef2))
-                    //smCache = smCache1)
+                    functionRecorder = s.functionRecorder.recordFvfAndDomain(smDef2),
+                    smCache = smCache1)
     Q(s1, v)
   }
 
@@ -1002,15 +1041,20 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val (relevantChunks, otherChunks) =
           quantifiedChunkSupporter.splitHeap[QuantifiedBasicChunk](
             h, ChunkIdentifier(resource, s.program))
-        //val (smDef1, smCache1) =
-        //  quantifiedChunkSupporter.summarisingSnapshotMap(
-        //    s, resource, formalQVars, relevantChunks, v)
+        val (newCond, smCache1, smDef1) = if (!Verifier.config.disableHeapDependentTriggers()) {
+          val (smDef1, smCache1) =
+            quantifiedChunkSupporter.summarisingSnapshotMap(
+              s, resource, formalQVars, relevantChunks, v)
+          (And(tCond, ResourceTriggerFunction(resource, smDef1.sm, tArgs, s.program)), smCache1, Some(smDef1))
+        } else {
+          (tCond, s.smCache, None)
+        }
 
         /* TODO: Can we omit/simplify the injectivity check in certain situations? */
         val receiverInjectivityCheck =
           quantifiedChunkSupporter.injectivityAxiom(
             qvars     = qvars,
-            condition = tCond, // And(tCond, ResourceTriggerFunction(resource, smDef1.sm, tArgs, s.program)),
+            condition = newCond,
             perms     = tPerm,
             arguments = tArgs,
             triggers  = Nil,
@@ -1025,19 +1069,20 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             v.decider.prover.comment("Definitional axioms for inverse functions")
             v.decider.assume(inverseFunctions.definitionalAxioms)
 
-            /*
-            v.decider.assume(
-              Forall(
-                formalQVars,
-                Implies(condOfInvOfLoc, ResourceTriggerFunction(resource, smDef1.sm, formalQVars, s.program)),
-                Trigger(inverseFunctions.inversesOf(formalQVars))))
+            if (!Verifier.config.disableHeapDependentTriggers()){
+              v.decider.assume(
+                Forall(
+                  formalQVars,
+                  Implies(condOfInvOfLoc, ResourceTriggerFunction(resource, smDef1.get.sm, formalQVars, s.program)),
+                  Trigger(inverseFunctions.inversesOf(formalQVars))))
+            }
 
-             */
+
 
             /* TODO: Try to unify the upcoming if/else-block, their code is rather similar */
             if (s.exhaleExt) {
               magicWandSupporter.transfer[QuantifiedBasicChunk](
-                                          s, //.copy(smCache = smCache1),
+                                          s.copy(smCache = smCache1),
                                           lossOfInvOfLoc,
                                           createFailure(pve dueTo insufficientPermissionReason/*InsufficientPermission(acc.loc)*/, v, s),
                                           v)((s2, heap, rPerm, v2) => {
@@ -1092,7 +1137,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               v.decider.clearModel()
               val permissionRemovalResult =
                 quantifiedChunkSupporter.removePermissions(
-                  s, //.copy(smCache = smCache1),
+                  s.copy(smCache = smCache1),
                   relevantChunks,
                   formalQVars,
                   condOfInvOfLoc,


### PR DESCRIPTION
This PR adds a flag ``--disableHeapDependentTriggers`` that disables all code in Silicon that emits field and predicate triggers and, in particular, prevents Silicon from emitting snapshot maps etc. that are required only for those triggers. As a result, heap-dependent triggers will no longer work (users can still write them, but the quantifiers that use them will no longer be triggered), i.e., using the flag does not impact soundness, but makes Silicon less expressive (or arguably less complete).

Its purpose is to improve performance for Viper code that does not use such triggers, in particular, Gobra-generated code used in the VerifiedSCION project, which reportedly gets a big performance improvement from disabling them.