### PR TITLE
Always use precondition function, even for functions without preconditions

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -728,10 +728,8 @@ object evaluator extends EvaluationRules {
                              smDomainNeeded = true)
             consumes(s3, pres, _ => pvePre, v2)((s4, snap, v3) => {
               val snap1 = snap.convert(sorts.Snap)
-              if (func.pres.nonEmpty) {
-                val preFApp = App(functionSupporter.preconditionVersion(v3.symbolConverter.toFunction(func)), snap1 :: tArgs)
-                v3.decider.assume(preFApp)
-              }
+              val preFApp = App(functionSupporter.preconditionVersion(v3.symbolConverter.toFunction(func)), snap1 :: tArgs)
+              v3.decider.assume(preFApp)
               val tFApp = App(v3.symbolConverter.toFunction(func), snap1 :: tArgs)
               val fr5 =
                 s4.functionRecorder.changeDepthBy(-1)

--- a/src/main/scala/state/FunctionPreconditionTransformer.scala
+++ b/src/main/scala/state/FunctionPreconditionTransformer.scala
@@ -35,15 +35,8 @@ object FunctionPreconditionTransformer {
           tBody
         else
           Quantification(q, vars, tBody, triggers, name, isGlobal)
-      case App(hdf@HeapDepFun(id, _, _), args)  =>
-        val funcName = id match {
-          case SuffixedIdentifier(prefix, _, _) => prefix.name
-          case _ => id.name
-        }
-        if (p.findFunction(funcName).pres.nonEmpty)
+      case App(hdf@HeapDepFun(_, _, _), args)  =>
           And(args.map(transform(_, p)) :+ App(functionSupporter.preconditionVersion(hdf), args))
-        else
-          And(args.map(transform(_, p)))
       case other => And(other.subterms.map(transform(_, p)))
     }
     res

--- a/src/main/scala/supporters/functions/FunctionData.scala
+++ b/src/main/scala/supporters/functions/FunctionData.scala
@@ -191,7 +191,7 @@ class FunctionData(val programFunction: ast.Function,
     assert(phase == 1, s"Postcondition axiom must be generated in phase 1, current phase is $phase")
 
     if (programFunction.posts.nonEmpty) {
-      val pre = if (programFunction.pres.nonEmpty) preconditionFunctionApplication else True()
+      val pre = preconditionFunctionApplication
       val innermostBody = And(generateNestedDefinitionalAxioms ++ List(Implies(pre, And(translatedPosts))))
       val bodyBindings: Map[Var, Term] = Map(formalResult -> limitedFunctionApplication)
       val body = Let(toMap(bodyBindings), innermostBody)
@@ -256,7 +256,7 @@ class FunctionData(val programFunction: ast.Function,
     assert(phase == 2, s"Definitional axiom must be generated in phase 2, current phase is $phase")
 
     optBody.map(translatedBody => {
-      val pre = if (programFunction.pres.nonEmpty) preconditionFunctionApplication else True()
+      val pre = preconditionFunctionApplication
       val nestedDefinitionalAxioms = generateNestedDefinitionalAxioms
       val body = And(nestedDefinitionalAxioms ++ List(Implies(pre, And(functionApplication === translatedBody))))
       val allTriggers = (
@@ -267,7 +267,7 @@ class FunctionData(val programFunction: ast.Function,
   }
 
   lazy val preconditionPropagationAxiom: Seq[Term] = {
-    val pre = if (programFunction.pres.nonEmpty) preconditionFunctionApplication else True()
+    val pre = preconditionFunctionApplication
     val bodyPreconditions = if (programFunction.body.isDefined) optBody.map(translatedBody => {
       val body = Implies(pre, FunctionPreconditionTransformer.transform(translatedBody, program))
       Forall(arguments, body, Seq(Trigger(functionApplication)))


### PR DESCRIPTION
Otherwise, the new encoding does not actually fix issue #369.

I measured a performance impact of 2% on the test suite, and 8% on a SCION example. If the performance impact turns out to be significant in general, we could consider doing something closer to Carbon's approach instead.