### PR TITLE
Add missing arguments to inverse functions to fix crash

### DIFF
--- a/src/main/scala/rules/StateConsolidator.scala
+++ b/src/main/scala/rules/StateConsolidator.scala
@@ -258,7 +258,7 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
             if (chunk.singletonRcvr.isDefined){
               v.decider.assume(PermAtMost(PermLookup(field.name, pmDef.pm, chunk.singletonRcvr.get), FullPerm()))
             } else {
-              val chunkReceivers = chunk.invs.get.inverses.map(i => App(i, chunk.quantifiedVars))
+              val chunkReceivers = chunk.invs.get.inverses.map(i => App(i, chunk.invs.get.additionalArguments ++ chunk.quantifiedVars))
               val triggers = chunkReceivers.map(r => Trigger(r)).toSeq
               val currentPermAmount = PermLookup(field.name, pmDef.pm, chunk.quantifiedVars.head)
               v.decider.prover.comment(s"Assume upper permission bound for field ${field.name}")


### PR DESCRIPTION
In the alternative version of assuming upper bounds for permissions that doesn't use field triggers, I introduced a potential crash because inverse functions aren't given all their arguments. This fixes that.