### PR TITLE
Removing unsound assumptions in quantifier context

### DIFF
--- a/src/main/scala/decider/PathConditions.scala
+++ b/src/main/scala/decider/PathConditions.scala
@@ -181,7 +181,7 @@ private trait LayeredPathConditionStackLike {
         Quantification(
           quantifier,
           qvars,
-          Implies(ignore, And(layer.nonGlobalAssumptions -- ignores)),
+          Implies(layer.branchCondition.getOrElse(True()), And(layer.nonGlobalAssumptions -- ignores)),
           triggers,
           name,
           isGlobal)

--- a/src/main/scala/decider/PathConditions.scala
+++ b/src/main/scala/decider/PathConditions.scala
@@ -181,7 +181,7 @@ private trait LayeredPathConditionStackLike {
         Quantification(
           quantifier,
           qvars,
-          And(layer.nonGlobalAssumptions -- ignores),
+          Implies(ignore, And(layer.nonGlobalAssumptions -- ignores)),
           triggers,
           name,
           isGlobal)

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -647,26 +647,10 @@ object evaluator extends EvaluationRules {
           case (s1, tVars, _, Seq(tBody), tTriggers, (tAuxGlobal, tAux), v1) =>
             val tAuxHeapIndep = tAux.flatMap(v.quantifierSupporter.makeTriggersHeapIndependent(_, v1.decider.fresh))
 
-            // TODO: Extracted top-level quantifications (tlqGlobal) are currently assumed twice:
-            //       once directly (tlqGlobal), once nested (tAuxGlobal). It would be better to remove the nested
-            //       instances, e.g. by replacing them with "true".
-
-            val tlqGlobal: Seq[Quantification] = tAuxGlobal flatMap {
-              case q1: Quantification => q1.deepCollect {case q2: Quantification if !q2.existsDefined {case v: Var if q1.vars.contains(v) => } => q2}
-              case _ => Seq.empty
-            }
-
-            val tlq: Seq[Quantification] = tAux flatMap (q1 =>
-              q1.deepCollect {case q2: Quantification if !q2.existsDefined {case v: Var if q1.vars.contains(v) => } => q2})
-
             v1.decider.prover.comment("Nested auxiliary terms: globals (aux)")
             v1.decider.assume(tAuxGlobal)
-            v1.decider.prover.comment("Nested auxiliary terms: globals (tlq)")
-            v1.decider.assume(tlqGlobal)
             v1.decider.prover.comment("Nested auxiliary terms: non-globals (aux)")
             v1.decider.assume(tAuxHeapIndep/*tAux*/)
-            v1.decider.prover.comment("Nested auxiliary terms: non-globals (tlq)")
-            v1.decider.assume(tlq)
 
             val tQuant = Quantification(qantOp, tVars, tBody, tTriggers, name)
             Q(s1, tQuant, v1)


### PR DESCRIPTION
Fixes issue #652 and issue #560.

For the latter, when asserting an outer quantifier, any nested quantifiers were (under some conditions) just assumed.
This is unsound, for example, as Malte pointed out, if we're trying to prove an outer quantifier like ``forall x . false ==> forall y. false``.
Since these assumptions don't seem to be needed (all tests pass without them, even after disabling caches), I'm simply removing them.

For the former, auxiliary information collected while evaluating a quantifier body (except for conditions directly mentioned in a QP condition) was sometimes assumed unconditionally.
So, for example, for the quantifier ``forall i . i >= 0 && i <= |s| - 1 ==> s[i] > 5``, the condition ``i < |s|`` is assumed for all ``i``, which is obviously wrong. Now, we're assuming them under their respective path conditions.