### PR TITLE
Added flag for disabling automatic function triggering on unfold

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -612,6 +612,12 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
+  val disableFunctionUnfoldTrigger: ScallopOption[Boolean] = opt[Boolean]("disableFunctionUnfoldTrigger",
+    descr = "Disables automatic triggering of function definitions when unfolding predicates they depend on.",
+    default = Some(false),
+    noshort = true
+  )
+
   def mapCache[A](opt: Option[A]): Option[A] = opt match {
     case Some(_) if disableCaches() => None
     case _ => opt

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -793,7 +793,8 @@ object evaluator extends EvaluationRules {
                          * to the function arguments and the predicate snapshot
                          * (see 'predicateTriggers' in FunctionData.scala).
                          */
-                      v4.decider.assume(App(s.predicateData(predicate).triggerFunction, snap.convert(terms.sorts.Snap) +: tArgs))
+                      if (!Verifier.config.disableFunctionUnfoldTrigger())
+                        v4.decider.assume(App(s.predicateData(predicate).triggerFunction, snap.convert(terms.sorts.Snap) +: tArgs))
                       val body = predicate.body.get /* Only non-abstract predicates can be unfolded */
                       val s7 = s6.scalePermissionFactor(tPerm)
                       val insg = s7.g + Store(predicate.formalArgs map (_.localVar) zip tArgs)

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -60,9 +60,11 @@ object predicateSupporter extends PredicateSupportRules {
                     smDomainNeeded = true)
               .scalePermissionFactor(tPerm)
     consume(s1, body, pve, v)((s1a, snap, v1) => {
-      val predTrigger = App(s1a.predicateData(predicate).triggerFunction,
-                            snap.convert(terms.sorts.Snap) +: tArgs)
-      v1.decider.assume(predTrigger)
+      if (!Verifier.config.disableFunctionUnfoldTrigger()) {
+        val predTrigger = App(s1a.predicateData(predicate).triggerFunction,
+          snap.convert(terms.sorts.Snap) +: tArgs)
+        v1.decider.assume(predTrigger)
+      }
       val s2 = s1a.setConstrainable(constrainableWildcards, false)
       if (s2.qpPredicates.contains(predicate)) {
         val predSnap = snap.convert(s2.predicateSnapMap(predicate))
@@ -135,10 +137,12 @@ object predicateSupporter extends PredicateSupportRules {
                    .setConstrainable(constrainableWildcards, false)
         produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
-          val predicateTrigger =
-            App(s4.predicateData(predicate).triggerFunction,
-              snap.convert(terms.sorts.Snap) +: tArgs)
-          v2.decider.assume(predicateTrigger)
+          if (!Verifier.config.disableFunctionUnfoldTrigger()) {
+            val predicateTrigger =
+              App(s4.predicateData(predicate).triggerFunction,
+                snap.convert(terms.sorts.Snap) +: tArgs)
+            v2.decider.assume(predicateTrigger)
+          }
           Q(s4.copy(g = s.g,
                     permissionScalingFactor = s.permissionScalingFactor),
             v2)})
@@ -151,9 +155,11 @@ object predicateSupporter extends PredicateSupportRules {
                    .setConstrainable(constrainableWildcards, false)
         produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
-          val predicateTrigger =
-            App(s4.predicateData(predicate).triggerFunction, snap +: tArgs)
-          v2.decider.assume(predicateTrigger)
+          if (!Verifier.config.disableFunctionUnfoldTrigger()) {
+            val predicateTrigger =
+              App(s4.predicateData(predicate).triggerFunction, snap +: tArgs)
+            v2.decider.assume(predicateTrigger)
+          }
           val s5 = s4.copy(g = s.g,
                            permissionScalingFactor = s.permissionScalingFactor)
           Q(s5, v2)})})

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -278,7 +278,8 @@ object producer extends ProductionRules {
                 val snap1 = snap.convert(sorts.Snap)
                 val ch = BasicChunk(PredicateID, BasicChunkIdentifier(predicate.name), tArgs, snap1, gain)
                 chunkSupporter.produce(s2, s2.h, ch, v2)((s3, h3, v3) => {
-                  if (Verifier.config.enablePredicateTriggersOnInhale() && s3.functionRecorder == NoopFunctionRecorder) {
+                  if (Verifier.config.enablePredicateTriggersOnInhale() && s3.functionRecorder == NoopFunctionRecorder
+                    && !Verifier.config.disableFunctionUnfoldTrigger()) {
                     v3.decider.assume(App(s3.predicateData(predicate).triggerFunction, snap1 +: tArgs))
                   }
                   Q(s3.copy(h = h3), v3)})


### PR DESCRIPTION
We trigger function's definitional axioms when unfolding any predicate they depend on.
Even when this functionality is not used, emitting this trigger can cause large slowdowns (since it creates a snapshot, which triggers the snapshot extensionality axiom) in programs that fold and unfold a lot (Vytautas has a test program that takes one minute with the triggers vs. 6 seconds without). 

In the medium term, we should try to minimize the performance impact of these triggers in general, but for now, I'm adding a flag to just disable them.