### PR TITLE
Sound MoreCompleteExhale on demand

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -635,8 +635,11 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     case _ => opt
   }
 
+  // DEPRECATED and replaced by exhaleMode.
   val moreCompleteExhale: ScallopOption[Boolean] = opt[Boolean]("enableMoreCompleteExhale",
-    descr = "Enable a more complete exhale version.",
+    descr =  "Warning: This option is deprecated. "
+           + "Please use 'exhaleMode' instead. "
+           + "Enables a more complete exhale version.",
     default = Some(false),
     noshort = true
   )
@@ -795,8 +798,9 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
          (Some(_), Some(_), Some(ExhaleMode.Greedy)) |
          (Some(_), Some(_), Some(ExhaleMode.MoreCompleteOnDemand)) =>
       Left(  s"Option ${counterexample.name} requires setting "
-           + s"flag ${moreCompleteExhale.name}")
-    case (_, Some(true), Some(m)) if m != ExhaleMode.MoreComplete => Left(s"Contradictory values given for options ${moreCompleteExhale.name} and ${exhaleModeOption.name}")
+           + s"${exhaleModeOption.name} to 1 (more complete)")
+    case (_, Some(true), Some(m)) if m != ExhaleMode.MoreComplete =>
+      Left(s"Contradictory values given for options ${moreCompleteExhale.name} and ${exhaleModeOption.name}")
     case _ => Right(())
   }
 

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -84,10 +84,10 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
 
   private val exhaleModeConverter: ValueConverter[ExhaleMode] = new ValueConverter[ExhaleMode] {
     def parse(s: List[(String, List[String])]): Either[String, Option[ExhaleMode]] = s match {
-      case (_, "0" :: Nil) :: Nil => Right(Some(ExhaleMode.Greedy))
-      case (_, "1" :: Nil) :: Nil => Right(Some(ExhaleMode.MoreComplete))
-      case (_, "2" :: Nil) :: Nil => Right(Some(ExhaleMode.MoreCompleteOnDemand))
-      case Nil => Right(None)
+      case Seq((_, Seq("0"))) => Right(Some(ExhaleMode.Greedy))
+      case Seq((_, Seq("1"))) => Right(Some(ExhaleMode.MoreComplete))
+      case Seq((_, Seq("2"))) => Right(Some(ExhaleMode.MoreCompleteOnDemand))
+      case Seq() => Right(None)
       case _ => Left(s"unexpected arguments")
     }
 

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -798,7 +798,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
          (Some(_), Some(_), Some(ExhaleMode.Greedy)) |
          (Some(_), Some(_), Some(ExhaleMode.MoreCompleteOnDemand)) =>
       Left(s"Option ${counterexample.name} requires setting "
-        + s"${exhaleModeOption.name} to 1 (more complete)")
+        + s"${exhaleModeOption.name} to 1 (more complete exhale)")
     case (_, Some(true), Some(m)) if m != ExhaleMode.MoreComplete =>
       Left(s"Contradictory values given for options ${moreCompleteExhale.name} and ${exhaleModeOption.name}")
     case _ => Right(())

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -82,6 +82,18 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     val argType: ArgType.V = org.rogach.scallop.ArgType.LIST
   }
 
+  private val exhaleModeConverter: ValueConverter[ExhaleMode] = new ValueConverter[ExhaleMode] {
+    def parse(s: List[(String, List[String])]): Either[String, Option[ExhaleMode]] = s match {
+      case (_, "0" :: Nil) :: Nil => Right(Some(ExhaleMode.Greedy))
+      case (_, "1" :: Nil) :: Nil => Right(Some(ExhaleMode.MoreComplete))
+      case (_, "2" :: Nil) :: Nil => Right(Some(ExhaleMode.MoreCompleteOnDemand))
+      case Nil => Right(None)
+      case _ => Left(s"unexpected arguments")
+    }
+
+    val argType: ArgType.V = org.rogach.scallop.ArgType.LIST
+  }
+
   private val saturationTimeoutWeightsConverter: ValueConverter[ProverSaturationTimeoutWeights] = new ValueConverter[ProverSaturationTimeoutWeights] {
     def parse(s: List[(String, List[String])]): Either[String, Option[ProverSaturationTimeoutWeights]] = s match {
       case Seq((_, Seq(rawString))) =>
@@ -623,11 +635,26 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     case _ => opt
   }
 
-  val enableMoreCompleteExhale: ScallopOption[Boolean] = opt[Boolean]("enableMoreCompleteExhale",
+  val moreCompleteExhale: ScallopOption[Boolean] = opt[Boolean]("enableMoreCompleteExhale",
     descr = "Enable a more complete exhale version.",
     default = Some(false),
     noshort = true
   )
+
+  val exhaleModeOption: ScallopOption[ExhaleMode] = opt[ExhaleMode]("exhaleMode",
+    descr = "Exhale mode. Options are 0 (greedy, default), 1 (more complete exhale), 2 (more complete exhale on demand).",
+    default = None,
+    noshort = true
+  )(exhaleModeConverter)
+
+  lazy val exhaleMode: ExhaleMode = {
+    if (exhaleModeOption.isDefined)
+      exhaleModeOption()
+    else if (moreCompleteExhale())
+      ExhaleMode.MoreComplete
+    else
+      ExhaleMode.Greedy
+  }
 
   val numberOfErrorsToReport: ScallopOption[Int] = opt[Int]("numberOfErrorsToReport",
     descr = "Number of errors per member before the verifier stops. If this number is set to 0, all errors are reported.",
@@ -763,9 +790,13 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
       sys.error(s"Unexpected combination: $other")
   }
 
-  validateOpt(counterexample, enableMoreCompleteExhale) {
-    case (Some(_), Some(false)) => Left(  s"Option ${counterexample.name} requires setting "
-                                        + s"flag ${enableMoreCompleteExhale.name}")
+  validateOpt(counterexample, moreCompleteExhale, exhaleModeOption) {
+    case (Some(_), Some(false), None) |
+         (Some(_), Some(_), Some(ExhaleMode.Greedy)) |
+         (Some(_), Some(_), Some(ExhaleMode.MoreCompleteOnDemand)) =>
+      Left(  s"Option ${counterexample.name} requires setting "
+           + s"flag ${moreCompleteExhale.name}")
+    case (_, Some(true), Some(m)) if m != ExhaleMode.MoreComplete => Left(s"Contradictory values given for options ${moreCompleteExhale.name} and ${exhaleModeOption.name}")
     case _ => Right(())
   }
 
@@ -802,6 +833,13 @@ object Config {
   object AssertionMode {
     case object PushPop extends AssertionMode
     case object SoftConstraints extends AssertionMode
+  }
+
+  sealed trait ExhaleMode
+  object ExhaleMode {
+    case object Greedy extends ExhaleMode
+    case object MoreComplete extends ExhaleMode
+    case object MoreCompleteOnDemand extends ExhaleMode
   }
 
   case class ProverStateSaturationTimeout(timeout: Int, comment: String)

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -197,7 +197,7 @@ object chunkSupporter extends ChunkSupportRules {
 
     executionFlowController.tryOrFail2[Heap, Term](s.copy(h = h), v)((s1, v1, QS) => {
       val lookupFunction =
-        if (s.isMethodVerification &&s1.moreCompleteExhale) moreCompleteExhaleSupporter.lookupComplete _
+        if (s.isMethodVerification && s1.moreCompleteExhale) moreCompleteExhaleSupporter.lookupComplete _
         else lookupGreedy _
       lookupFunction(s1, s1.h, resource, args, ve, v1)((s2, tSnap, v2) =>
         QS(s2.copy(h = s.h), s2.h, tSnap, v2))

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -109,7 +109,7 @@ object chunkSupporter extends ChunkSupportRules {
     } else {
       executionFlowController.tryOrFail2[Heap, Option[Term]](s.copy(h = h), v)((s1, v1, QS) =>
         // 2022-05-07 MHS: MoreCompleteExhale isn't yet integrated into function verification, hence the limitation to method verification
-        if (s.isMethodVerification && Verifier.config.enableMoreCompleteExhale()) {
+        if (s.isMethodVerification && s1.moreCompleteExhale) {
           moreCompleteExhaleSupporter.consumeComplete(s1, s1.h, resource, args, perms, ve, v1)((s2, h2, snap2, v2) => {
             QS(s2.copy(h = s.h), h2, snap2, v2)
           })
@@ -197,7 +197,7 @@ object chunkSupporter extends ChunkSupportRules {
 
     executionFlowController.tryOrFail2[Heap, Term](s.copy(h = h), v)((s1, v1, QS) => {
       val lookupFunction =
-        if (s.isMethodVerification && Verifier.config.enableMoreCompleteExhale()) moreCompleteExhaleSupporter.lookupComplete _
+        if (s.isMethodVerification &&s1.moreCompleteExhale) moreCompleteExhaleSupporter.lookupComplete _
         else lookupGreedy _
       lookupFunction(s1, s1.h, resource, args, ve, v1)((s2, tSnap, v2) =>
         QS(s2.copy(h = s.h), s2.h, tSnap, v2))

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -119,10 +119,10 @@ object chunkSupporter extends ChunkSupportRules {
               val snap = optCh2 match {
                 case None => None
                 case Some(ch) =>
-                  if (v1.decider.check(Greater(perms, NoPerm()), Verifier.config.checkTimeout())) {
+                  if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout())) {
                     Some(ch.snap)
                   } else {
-                    Some(Ite(Greater(perms, NoPerm()), ch.snap.convert(sorts.Snap), Unit))
+                    Some(Ite(IsPositive(perms), ch.snap.convert(sorts.Snap), Unit))
                   }
               }
               QS(s2.copy(h = s.h), h2, snap, v1)

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -655,23 +655,7 @@ object evaluator extends EvaluationRules {
             v1.decider.prover.comment("Nested auxiliary terms: globals (aux)")
             v1.decider.assume(tAuxGlobal)
             v1.decider.prover.comment("Nested auxiliary terms: non-globals (aux)")
-
-            tAuxHeapIndep.foreach(q => {
-              var inQuant: List[Term] = Nil
-              var outQuant: List[Term] = Nil
-              q.body.topLevelConjuncts.foreach(tlc => {
-                if (tVars.exists(tv => tlc.contains(tv))) {
-                  inQuant = tlc :: inQuant
-                } else {
-                  outQuant = tlc :: outQuant
-                }
-              })
-              v1.decider.assume(outQuant)
-              v1.decider.assume(q.copy(body = And(inQuant)))
-            })
-
-            //v1.decider.assume()
-            //v1.decider.assume(tAuxHeapIndep/*tAux*/)
+            v1.decider.assume(tAuxHeapIndep/*tAux*/)
 
             if (qantOp == Exists) {
               // For universal quantification, the non-global auxiliary assumptions will contain the information that
@@ -689,8 +673,7 @@ object evaluator extends EvaluationRules {
 
       case fapp @ ast.FuncApp(funcName, eArgs) =>
         val func = s.program.findFunction(funcName)
-        val s0 = s
-        evals2(s0, eArgs, Nil, _ => pve, v)((s1, tArgs, v1) => {
+        evals2(s, eArgs, Nil, _ => pve, v)((s1, tArgs, v1) => {
 //          bookkeeper.functionApplications += 1
           val joinFunctionArgs = tArgs //++ c2a.quantifiedVariables.filterNot(tArgs.contains)
           /* TODO: Does it matter that the above filterNot does not filter out quantified

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -655,7 +655,23 @@ object evaluator extends EvaluationRules {
             v1.decider.prover.comment("Nested auxiliary terms: globals (aux)")
             v1.decider.assume(tAuxGlobal)
             v1.decider.prover.comment("Nested auxiliary terms: non-globals (aux)")
-            v1.decider.assume(tAuxHeapIndep/*tAux*/)
+
+            tAuxHeapIndep.foreach(q => {
+              var inQuant: List[Term] = Nil
+              var outQuant: List[Term] = Nil
+              q.body.topLevelConjuncts.foreach(tlc => {
+                if (tVars.exists(tv => tlc.contains(tv))) {
+                  inQuant = tlc :: inQuant
+                } else {
+                  outQuant = tlc :: outQuant
+                }
+              })
+              v1.decider.assume(outQuant)
+              v1.decider.assume(q.copy(body = And(inQuant)))
+            })
+
+            //v1.decider.assume()
+            //v1.decider.assume(tAuxHeapIndep/*tAux*/)
 
             if (qantOp == Exists) {
               // For universal quantification, the non-global auxiliary assumptions will contain the information that
@@ -673,7 +689,7 @@ object evaluator extends EvaluationRules {
 
       case fapp @ ast.FuncApp(funcName, eArgs) =>
         val func = s.program.findFunction(funcName)
-        val s0 = s.copy(hackIssue387DisablePermissionConsumption = s.moreCompleteExhale)
+        val s0 = s
         evals2(s0, eArgs, Nil, _ => pve, v)((s1, tArgs, v1) => {
 //          bookkeeper.functionApplications += 1
           val joinFunctionArgs = tArgs //++ c2a.quantifiedVariables.filterNot(tArgs.contains)

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -672,7 +672,7 @@ object evaluator extends EvaluationRules {
 
       case fapp @ ast.FuncApp(funcName, eArgs) =>
         val func = s.program.findFunction(funcName)
-        val s0 = s.copy(hackIssue387DisablePermissionConsumption = Verifier.config.enableMoreCompleteExhale())
+        val s0 = s.copy(hackIssue387DisablePermissionConsumption = s.moreCompleteExhale)
         evals2(s0, eArgs, Nil, _ => pve, v)((s1, tArgs, v1) => {
 //          bookkeeper.functionApplications += 1
           val joinFunctionArgs = tArgs //++ c2a.quantifiedVariables.filterNot(tArgs.contains)

--- a/src/main/scala/rules/ExecutionFlowController.scala
+++ b/src/main/scala/rules/ExecutionFlowController.scala
@@ -128,9 +128,9 @@ object executionFlowController extends ExecutionFlowRules {
 
         val comLog = new CommentRecord("Retry", s0, v.decider.pcs)
         val sepIdentifier = v.symbExLog.openScope(comLog)
-        action(s0.copy(retrying = true, retryLevel = s.retryLevel), v, (s1, r, v1) => {
+        action(s0.copy(retrying = true, retryLevel = s.retryLevel, moreCompleteExhale = true), v, (s1, r, v1) => {
           v1.symbExLog.closeScope(sepIdentifier)
-          Q(s1.copy(retrying = false), r, v1)
+          Q(s1.copy(retrying = false, moreCompleteExhale = s0.moreCompleteExhale), r, v1)
         })
       }
 

--- a/src/main/scala/rules/ExecutionFlowController.scala
+++ b/src/main/scala/rules/ExecutionFlowController.scala
@@ -128,9 +128,9 @@ object executionFlowController extends ExecutionFlowRules {
 
         val comLog = new CommentRecord("Retry", s0, v.decider.pcs)
         val sepIdentifier = v.symbExLog.openScope(comLog)
-        action(s0.copy(retrying = true, retryLevel = s.retryLevel, moreCompleteExhale = true), v, (s1, r, v1) => {
+        action(s0.copy(retrying = true, retryLevel = s.retryLevel /* , moreCompleteExhale = true */), v, (s1, r, v1) => {
           v1.symbExLog.closeScope(sepIdentifier)
-          Q(s1.copy(retrying = false, moreCompleteExhale = s0.moreCompleteExhale), r, v1)
+          Q(s1.copy(retrying = false /*, moreCompleteExhale = s0.moreCompleteExhale */), r, v1)
         })
       }
 

--- a/src/main/scala/rules/ExecutionFlowController.scala
+++ b/src/main/scala/rules/ExecutionFlowController.scala
@@ -6,6 +6,7 @@
 
 package viper.silicon.rules
 
+import viper.silicon.Config.ExhaleMode
 import viper.silicon.interfaces._
 import viper.silicon.logger.records.data.CommentRecord
 import viper.silicon.state.State
@@ -128,9 +129,10 @@ object executionFlowController extends ExecutionFlowRules {
 
         val comLog = new CommentRecord("Retry", s0, v.decider.pcs)
         val sepIdentifier = v.symbExLog.openScope(comLog)
-        action(s0.copy(retrying = true, retryLevel = s.retryLevel /* , moreCompleteExhale = true */), v, (s1, r, v1) => {
+        val temporaryMCE = Verifier.config.exhaleMode != ExhaleMode.Greedy
+        action(s0.copy(retrying = true, retryLevel = s.retryLevel, moreCompleteExhale =  temporaryMCE), v, (s1, r, v1) => {
           v1.symbExLog.closeScope(sepIdentifier)
-          Q(s1.copy(retrying = false /*, moreCompleteExhale = s0.moreCompleteExhale */), r, v1)
+          Q(s1.copy(retrying = false, moreCompleteExhale = s0.moreCompleteExhale), r, v1)
         })
       }
 

--- a/src/main/scala/rules/ExecutionFlowController.scala
+++ b/src/main/scala/rules/ExecutionFlowController.scala
@@ -130,7 +130,7 @@ object executionFlowController extends ExecutionFlowRules {
         val comLog = new CommentRecord("Retry", s0, v.decider.pcs)
         val sepIdentifier = v.symbExLog.openScope(comLog)
         val temporaryMCE = Verifier.config.exhaleMode != ExhaleMode.Greedy
-        action(s0.copy(retrying = true, retryLevel = s.retryLevel, moreCompleteExhale =  temporaryMCE), v, (s1, r, v1) => {
+        action(s0.copy(retrying = true, retryLevel = s.retryLevel, moreCompleteExhale = temporaryMCE), v, (s1, r, v1) => {
           v1.symbExLog.closeScope(sepIdentifier)
           Q(s1.copy(retrying = false, moreCompleteExhale = s0.moreCompleteExhale), r, v1)
         })

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -282,10 +282,10 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         val s0 = s.copy(functionRecorder = currentFunctionRecorder)
 
         summarise(s0, relevantChunks.toSeq, resource, args, v)((s1, snap, _, _, v1) => {
-          val condSnap = if (v1.decider.check(Greater(perms, NoPerm()), Verifier.config.checkTimeout())) {
+          val condSnap = if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout())) {
             snap
           } else {
-            Ite(Greater(perms, NoPerm()), snap.convert(sorts.Snap), Unit)
+            Ite(IsPositive(perms), snap.convert(sorts.Snap), Unit)
           }
           if (!moreNeeded) {
             Q(s1, newHeap, Some(condSnap), v1)

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -306,8 +306,6 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                                                 (Q: (State, ListBuffer[NonQuantifiedChunk], Option[Term], Verifier) => VerificationResult)
                                                 : VerificationResult = {
 
-    //assert(s.functionRecorder == NoopFunctionRecorder)
-
     var totalPermSum: Term = NoPerm()
     var totalPermTaken: Term = NoPerm()
     var newFr = s.functionRecorder
@@ -322,7 +320,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
         val constraint = And(IsValidPermVar(permTaken),
           PermAtMost(permTaken, ch.perm),
-          Implies(Not(eq), permTaken === NoPerm()))
+          Implies(Not(eq), permTaken === NoPerm())
+        )
 
         v.decider.assume(constraint)
         newFr = newFr.recordArp(permTaken, constraint)

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -281,17 +281,22 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
         val s0 = s.copy(functionRecorder = currentFunctionRecorder)
 
-        summarise(s0, relevantChunks.toSeq, resource, args, v)((s1, snap, _, _, v1) =>
+        summarise(s0, relevantChunks.toSeq, resource, args, v)((s1, snap, _, _, v1) => {
+          val condSnap = if (v1.decider.check(Greater(perms, NoPerm()), Verifier.config.checkTimeout())) {
+            snap
+          } else {
+            Ite(Greater(perms, NoPerm()), snap.convert(sorts.Snap), Unit)
+          }
           if (!moreNeeded) {
-            Q(s1, newHeap, Some(snap), v1)
+            Q(s1, newHeap, Some(condSnap), v1)
           } else {
             v1.decider.assert(pNeeded === NoPerm()) {
               case true =>
-                Q(s1, newHeap, Some(snap), v1)
+                Q(s1, newHeap, Some(condSnap), v1)
               case false =>
                 createFailure(ve, v1, s1)
             }
-          })
+          }})
       }
     }
   }

--- a/src/main/scala/state/State.scala
+++ b/src/main/scala/state/State.scala
@@ -67,7 +67,8 @@ final case class State(g: Store = Store(),
                        isMethodVerification: Boolean = false,
                        retryLevel: Int = 0,
                        /* ast.Field, ast.Predicate, or MagicWandIdentifier */
-                       heapDependentTriggers: InsertionOrderedSet[Any] = InsertionOrderedSet.empty)
+                       heapDependentTriggers: InsertionOrderedSet[Any] = InsertionOrderedSet.empty,
+                       moreCompleteExhale: Boolean = false)
     extends Mergeable[State] {
 
   def incCycleCounter(m: ast.Predicate) =
@@ -147,7 +148,8 @@ object State {
                  reserveHeaps1, reserveCfgs1, conservedPcs1, recordPcs1, exhaleExt1,
                  ssCache1, hackIssue387DisablePermissionConsumption1,
                  qpFields1, qpPredicates1, qpMagicWands1, smCache1, pmCache1, smDomainNeeded1,
-                 predicateSnapMap1, predicateFormalVarMap1, hack, retryLevel, useHeapTriggers) =>
+                 predicateSnapMap1, predicateFormalVarMap1, hack, retryLevel, useHeapTriggers,
+                 moreCompleteExhale) =>
 
         /* Decompose state s2: most values must match those of s1 */
         s2 match {
@@ -171,7 +173,8 @@ object State {
                      `reserveHeaps1`, `reserveCfgs1`, `conservedPcs1`, `recordPcs1`, `exhaleExt1`,
                      ssCache2, `hackIssue387DisablePermissionConsumption1`,
                      `qpFields1`, `qpPredicates1`, `qpMagicWands1`, smCache2, pmCache2, `smDomainNeeded1`,
-                     `predicateSnapMap1`, `predicateFormalVarMap1`, `hack`, `retryLevel`, `useHeapTriggers`) =>
+                     `predicateSnapMap1`, `predicateFormalVarMap1`, `hack`, `retryLevel`, `useHeapTriggers`,
+                     moreCompleteExhale2) =>
 
             val functionRecorder3 = functionRecorder1.merge(functionRecorder2)
             val triggerExp3 = triggerExp1 && triggerExp2
@@ -182,6 +185,7 @@ object State {
             val pmCache3 = pmCache1 ++ pmCache2
 
             val ssCache3 = ssCache1 ++ ssCache2
+            val moreCompleteExhale3 = moreCompleteExhale || moreCompleteExhale2
 
             s1.copy(functionRecorder = functionRecorder3,
                     possibleTriggers = possibleTriggers3,
@@ -189,7 +193,8 @@ object State {
                     constrainableARPs = constrainableARPs3,
                     ssCache = ssCache3,
                     smCache = smCache3,
-                    pmCache = pmCache3)
+                    pmCache = pmCache3,
+                    moreCompleteExhale = moreCompleteExhale3)
 
           case _ =>
             val err = new StringBuilder()

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -6,6 +6,8 @@
 
 package viper.silicon.verifier
 
+import viper.silicon.Config.ExhaleMode
+
 import java.text.SimpleDateFormat
 import java.util.concurrent._
 import scala.annotation.unused
@@ -308,7 +310,7 @@ class DefaultMainVerifier(config: Config,
           predicateFormalVarMap = predSnapGenerator.formalVarMap,
           isMethodVerification = member.isInstanceOf[ast.Member],
           heapDependentTriggers = resourceTriggers,
-          moreCompleteExhale = Verifier.config.enableMoreCompleteExhale())
+          moreCompleteExhale = Verifier.config.exhaleMode == ExhaleMode.MoreComplete)
   }
 
   private def createInitialState(@unused cfg: SilverCfg,
@@ -328,7 +330,7 @@ class DefaultMainVerifier(config: Config,
       qpMagicWands = quantifiedMagicWands,
       predicateSnapMap = predSnapGenerator.snapMap,
       predicateFormalVarMap = predSnapGenerator.formalVarMap,
-      moreCompleteExhale = Verifier.config.enableMoreCompleteExhale())
+      moreCompleteExhale = Verifier.config.exhaleMode == ExhaleMode.MoreComplete)
   }
 
   private def excludeMethod(method: ast.Method) = (

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -303,7 +303,8 @@ class DefaultMainVerifier(config: Config,
           predicateSnapMap = predSnapGenerator.snapMap,
           predicateFormalVarMap = predSnapGenerator.formalVarMap,
           isMethodVerification = member.isInstanceOf[ast.Member],
-          heapDependentTriggers = resourceTriggers)
+          heapDependentTriggers = resourceTriggers,
+          moreCompleteExhale = Verifier.config.enableMoreCompleteExhale())
   }
 
   private def createInitialState(@unused cfg: SilverCfg,
@@ -322,7 +323,8 @@ class DefaultMainVerifier(config: Config,
       qpPredicates = quantifiedPredicates,
       qpMagicWands = quantifiedMagicWands,
       predicateSnapMap = predSnapGenerator.snapMap,
-      predicateFormalVarMap = predSnapGenerator.formalVarMap)
+      predicateFormalVarMap = predSnapGenerator.formalVarMap,
+      moreCompleteExhale = Verifier.config.enableMoreCompleteExhale())
   }
 
   private def excludeMethod(method: ast.Method) = (

--- a/src/test/resources/moreCompleteExhale/0523.vpr
+++ b/src/test/resources/moreCompleteExhale/0523.vpr
@@ -1,0 +1,37 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Int
+
+function req(x: Ref): Bool
+  requires acc(x.f, 2/1)
+{ true }
+
+method test(x: Ref) {
+  inhale acc(x.f)
+  //:: ExpectedOutput(application.precondition:insufficient.permission)
+  assert req(x) // Fails only without --enableMoreCompleteExhale (and should fail)
+  assert false  // Fails even with --enableMoreCompleteExhale (and should fail)
+}
+
+
+
+/////// Example from issue 594
+
+field val$_Int: Int
+
+function getter_pkg_F(param_pkg_V0: Ref): Int
+  requires acc(SomePredicate_pkg_F(param_pkg_V0), write)
+{
+  (unfolding acc(SomePredicate_pkg_F(param_pkg_V0), write) in param_pkg_V0.val$_Int)
+}
+
+predicate SomePredicate_pkg_F(param_pkg_V0: Ref) {
+  true && acc(param_pkg_V0.val$_Int, write)
+}
+
+method client2_pkg_F(param_pkg_V0: Ref) returns (res_pkg_V0: Int)
+  requires acc(SomePredicate_pkg_F(param_pkg_V0), 1 / 2)
+  ensures acc(SomePredicate_pkg_F(param_pkg_V0), 1 / 2)
+  //:: ExpectedOutput(application.precondition:insufficient.permission)
+  ensures res_pkg_V0 == getter_pkg_F(param_pkg_V0)

--- a/src/test/scala/SiliconTestsMoreCompleteExhale.scala
+++ b/src/test/scala/SiliconTestsMoreCompleteExhale.scala
@@ -11,5 +11,5 @@ class SiliconTestsMoreCompleteExhale extends SiliconTests {
 
  override val commandLineArguments: Seq[String] = Seq(
     "--timeout", "300" /* seconds */,
-    "--enableMoreCompleteExhale")
+    "--exhaleMode=1")
 }


### PR DESCRIPTION
This PR does two things:

First, it adds a mode where Silicon's MoreCompleteExhale mode is used on retry only. That is, Silicon works in its normal greedy mode, and whenever it cannot prove an assertion and retries the proof, MoreCompleteExhale is temporarily turned on (for this purpose, a ``moreCompleteExhale`` flag is introduced in the State). Then, the assertion is proved in MCE mode, and the branch continues verifying in greedy mode.
The idea is that MCE is often needed to prove a few assertions in large examples, but is not needed for the vast majority. Since MCE also comes with a performance penalty, we try to do as much as possible in the faster greedy mode, and only switch to MCE when needed.
To do this, the PR adds a new command line flag ``exhaleMode``, which can be set to greedy (default), MCE, or MCE-on-demand. The existing ``enableMoreCompleteExhale`` flag is kept for compatibility reasons but deprecated.

Second, it fixes the unsoundness mentioned in issue #594 and #523. I.e., when checking function preconditions in MCE mode, Silicon used to ignore permission amounts and just prove that *some* permission for every mentioned field and predicate was available. For consistency (until we switch everything to ignoring permission amounts in function preconditions), we now consider permission amounts in these situations as well. The implementation simply uses the existing MCE functionality and, when wildcards are used, also uses the existing ``summarise`` function, which is already used elsewhere and does not have the incompleteness problems of the existing implementation.