### PR TITLE
Added smoke check when trying to produce a multi-part assertion with a unit snapshot

### DIFF
--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -157,6 +157,9 @@ object producer extends ProductionRules {
           wrappedProduceTlc(s, sf0, a, pve, v)((s1, v1) =>
             produceTlcs(s1, sf1, as.tail, pves.tail, v1)(Q))
         } catch {
+          // We will get an IllegalArgumentException from createSnapshotPair if sf(...) returns Unit.
+          // This should never happen if we're in a reachable state, so here we check for that
+          // (without timeout, since there is no fallback) and stop verifying the current branch.
           case _: IllegalArgumentException if v.decider.check(False(), 0) =>
             Unreachable()
         }

--- a/src/main/scala/supporters/SnapshotSupporter.scala
+++ b/src/main/scala/supporters/SnapshotSupporter.scala
@@ -127,7 +127,9 @@ class DefaultSnapshotSupporter(symbolConverter: SymbolConverter) extends Snapsho
      * to use First(snap)/Second(snap) as the default.
      */
 
-    assert(snap != Unit, "Unit snapshot cannot be decomposed")
+    if (snap == Unit) {
+      throw new IllegalArgumentException("Unit snapshot cannot be decomposed")
+    }
 
     val (snap0, snap1, snapshotEq) =
       /* // [2019-12-22 Malte] Old code kept for documentation purposes


### PR DESCRIPTION
@jcp19 found an example where Silicon tries to produce a multi-part assertion with a unit snapshot, and then throws a runtime error when splitting the unit snapshot into two parts.
The reason, I *think*, is that the branch this happened on was dead, Silicon noticed this while consuming the assertion and this resulted in a smaller-than-expected snapshot (though I'm not sure which part of Silicon would do that; maybe consumeFromMultipleHeaps?) .
This PR just adds a check if we're in this situation and the current branch is dead, and if that is the case, just finishes verification before we can run into the error.
