### PR TITLE
Fixing issue #676

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -763,6 +763,12 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
       sys.error(s"Unexpected combination: $other")
   }
 
+  validateOpt(assertionMode, parallelizeBranches) {
+    case (Some(AssertionMode.SoftConstraints), Some(true)) =>
+      Left(s"Assertion mode SoftConstraints is not supported in combination with ${parallelizeBranches.name}")
+    case _ => Right()
+  }
+
   validateOpt(counterexample, enableMoreCompleteExhale) {
     case (Some(_), Some(false)) => Left(  s"Option ${counterexample.name} requires setting "
                                         + s"flag ${enableMoreCompleteExhale.name}")

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -565,7 +565,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
 
   val assertionMode: ScallopOption[AssertionMode] = opt[AssertionMode]("assertionMode",
     descr = (  "Determines how assertion checks are encoded in SMTLIB. Options are "
-             + "'pp' (push-pop) and 'cs' (soft constraints) (default: pp)."),
+             + "'pp' (push-pop) and 'sc' (soft constraints) (default: pp)."),
     default = Some(AssertionMode.PushPop),
     noshort = true
   )(assertionModeConverter)

--- a/src/main/scala/decider/ProverStdIO.scala
+++ b/src/main/scala/decider/ProverStdIO.scala
@@ -297,12 +297,13 @@ abstract class ProverStdIO(uniqueId: String,
     setTimeout(timeout)
 
     val guard = fresh("grd", Nil, sorts.Bool)
+    val guardApp = App(guard, Nil)
 
-    writeLine(s"(assert (=> $guard (not $goal)))")
+    writeLine(s"(assert (=> $guardApp (not $goal)))")
     readSuccess()
 
     val startTime = System.currentTimeMillis()
-    writeLine(s"(check-sat $guard)")
+    writeLine(s"(check-sat $guardApp)")
     val result = readUnsat()
     val endTime = System.currentTimeMillis()
 


### PR DESCRIPTION
- Fixed description of assertion mode in help text
- Fixed soft constraint assertion mode, which used to result in Z3 error
- Added validation for unsupported combination of soft constraint mode and branch parallelization