### PR TITLE
Improvements to --parallelizeBranches

### DIFF
--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -22,6 +22,8 @@ import viper.silicon.state.terms._
 import viper.silicon.verifier.{Verifier, VerifierComponent}
 import viper.silver.reporter.{ConfigurationConfirmation, InternalWarningMessage}
 
+import scala.collection.immutable.HashSet
+
 /*
  * Interfaces
  */
@@ -66,9 +68,12 @@ trait Decider {
   def isModelValid(): Boolean
 
 /* [BRANCH-PARALLELISATION] */
-  def freshFunctions: InsertionOrderedSet[FunctionDecl]
+  // HashSets lead to non-deterministic order, but branch parallelization leads to highly non-deterministic prover
+  // states anyway (and Scala does not seem to have efficient order-preserving sets). ListSets are significantly
+  // slower, so this tradeoff seems worth it.
+  def freshFunctions: HashSet[FunctionDecl]
   def freshMacros: Vector[MacroDecl]
-  def declareAndRecordAsFreshFunctions(functions: InsertionOrderedSet[FunctionDecl]): Unit
+  def declareAndRecordAsFreshFunctions(functions: HashSet[FunctionDecl]): Unit
   def declareAndRecordAsFreshMacros(functions: Vector[MacroDecl]): Unit
   def setPcs(other: PathConditionStack): Unit
 
@@ -92,7 +97,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     private var _prover: Prover = _
     private var pathConditions: PathConditionStack = _
 
-    private var _freshFunctions: InsertionOrderedSet[FunctionDecl] = _ /* [BRANCH-PARALLELISATION] */
+    private var _freshFunctions: HashSet[FunctionDecl] = _ /* [BRANCH-PARALLELISATION] */
     private var _freshMacros: Vector[MacroDecl] = _
 
     def prover: Prover = _prover
@@ -158,7 +163,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
     def start(): Unit = {
       pathConditions = new LayeredPathConditionStack()
-      _freshFunctions = InsertionOrderedSet.empty /* [BRANCH-PARALLELISATION] */
+      _freshFunctions = HashSet.empty /* [BRANCH-PARALLELISATION] */
       _freshMacros = Vector.empty
       createProver()
     }
@@ -166,7 +171,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     def reset(): Unit = {
       _prover.reset()
       pathConditions = new LayeredPathConditionStack()
-      _freshFunctions = InsertionOrderedSet.empty /* [BRANCH-PARALLELISATION] */
+      _freshFunctions = HashSet.empty /* [BRANCH-PARALLELISATION] */
       _freshMacros = Vector.empty
     }
 
@@ -358,10 +363,10 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
 
 /* [BRANCH-PARALLELISATION] */
-    def freshFunctions: InsertionOrderedSet[FunctionDecl] = _freshFunctions
+    def freshFunctions: HashSet[FunctionDecl] = _freshFunctions
     def freshMacros: Vector[MacroDecl] = _freshMacros
 
-    def declareAndRecordAsFreshFunctions(functions: InsertionOrderedSet[FunctionDecl]): Unit = {
+    def declareAndRecordAsFreshFunctions(functions: HashSet[FunctionDecl]): Unit = {
       functions foreach prover.declare
 
       _freshFunctions = _freshFunctions ++ functions

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -22,7 +22,7 @@ import viper.silicon.state.terms._
 import viper.silicon.verifier.{Verifier, VerifierComponent}
 import viper.silver.reporter.{ConfigurationConfirmation, InternalWarningMessage}
 
-import scala.collection.immutable.{HashSet, ListSet}
+import scala.collection.immutable.HashSet
 
 /*
  * Interfaces
@@ -163,7 +163,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
     def start(): Unit = {
       pathConditions = new LayeredPathConditionStack()
-      _freshFunctions = if (Verifier.config.parallelizeBranches()) HashSet.empty else ListSet.empty /* [BRANCH-PARALLELISATION] */
+      _freshFunctions = if (Verifier.config.parallelizeBranches()) HashSet.empty else InsertionOrderedSet.empty /* [BRANCH-PARALLELISATION] */
       _freshMacros = Vector.empty
       createProver()
     }
@@ -171,7 +171,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     def reset(): Unit = {
       _prover.reset()
       pathConditions = new LayeredPathConditionStack()
-      _freshFunctions = if (Verifier.config.parallelizeBranches()) HashSet.empty else ListSet.empty /* [BRANCH-PARALLELISATION] */
+      _freshFunctions = if (Verifier.config.parallelizeBranches()) HashSet.empty else InsertionOrderedSet.empty /* [BRANCH-PARALLELISATION] */
       _freshMacros = Vector.empty
     }
 

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -123,7 +123,8 @@ object brancher extends BranchingRules {
             v1.decider.prover.comment(s"[else-branch: $cnt | $negatedCondition]")
             v1.decider.setCurrentBranchCondition(negatedCondition, negatedConditionExp)
 
-            v1.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
+            if (v.uniqueId != v0.uniqueId)
+              v1.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
 
             fElse(v1.stateConsolidator.consolidateIfRetrying(s1, v1), v1)
           })

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -7,7 +7,6 @@
 package viper.silicon.rules
 
 import java.util.concurrent._
-import viper.silicon.common.collections.immutable
 import viper.silicon.common.concurrency._
 import viper.silicon.decider.PathConditionStack
 import viper.silicon.interfaces.{Unreachable, VerificationResult}
@@ -16,8 +15,6 @@ import viper.silicon.state.State
 import viper.silicon.state.terms.{FunctionDecl, MacroDecl, Not, Term}
 import viper.silicon.verifier.Verifier
 import viper.silver.ast
-
-import scala.collection.immutable.HashSet
 
 trait BranchingRules extends SymbolicExecutionRules {
   def branch(s: State,
@@ -82,7 +79,7 @@ object brancher extends BranchingRules {
     v.decider.prover.comment(elseBranchComment)
 
     val uidBranchPoint = SymbExLogger.currentLog().insertBranchPoint(2, Some(condition))
-    var functionsOfCurrentDecider: HashSet[FunctionDecl] = null
+    var functionsOfCurrentDecider: Set[FunctionDecl] = null
     var macrosOfCurrentDecider: Vector[MacroDecl] = null
     var pcsOfCurrentDecider: PathConditionStack = null
 

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -24,7 +24,9 @@ import viper.silicon.state.terms._
 import viper.silicon.state.terms.predef.`?r`
 import viper.silicon.utils.freshSnap
 import viper.silicon.verifier.Verifier
-import viper.silver.cfg.{ConditionalEdge, Kind}
+import viper.silver.cfg.ConditionalEdge
+
+import scala.collection.immutable.HashSet
 
 trait ExecutionRules extends SymbolicExecutionRules {
   def exec(s: State,
@@ -50,19 +52,6 @@ object executor extends ExecutionRules {
   private def follow(s: State, edge: SilverEdge, v: Verifier)
                     (Q: (State, Verifier) => VerificationResult)
                     : VerificationResult = {
-
-    def handleOutEdge(s: State, edge: SilverEdge, v: Verifier): State = {
-      edge.kind match {
-        case cfg.Kind.Out =>
-          val (fr1, h1) = v.stateConsolidator.merge(s.functionRecorder, s.h, s.invariantContexts.head, v)
-          val s1 = s.copy(functionRecorder = fr1, h = h1,
-                          invariantContexts = s.invariantContexts.tail)
-          s1
-        case _ =>
-          /* No need to do anything special. See also the handling of loop heads in exec below. */
-          s
-      }
-    }
 
     edge match {
       case ce: cfg.ConditionalEdge[ast.Stmt, ast.Exp] =>
@@ -90,6 +79,19 @@ object executor extends ExecutionRules {
     }
   }
 
+  def handleOutEdge(s: State, edge: SilverEdge, v: Verifier): State = {
+    edge.kind match {
+      case cfg.Kind.Out =>
+        val (fr1, h1) = v.stateConsolidator.merge(s.functionRecorder, s.h, s.invariantContexts.head, v)
+        val s1 = s.copy(functionRecorder = fr1, h = h1,
+          invariantContexts = s.invariantContexts.tail)
+        s1
+      case _ =>
+        /* No need to do anything special. See also the handling of loop heads in exec below. */
+        s
+    }
+  }
+
   private def follows(s: State,
                       edges: Seq[SilverEdge],
                       @unused pvef: ast.Exp => PartialVerificationError,
@@ -103,23 +105,27 @@ object executor extends ExecutionRules {
       follow(s, edges.head, v)(Q)
     } else {
       edges match {
-        case Seq(thenEdge@ConditionalEdge(cond1, _, _, Kind.Normal), elseEdge@ConditionalEdge(cond2, _, _, Kind.Normal))
+        case Seq(thenEdge@ConditionalEdge(cond1, _, _, _), elseEdge@ConditionalEdge(cond2, _, _, _))
             if Verifier.config.parallelizeBranches() && cond2 == ast.Not(cond1)()  =>
           val condEdgeRecord = new ConditionalEdgeRecord(thenEdge.condition, s, v.decider.pcs)
           val sepIdentifier = SymbExLogger.currentLog().openScope(condEdgeRecord)
           val res = eval(s, thenEdge.condition, IfFailed(thenEdge.condition), v)((s2, tCond, v1) =>
             brancher.branch(s2, tCond, Some(thenEdge.condition), v1)(
-              (s3, v3) =>
-                exec(s3, thenEdge.target, thenEdge.kind, v3)((s4, v4) => {
+              (s3, v3) => {
+                val s3p = handleOutEdge(s3, thenEdge, v3)
+                exec(s3p, thenEdge.target, thenEdge.kind, v3)((s4, v4) => {
                   SymbExLogger.currentLog().closeScope(sepIdentifier)
                   val branchRes = Q(s4, v4)
                   branchRes
-                }),
-              (s3, v3) =>
-                exec(s3, elseEdge.target, elseEdge.kind, v3)((s4, v4) => {
+                })
+              },
+              (s3, v3) => {
+                val s3p = handleOutEdge(s3, elseEdge, v3)
+                exec(s3p, elseEdge.target, elseEdge.kind, v3)((s4, v4) => {
                   SymbExLogger.currentLog().closeScope(sepIdentifier)
                   Q(s4, v4)
-                })))
+                })
+              }))
           res
         case _ =>
           val uidBranchPoint = SymbExLogger.currentLog().insertBranchPoint(edges.length)
@@ -189,7 +195,7 @@ object executor extends ExecutionRules {
             val edgeConditions = sortedEdges.collect{case ce: cfg.ConditionalEdge[ast.Stmt, ast.Exp] => ce.condition}
                                             .distinct
 
-            type PhaseData = (State, RecordedPathConditions, InsertionOrderedSet[FunctionDecl])
+            type PhaseData = (State, RecordedPathConditions, HashSet[FunctionDecl])
             var phase1data: Vector[PhaseData] = Vector.empty
 
             (executionFlowController.locally(sBody, v)((s0, v0) => {

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -26,8 +26,6 @@ import viper.silicon.utils.freshSnap
 import viper.silicon.verifier.Verifier
 import viper.silver.cfg.ConditionalEdge
 
-import scala.collection.immutable.HashSet
-
 trait ExecutionRules extends SymbolicExecutionRules {
   def exec(s: State,
            cfg: SilverCfg,
@@ -195,7 +193,7 @@ object executor extends ExecutionRules {
             val edgeConditions = sortedEdges.collect{case ce: cfg.ConditionalEdge[ast.Stmt, ast.Exp] => ce.condition}
                                             .distinct
 
-            type PhaseData = (State, RecordedPathConditions, HashSet[FunctionDecl])
+            type PhaseData = (State, RecordedPathConditions, Set[FunctionDecl])
             var phase1data: Vector[PhaseData] = Vector.empty
 
             (executionFlowController.locally(sBody, v)((s0, v0) => {


### PR DESCRIPTION
Three changes to --parallelizeBranches:
- We parallelize even if an edge is an out-edge
- We saturate when a new verifier takes over a branch
- If parallelizeBranches is used, we use HashSets instead of InsertionOrderedSets for the freshFunctions. For large examples, with InsertionOrderedSets (which are actually ListSets), Silicon spent a LOT of time just computing set unions and differences. Unfortunately, Scala does not have a LinkedHashSet, but --parallelizeBranches leads to massively non-deterministic prover states anyway.