### PR TITLE
Updating --conditionalizePermissions

### DIFF
--- a/src/main/scala/extensions/ConditionalPermissionRewriter.scala
+++ b/src/main/scala/extensions/ConditionalPermissionRewriter.scala
@@ -74,10 +74,13 @@ class ConditionalPermissionRewriter {
       val cond = cc.c.exp
       (Implies(cond, exp)(cond.pos, cond.info, cond.errT), cc) // Won't recurse into exp's children
   }, Condition(), Traverse.TopDown).recurseFunc({
-    case exp: Exp if exp.isPure => Nil // Don't recurse into pure expressions
-    case _: AccessPredicate => Nil // Don't recurse into accessibility predicates
-    case l: Let => l.body :: Nil  // Don't recurse into bound expression
     case e: Exp if alreadySeen.contains(e) => Nil
+    case exp: Exp if exp.isPure => Nil  // Don't recurse into pure expressions
+    case _: AccessPredicate => Nil  // Don't recurse into accessibility predicates
+    case f: Forall => f.exp :: Nil  // Don't recurse into triggers
+    case e: Exists => e.exp :: Nil  // Don't recurse into triggers
+    case l: Let => l.body :: Nil  // Don't recurse into bound expression
+
   })
 
   // Rewrite impure ternary expressions to a conjuction of implications in order to be able to use the implication

--- a/src/main/scala/extensions/ConditionalPermissionRewriter.scala
+++ b/src/main/scala/extensions/ConditionalPermissionRewriter.scala
@@ -7,8 +7,10 @@
 package viper.silicon.extensions
 
 import viper.silver.ast._
-import viper.silver.ast.utility.ViperStrategy
+import viper.silver.ast.utility.{Expressions, ViperStrategy}
 import viper.silver.ast.utility.rewriter.Traverse
+
+import scala.collection.mutable
 
 /** An AST rewriter that transforms accessibility predicates under conditionals into accessibility
   * predicates with corresponding conditional permission expressions. E.g. it transforms
@@ -16,27 +18,39 @@ import viper.silver.ast.utility.rewriter.Traverse
   * to
   *   acc(x.f, b ? p : none)
   *
-  * TODO: Support magic wands
-  * TODO: Support ternary expressions b ? a1 : a2
   */
 class ConditionalPermissionRewriter {
-  private val rewriter = ViperStrategy.Context[Condition]({
-    // TODO: Support ternary expressions b ? a1 : a2
+  private def rewriter(implicit p: Program, alreadySeen: mutable.HashSet[Exp]) = ViperStrategy.Context[Condition]({
+    // Does NOT rewrite ternary expressions; those have to be transformed to implications in advance
+    // using the ternaryRewriter below.
     //
     // General note regarding the AST transformer framework: the new node, i.e. the node returned in
     // a match case, will not itself be visited again. The recurseFunc, defined below, will determine
     // which of the new node's children will be visited.
-    case (Implies(cond, acc: AccessPredicate), cc) =>
+    case (i@Implies(cond, acc: AccessPredicate), cc) =>
       // Found an implication b ==> acc(...)
-      (conditionalize(acc, cc.c &*& cond), cc) // Won't recurse into acc's children (see recurseFunc below)
+      // Transformation causes issues if the permission involve a wildcard, so we avoid that case.
+      val res = if (!acc.perm.contains[WildcardPerm])
+        (conditionalize(acc, cc.c &*& cond), cc) // Won't recurse into acc's children (see recurseFunc below)
+      else
+        (Implies(And(cc.c.exp, cond)(), acc)(i.pos, i.info, i.errT), cc)
+      alreadySeen.add(res._1)
+      res
+
 
     case (impl: Implies, cc) if !impl.right.isPure =>
       // Entering an implication b ==> A, where A is not pure, i.e. contains an accessibility accessibility
       (impl.right, cc.updateContext(cc.c &*& impl.left))
 
-    case (acc: AccessPredicate, cc) if cc.c.optExp.nonEmpty =>
+    case (acc: AccessPredicate, cc) if cc.c.optExp.nonEmpty  =>
       // Found an accessibility predicate nested under some conditionals
-      (conditionalize(acc, cc.c), cc) // Won't recurse into acc's children
+      // Wildcards may cause issues, see above.
+      val res = if (!acc.perm.contains[WildcardPerm])
+        (conditionalize(acc, cc.c), cc) // Won't recurse into acc's children
+      else
+        (Implies(cc.c.exp, acc)(acc.pos, acc.info, acc.errT), cc)
+      alreadySeen.add(res._1)
+      res
 
     case (exp: Exp, cc) if cc.c.optExp.nonEmpty && exp.isPure =>
       // Found a pure expression nested under some conditionals
@@ -45,31 +59,58 @@ class ConditionalPermissionRewriter {
   }, Condition(), Traverse.TopDown).recurseFunc({
     case exp: Exp if exp.isPure => Nil // Don't recurse into pure expressions
     case _: AccessPredicate => Nil // Don't recurse into accessibility predicates
+    case e: Exp if alreadySeen.contains(e) => Nil
   })
+
+  // Rewrite impure ternary expressions to a conjuction of implications in order to be able to use the implication
+  // rewriter above.
+  val ternaryRewriter = ViperStrategy.Slim{
+    case ce@CondExp(cond, tExp, fExp) if !tExp.isPure || !fExp.isPure =>
+      And(Implies(cond, tExp)(ce.pos, ce.info, ce.errT),
+        Implies(Not(cond)(cond.pos, cond.info, cond.errT), fExp)(ce.pos, ce.info, ce.errT))(ce.pos, ce.info, ce.errT)
+  }
 
   /** Transforms all conditional accessibility predicates in `root` into unconditional accessibility
     * predicates with suitable conditional permission expressions.
     */
-  def rewrite(root: Node): Node = {
-    rewriter.execute(root)
+  def rewrite(root: Program): Program = {
+    val res: Program = rewriter(root, new mutable.HashSet[Exp]()).execute(ternaryRewriter.execute(root))
+    res
   }
 
   /** Convenient factory for a node CondExp(cond, perm). */
-  private def makeCondExp(cond: Exp, perm: Exp): CondExp = {
-    CondExp(cond, perm, NoPerm()(perm.pos, perm.info, perm.errT))(perm.pos, perm.info, perm.errT)
+  private def makeCondExp(cond: Exp, perm: Exp, elsePerm: Exp = NoPerm()()): CondExp = {
+    CondExp(cond, perm, elsePerm)(perm.pos, perm.info, perm.errT)
   }
 
   /** Makes `acc`'s permissions conditional w.r.t. `cond`.
-    * TODO: Support magic wands
     */
-  private def conditionalize(acc: AccessPredicate, cond: Condition): AccessPredicate = {
+  private def conditionalize(acc: AccessPredicate, cond: Condition)(implicit p: Program): Exp = {
+    // We have to be careful not to introduce well-definedness issues when conditionalizing.
+    // For example, if we transform
+    // i >= 0 && i < |s| ==> acc(s[i].f)
+    // to
+    // acc(s[i].f, i >= 0 && i < |s| ? write : none)
+    // then backends may complain that s[i].f is not well-defined. Thus, we only perform the
+    // transformation if receiver/argument expressions are always well-defined.
     acc match {
       case FieldAccessPredicate(loc, perm) =>
-        FieldAccessPredicate(loc, makeCondExp(cond.exp, perm))(acc.pos, acc.info, acc.errT)
+        if (Expressions.proofObligations(loc.rcv)(p).isEmpty) {
+          FieldAccessPredicate(loc, makeCondExp(cond.exp, perm))(acc.pos, acc.info, acc.errT)
+        } else {
+          // Hack: use a conditional null as the receiver, that's always well-defined.
+          val fieldAccess = loc.copy(rcv = makeCondExp(cond.exp, loc.rcv, NullLit()()))(loc.pos, loc.info, loc.errT)
+          FieldAccessPredicate(fieldAccess, makeCondExp(cond.exp, perm))(acc.pos, acc.info, acc.errT)
+        }
       case PredicateAccessPredicate(loc, perm) =>
-        PredicateAccessPredicate(loc, makeCondExp(cond.exp, perm))(acc.pos, acc.info, acc.errT)
+        if (!loc.args.exists(a => Expressions.proofObligations(a)(p).nonEmpty))
+          PredicateAccessPredicate(loc, makeCondExp(cond.exp, perm))(acc.pos, acc.info, acc.errT)
+        else
+          Implies(cond.exp, acc)(acc.pos, acc.info, acc.errT)
       case wand: MagicWand =>
-        sys.error(s"Cannot conditionalise magic wand $wand (${viper.silicon.utils.ast.sourceLineColumn(wand)})")
+        // Since wands do not have permission amounts, we cannot conditionalize them;
+        // in order to be able to support programs with wands at all, we just write an implication.
+        Implies(cond.exp, wand)(acc.pos, acc.info, acc.errT)
     }
   }
 }

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1123,7 +1123,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             if (s.exhaleExt) {
               magicWandSupporter.transfer[QuantifiedBasicChunk](
                                           s.copy(smCache = smCache1),
-                                          lossOfInvOfLoc,
+                                          loss,
                                           createFailure(pve dueTo insufficientPermissionReason/*InsufficientPermission(acc.loc)*/, v, s),
                                           v)((s2, heap, rPerm, v2) => {
                 val (relevantChunks, otherChunks) =


### PR DESCRIPTION
Silicon's experimental ``--conditionalizePermissions`` flag performs a program transformation that rewrites access predicates under conditions, i.e., ``b ==> acc(e.f, r)``, into unconditional access predicates with conditional permission amounts, i.e., ``acc(e.f, b ? r : none)``, with the intention of preventing Silicon from branching on the value of ``b`` to reduce the number of branches.

This PR updates the rewriter to add features and fix some issues to make it more generally usable:
- Instead of throwing a runtime error when encountering a wand (which cannot have a conditional permission amount), it simply does not perform the rewriting for wands (i.e., it will output a mostly unchanged ``b ==> P --* Q``.
- Similarly, it does not perform the rewriting if ``r`` is a wildcard (since that leads to completeness issues), or when ``e`` is a complex expression that is not always well-defined, since the well-definedness of ``e`` may depend on condition ``b``: Given ``acc(e.f, b ? r : none)``, Silicon checks that e is well-defined in the current context in general, not only if ``b`` is true. 
- It fixes previous issues when transforming quantifiers or let-expressions, where the transformer would turn transform triggers and bound expressions, respectively, into implications, which results in invalid code.
- It adds a phase that transforms impure ternary expressions ``b ? P : Q`` into a conjunction of implications ``b ==> P && !b ==> Q``, which is then transformed as described above (ternary expressions were previously left untransformed).

Finally, it fixes an issue that occurs when packaging a wand that contains a quantified permission with a complex permission amount (which is technically a different issue, but will happen more often when using the transformation).