### PR TITLE
Reporting of all errors in the entity result messages

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -243,21 +243,21 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
 
     /*verifier.bookkeeper.*/elapsedMillis = System.currentTimeMillis() - /*verifier.bookkeeper.*/startTime
 
-    val failures =
-      results.flatMap(r => r :: r.previous.toList)
-        .collect{ case f: Failure => f } /* Ignore successes */
-        .pipe(allResults => {
-          /* If branchconditions are to be reported we collect the different failure contexts
-          *  of all failures that report the same error (but on different branches, with different CounterExample)
-          *  and put those into one failure */
-          if (config.enableBranchconditionReporting())
-            allResults.groupBy(failureFilterAndGroupingCriterion).map{case (_: String, fs:List[Failure]) =>
-              fs.head.message.failureContexts = fs.flatMap(_.message.failureContexts)
-              Failure(fs.head.message)
-            }.toList
-             else allResults.distinctBy(failureFilterAndGroupingCriterion)
-        })
-        .sortBy(failureSortingCriterion)
+    val failures = results
+      .collect{ case f: Failure => f } /* Ignore successes */
+      .pipe(allResults => {
+        /* If branchconditions are to be reported we collect the different failure contexts
+         *  of all failures that report the same error (but on different branches, with different CounterExample)
+         *  and put those into one failure
+         */
+        if (config.enableBranchconditionReporting())
+          allResults.groupBy(failureFilterAndGroupingCriterion).map{case (_: String, fs:List[Failure]) =>
+            fs.head.message.failureContexts = fs.flatMap(_.message.failureContexts)
+            Failure(fs.head.message)
+          }.toList
+        else allResults.distinctBy(failureFilterAndGroupingCriterion)
+      })
+      .sortBy(failureSortingCriterion)
 
 //    if (config.showStatistics.isDefined) {
 //      val proverStats = verifier.decider.statistics()

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -244,6 +244,8 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
     /*verifier.bookkeeper.*/elapsedMillis = System.currentTimeMillis() - /*verifier.bookkeeper.*/startTime
 
     val failures = results
+      // note that we do not extract 'previous' verification errors from VerificationResult's `previous` field
+      // because this is expected to have already been done in `verifier.verify` (for each member).
       .collect{ case f: Failure => f } /* Ignore successes */
       .pipe(allResults => {
         /* If branchconditions are to be reported we collect the different failure contexts

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -209,6 +209,7 @@ class DefaultMainVerifier(config: Config,
     val functionVerificationResults = functionsSupporter.units.toList flatMap (function => {
       val startTime = System.currentTimeMillis()
       val results = functionsSupporter.verify(createInitialState(function, program, functionData, predicateData), function)
+        .flatMap(extractAllVerificationResults)
       val elapsed = System.currentTimeMillis() - startTime
       reporter report VerificationResultMessage(s"silicon", function, elapsed, condenseToViperResult(results))
       logger debug s"Silicon finished verification of function `${function.name}` in ${viper.silver.reporter.format.formatMillisReadably(elapsed)} seconds with the following result: ${condenseToViperResult(results).toString}"
@@ -218,6 +219,7 @@ class DefaultMainVerifier(config: Config,
     val predicateVerificationResults = predicateSupporter.units.toList flatMap (predicate => {
       val startTime = System.currentTimeMillis()
       val results = predicateSupporter.verify(createInitialState(predicate, program, functionData, predicateData), predicate)
+        .flatMap(extractAllVerificationResults)
       val elapsed = System.currentTimeMillis() - startTime
       reporter report VerificationResultMessage(s"silicon", predicate, elapsed, condenseToViperResult(results))
       logger debug s"Silicon finished verification of predicate `${predicate.name}` in ${viper.silver.reporter.format.formatMillisReadably(elapsed)} seconds with the following result: ${condenseToViperResult(results).toString}"
@@ -246,6 +248,7 @@ class DefaultMainVerifier(config: Config,
         _verificationPoolManager.queueVerificationTask(v => {
           val startTime = System.currentTimeMillis()
           val results = v.methodSupporter.verify(s, method)
+            .flatMap(extractAllVerificationResults)
           val elapsed = System.currentTimeMillis() - startTime
 
           reporter report VerificationResultMessage(s"silicon", method, elapsed, condenseToViperResult(results))
@@ -259,6 +262,7 @@ class DefaultMainVerifier(config: Config,
         _verificationPoolManager.queueVerificationTask(v => {
           val startTime = System.currentTimeMillis()
           val results = v.cfgSupporter.verify(s, cfg)
+            .flatMap(extractAllVerificationResults)
           val elapsed = System.currentTimeMillis() - startTime
 
           reporter report VerificationResultMessage(s"silicon"/*, cfg*/, elapsed, condenseToViperResult(results))
@@ -513,4 +517,12 @@ class DefaultMainVerifier(config: Config,
     }
     results
   }
+
+  /**
+    * In case Silicon encounters an expected error (i.e. `ErrorMessage.isExpected`), Silicon continues (until at most
+    * config.numberOfErrorsToReport() have been encountered (per member)).
+    * This function retrieves all errors that have been encountered and creates a verification result containing them.
+    */
+  private def extractAllVerificationResults(res: VerificationResult): Seq[VerificationResult] =
+    res :: res.previous.toList
 }

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -521,7 +521,7 @@ class DefaultMainVerifier(config: Config,
   /**
     * In case Silicon encounters an expected error (i.e. `ErrorMessage.isExpected`), Silicon continues (until at most
     * config.numberOfErrorsToReport() have been encountered (per member)).
-    * This function retrieves all errors that have been encountered and creates a verification result containing them.
+    * This function combines the verification result with verification results stored in its `previous` field.
     */
   private def extractAllVerificationResults(res: VerificationResult): Seq[VerificationResult] =
     res :: res.previous.toList


### PR DESCRIPTION
### Use case for expected errors
Josua Stuck has added the concept of expected verification errors which make Silicon continue despite the occurrence of an error. This feature is in particular used by the refute plugin that marks all encoded refute statements as expected verification errors. These expected errors won't be reported to the user by the refute plugin and instead the plugin produces verification errors for encoded refute statements for which no error has been encountered by Silicon.

### Keeping track of expected errors in Silicon
Silicon keeps track of these expected and encountered verification errors in the `previous` field of Silicon's `VerificationResult`. It seems that the first encountered error is the verification result and all subsequent verification errors (due to continuing with verifying the input) are placed in the `previous` field.

### Post-processing expected errors - so far
The `DefaultMainVerifier` used to produce verification results per member while ignoring the `previous` field, i.e. the first encountered error is returned. [`Silicon` line 247](https://github.com/viperproject/silicon/blob/fb1bd019f764aef130d14a469c3293ab702f970b/src/main/scala/Silicon.scala#L247) retrieved the errors encountered after the first one by taking the `previous` field into account and flatting all verification results.

### Issue
`DefaultMainVerifier` is responsible for emitting entity verification result messages. Since the `DefaultMainVerifier` does not consider the `previous` field of verification results, entity verification result messages contain different (i.e. a subset) of errors compared to Silicon's overall result (when considering the errors for the same member).
This behavior is problematic in the context of [Silver #641](https://github.com/viperproject/silver/pull/641) since plugins will handle entity verification result such that the ViperServer & the IDE support plugins (see [ViperServer #99](https://github.com/viperproject/viperserver/pull/99)).

### Post-processing expected errors - new
This PR basically moves [`Silicon` line 247](https://github.com/viperproject/silicon/blob/fb1bd019f764aef130d14a469c3293ab702f970b/src/main/scala/Silicon.scala#L247) into `DefaultMainVerifier` to ensure that the union of all entity verification results (hopefully) correspond to the overall result returned by Silicon. Note however that grouping, sorting, and dealing with branch conditions have been left in `Silicon` as imho this concerns more errors will be printed and it's not immediately clear whether this functionality can be as easily moved into `DefaultMainVerifier `, even though this could make sense in the long run.
