### PR TITLE
Renames QuantifierWeightTests to avoid a name clash with Carbon

### DIFF
--- a/src/test/scala/SiliconQuantifierWeightTests.scala
+++ b/src/test/scala/SiliconQuantifierWeightTests.scala
@@ -15,7 +15,7 @@ import viper.silver.ast.{AnonymousDomainAxiom, Bool, Domain, DomainFunc, DomainF
 import viper.silver.reporter.NoopReporter
 import viper.silver.verifier.{Failure, Success}
 
-class QuantifierWeightTests extends AnyFunSuite {
+class SiliconQuantifierWeightTests extends AnyFunSuite {
   val symbolConverter = new DefaultSymbolConverter()
   val termConverter = new TermToSMTLib2Converter()
   val translator = new ExpressionTranslator {


### PR DESCRIPTION
Assembling a fat JAR containing our tests currently fails in ViperServer because Carbon and Silicon both have a class QuantifierWeightTests. This PR address this issue by making the test classes' names unique.

See [Carbon #450](https://github.com/viperproject/carbon/pull/450)