### PR TITLE
Thread safe trigger generation

### DIFF
--- a/src/main/scala/Utils.scala
+++ b/src/main/scala/Utils.scala
@@ -16,6 +16,7 @@ import viper.silver.verifier.reasons.{FeatureUnsupported, UnexpectedNode}
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silicon.state.terms.{Sort, Term, Var}
 import viper.silicon.verifier.Verifier
+import viper.silver.ast.utility.Triggers.TriggerGenerationWithAddAndSubtract
 
 package object utils {
   def freshSnap: (Sort, Verifier) => Var = (sort, v) => v.decider.fresh(sort)
@@ -165,13 +166,7 @@ package object utils {
           /* Standard trigger generation code failed.
            * Let's try generating (certain) invalid triggers, which will then be rewritten
            */
-          silver.ast.utility.Triggers.TriggerGeneration.setCustomIsForbiddenInTrigger {
-            case _: silver.ast.Add | _: silver.ast.Sub => false
-          }
-
-          val optTriggerSet = silver.ast.utility.Expressions.generateTriggerSet(q)
-
-          silver.ast.utility.Triggers.TriggerGeneration.setCustomIsForbiddenInTrigger(PartialFunction.empty)
+          val optTriggerSet = silver.ast.utility.Expressions.generateTriggerSet(q, TriggerGenerationWithAddAndSubtract)
 
           val advancedTriggerForall =
             optTriggerSet match {


### PR DESCRIPTION
Adaptation to a change in Silver s.t. we no longer use mutable global state by default in the code for trigger generation, which can cause issues when running multiple instances of Silicon in parallel (see issue #660).