### PR TITLE
Syntax for backend types

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -338,6 +338,8 @@ class SiliconFrontend(override val reporter: Reporter,
 
   protected var siliconInstance: Silicon = _
 
+  override def backendTypeFormat: Option[String] = Some("SMTLIB")
+
   def createVerifier(fullCmd: String) = {
     siliconInstance = new Silicon(reporter, Seq("args" -> fullCmd))
 

--- a/src/main/scala/reporting/Converter.scala
+++ b/src/main/scala/reporting/Converter.scala
@@ -675,8 +675,8 @@ object Converter {
 
     val smtfunc = func match {
       case t: ast.Function => symbolConverter.toFunction(t).id
+      case t@ast.BackendFunc(_, _, _, _) => symbolConverter.toFunction(t, program).id
       case t: ast.DomainFunc => symbolConverter.toFunction(t, argSort :+ resSort, program).id
-      case t: ast.BackendFunc => symbolConverter.toFunction(t).id
     }
     val kek = smtfunc.toString
       .replace("[", "<")

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -427,9 +427,10 @@ object evaluator extends EvaluationRules {
           val fi = v1.symbolConverter.toFunction(s.program.findDomainFunction(funcName), inSorts :+ outSort, s.program)
           Q(s1, App(fi, tArgs), v1)})
 
-      case ast.BackendFuncApp(func, eArgs) =>
+      case ast.BackendFuncApp(funcName, eArgs) =>
         evals(s, eArgs, _ => pve, v)((s1, tArgs, v1) => {
-          val fi = v1.symbolConverter.toFunction(func)
+          val func = s.program.findDomainFunction(funcName)
+          val fi = v1.symbolConverter.toFunction(func, s.program)
           Q(s1, App(fi, tArgs), v1)})
 
       case ast.CurrentPerm(resacc) =>

--- a/src/main/scala/state/SymbolConverter.scala
+++ b/src/main/scala/state/SymbolConverter.scala
@@ -14,10 +14,8 @@ trait SymbolConverter {
 
   def toSortSpecificId(name: String, sorts: Seq[Sort]): Identifier
 
-  def toFunction(function: ast.DomainFunc, prog: ast.Program): terms.DomainFun
+  def toFunction(function: ast.DomainFunc, prog: ast.Program): terms.Applicable
   def toFunction(function: ast.DomainFunc, sorts: Seq[Sort], prog: ast.Program): terms.DomainFun
-
-  def toFunction(function: ast.BackendFunc): terms.SMTFun
 
   def toFunction(function: ast.Function): terms.HeapDepFun
 }
@@ -38,7 +36,7 @@ class DefaultSymbolConverter extends SymbolConverter {
       assert(dt.isConcrete, "Expected only concrete domain types, but found " + dt)
       sorts.UserSort(Identifier(dt.toString()))
 
-    case ast.BackendType(_, smtName) if smtName != null => sorts.SMTSort(Identifier(smtName))
+    case ast.BackendType(_, interpretations) if interpretations.contains("SMTLIB") != null => sorts.SMTSort(Identifier(interpretations("SMTLIB")))
     case ast.BackendType(_, _) => sys.error("Found backend type without SMTLIB name.")
     case viper.silicon.utils.ast.ViperEmbedding(sort) => sort
       
@@ -52,20 +50,14 @@ class DefaultSymbolConverter extends SymbolConverter {
   def toSortSpecificId(name: String, sorts: Seq[Sort]): Identifier =
     Identifier(name + sorts.mkString("[",",","]"))
 
-  def toFunction(function: ast.DomainFunc, program: ast.Program): terms.DomainFun = {
+  def toFunction(function: ast.DomainFunc, program: ast.Program): terms.Applicable = {
     val inSorts = function.formalArgs map (_.typ) map toSort
     val outSort = toSort(function.typ)
 
-    toFunction(function, inSorts :+ outSort, program)
-  }
-
-  def toFunction(function: ast.BackendFunc): terms.SMTFun = {
-    val inSorts = function.formalArgs map (_.typ) map toSort
-    val outSort = toSort(function.typ)
-
-    val id = Identifier(function.smtName)
-
-    terms.SMTFun(id, inSorts, outSort)
+    if (function.interpretation.isEmpty)
+      toFunction(function, inSorts :+ outSort, program)
+    else
+      terms.SMTFun(Identifier(function.interpretation.get), inSorts, outSort)
   }
 
   def toFunction(function: ast.DomainFunc, sorts: Seq[Sort], program: ast.Program): terms.DomainFun = {

--- a/src/main/scala/supporters/BuiltinDomainsContributor.scala
+++ b/src/main/scala/supporters/BuiltinDomainsContributor.scala
@@ -114,7 +114,8 @@ abstract class BuiltinDomainsContributor extends PreambleContributor[Sort, Domai
   protected def collectFunctions(domains: Set[ast.Domain], program: ast.Program): Unit = {
     domains foreach (
       _.functions foreach (df =>
-        collectedFunctions += symbolConverter.toFunction(df, program)))
+        if (df.interpretation.isEmpty)
+          collectedFunctions += symbolConverter.toFunction(df, program).asInstanceOf[DomainFun]))
   }
 
   protected def collectAxioms(domains: Set[(ast.DomainType, ast.Domain)]): Unit = {

--- a/src/main/scala/supporters/Domains.scala
+++ b/src/main/scala/supporters/Domains.scala
@@ -84,15 +84,17 @@ class DefaultDomainsContributor(symbolConverter: SymbolConverter,
 
     instantiatedDomains foreach (domain => {
       domain.functions foreach (function => {
-        val fct = symbolConverter.toFunction(function, program)
+        if (function.interpretation.isEmpty) {
+          val fct = symbolConverter.toFunction(function, program).asInstanceOf[DomainFun]
 
-        collectedFunctions += fct
+          collectedFunctions += fct
 
-        if (function.unique) {
-          assert(function.formalArgs.isEmpty,
-            s"Expected unique domain functions to not take arguments, but found $function")
+          if (function.unique) {
+            assert(function.formalArgs.isEmpty,
+              s"Expected unique domain functions to not take arguments, but found $function")
 
-          uniqueSymbols = uniqueSymbols.addBinding(fct.resultSort, fct)
+            uniqueSymbols = uniqueSymbols.addBinding(fct.resultSort, fct)
+          }
         }
       })
 

--- a/src/main/scala/supporters/ExpressionTranslator.scala
+++ b/src/main/scala/supporters/ExpressionTranslator.scala
@@ -138,11 +138,11 @@ trait ExpressionTranslator {
         val df = Fun(id, inSorts, outSort)
         App(df, tArgs)
 
-      case ast.BackendFuncApp(func, args) =>
+      case bfa@ast.BackendFuncApp(func, args) =>
         val tArgs = args map f
         val inSorts = tArgs map (_.sort)
-        val outSort = toSort(func.typ)
-        val id = Identifier(func.smtName)
+        val outSort = toSort(bfa.typ)
+        val id = Identifier(bfa.interpretation)
         val sf = SMTFun(id, inSorts, outSort)
         App(sf, tArgs)
 


### PR DESCRIPTION
Adapting to changes made in Silver PR 638 (https://github.com/viperproject/silver/pull/638):
Domains and Domain Functions can now have attached interpretations. DomainFuncs with attached interpretations replace the existing BackendFunc AST node.

That means:
- We only generate sorts and declare functions for domain types and functions without interpretations
- Some code dealing with BackendFuncs has to be changed.
- The SiliconFrontend declares its backend name (SMTLIB) to enable consistency checks that ensure that the verified program has interpretations compatible with Silicon.