### PR TITLE
Fixing issue #205

### DIFF
--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -116,7 +116,16 @@ object chunkSupporter extends ChunkSupportRules {
         } else {
           consumeGreedy(s1, s1.h, id, args, perms, v1) match {
             case (Complete(), s2, h2, optCh2) =>
-              QS(s2.copy(h = s.h), h2, optCh2.map(_.snap), v1)
+              val snap = optCh2 match {
+                case None => None
+                case Some(ch) =>
+                  if (v1.decider.check(Greater(perms, NoPerm()), Verifier.config.checkTimeout())) {
+                    Some(ch.snap)
+                  } else {
+                    Some(Ite(Greater(perms, NoPerm()), ch.snap.convert(sorts.Snap), Unit))
+                  }
+              }
+              QS(s2.copy(h = s.h), h2, snap, v1)
             case _ if v1.decider.checkSmoke() =>
               Success() // TODO: Mark branch as dead?
             case _ =>

--- a/src/main/scala/state/Terms.scala
+++ b/src/main/scala/state/Terms.scala
@@ -947,6 +947,7 @@ class Less(val p0: Term, val p1: Term) extends ComparisonTerm
 object Less extends /* OptimisingBinaryArithmeticOperation with */ ((Term, Term) => Term) {
   def apply(e0: Term, e1: Term) = (e0, e1) match {
     case (IntLiteral(n0), IntLiteral(n1)) => if (n0 < n1) True() else False()
+    case (pl0: PermLiteral, pl1: PermLiteral) => if (pl0.literal < pl1.literal) True() else False()
     case (t0, t1) if t0 == t1 => False()
     case _ => new Less(e0, e1)
   }
@@ -963,6 +964,7 @@ class AtMost(val p0: Term, val p1: Term) extends ComparisonTerm
 object AtMost extends /* OptimisingBinaryArithmeticOperation with */ ((Term, Term) => Term) {
   def apply(e0: Term, e1: Term) = (e0, e1) match {
     case (IntLiteral(n0), IntLiteral(n1)) => if (n0 <= n1) True() else False()
+    case (pl0: PermLiteral, pl1: PermLiteral) => if (pl0.literal <= pl1.literal) True() else False()
     case (t0, t1) if t0 == t1 => True()
     case _ => new AtMost(e0, e1)
   }
@@ -979,6 +981,7 @@ class Greater(val p0: Term, val p1: Term) extends ComparisonTerm
 object Greater extends /* OptimisingBinaryArithmeticOperation with */ ((Term, Term) => Term) {
   def apply(e0: Term, e1: Term) = (e0, e1) match {
     case (IntLiteral(n0), IntLiteral(n1)) => if (n0 > n1) True() else False()
+    case (pl0: PermLiteral, pl1: PermLiteral) => if (pl0.literal > pl1.literal) True() else False()
     case (t0, t1) if t0 == t1 => False()
     case _ => new Greater(e0, e1)
   }
@@ -995,6 +998,7 @@ class AtLeast(val p0: Term, val p1: Term) extends ComparisonTerm
 object AtLeast extends /* OptimisingBinaryArithmeticOperation with */ ((Term, Term) => Term) {
   def apply(e0: Term, e1: Term) = (e0, e1) match {
     case (IntLiteral(n0), IntLiteral(n1)) => if (n0 >= n1) True() else False()
+    case (pl0: PermLiteral, pl1: PermLiteral) => if (pl0.literal >= pl1.literal) True() else False()
     case (t0, t1) if t0 == t1 => True()
     case _ => new AtLeast(e0, e1)
   }


### PR DESCRIPTION
When consuming a chunk, this PR adds a check whether the consumed permission amount is definitely non-zero. If so, nothing changes, otherwise it makes the returned snapshot a ternary expression that is unit in case the permission amount is zero. 

The purpose of this change is to tighten the footprint of functions whose preconditions contain access predicates with conditional permission amounts, which fixes issue #205.

A previous PR tried to achieve the same fix by branching on the value of the permission expression; I think this solution is better, since it does not introduce additional branching (otherwise, the parameter ``--conditionalizePermissions``, which pushes conditions into permission expressions, would be completely useless, for example).

I've also added shortcuts for evaluating comparisons between permission literals, which should mean that no additional SMT solver queries have to be made in 99% of cases. I haven't observed any noticable permormance difference as a result of this branch on a mix of test suite and frontend benchmarks or on a larger SCION example.