### PR TITLE
Fix issue #688

### DIFF
--- a/src/main/scala/decider/PathConditions.scala
+++ b/src/main/scala/decider/PathConditions.scala
@@ -46,7 +46,7 @@ trait PathConditionStack extends RecordedPathConditions {
   def pushScope(): Unit
   def popScope(): Unit
   def mark(): Mark
-  def popLayersAndRemoveMark(mark: Mark): Unit
+  def popUntilMark(mark: Mark): Unit
   def after(mark: Mark): RecordedPathConditions
   def isEmpty: Boolean
   def duplicate(): PathConditionStack
@@ -273,7 +273,12 @@ private[decider] class LayeredPathConditionStack
     mark
   }
 
-  def popLayersAndRemoveMark(mark: Mark): Unit = {
+  def popUntilMark(mark: Mark): Unit = {
+    assert(markToLength.contains(mark), "Cannot pop unknown mark")
+    popLayersAndRemoveMark(mark)
+  }
+
+  private def popLayersAndRemoveMark(mark: Mark): Unit = {
     val targetLength = markToLength(mark)
     val dropLength = layers.length - targetLength
 

--- a/src/main/scala/decider/PathConditions.scala
+++ b/src/main/scala/decider/PathConditions.scala
@@ -46,6 +46,7 @@ trait PathConditionStack extends RecordedPathConditions {
   def pushScope(): Unit
   def popScope(): Unit
   def mark(): Mark
+  def popLayersAndRemoveMark(mark: Mark): Unit
   def after(mark: Mark): RecordedPathConditions
   def isEmpty: Boolean
   def duplicate(): PathConditionStack
@@ -272,7 +273,7 @@ private[decider] class LayeredPathConditionStack
     mark
   }
 
-  private def popLayersAndRemoveMark(mark: Mark): Unit = {
+  def popLayersAndRemoveMark(mark: Mark): Unit = {
     val targetLength = markToLength(mark)
     val dropLength = layers.length - targetLength
 

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1309,7 +1309,7 @@ object evaluator extends EvaluationRules {
         Success()})
 
     // Pop back layer that was introduced when setting preMark layer above.
-    v.decider.pcs.popScope()
+    v.decider.pcs.popLayersAndRemoveMark(preMark)
 
     (r, optRemainingTriggerTerms) match {
       case (Success(), Some(remainingTriggerTerms)) =>

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1312,7 +1312,7 @@ object evaluator extends EvaluationRules {
     // IF trigger evaluation was successful, we will assume them again (see success case below).
     // However, they need to be removed for now since they would otherwise be assumed unconditionally
     // (since the preMark layer has no branch conditions), and we can assume them only conditionally.
-    // See issue #668 for an example of what happens otherwise.
+    // See issue #688 for an example of what happens otherwise.
     v.decider.pcs.popUntilMark(preMark)
 
     (r, optRemainingTriggerTerms) match {

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1308,8 +1308,12 @@ object evaluator extends EvaluationRules {
         pcDelta = v1.decider.pcs.after(preMark).assumptions //decider.π -- πPre
         Success()})
 
-    // Pop back layer that was introduced when setting preMark layer above.
-    v.decider.pcs.popLayersAndRemoveMark(preMark)
+    // Remove all assumptions resulting from evaluating the trigger.
+    // IF trigger evaluation was successful, we will assume them again (see success case below).
+    // However, they need to be removed for now since they would otherwise be assumed unconditionally
+    // (since the preMark layer has no branch conditions), and we can assume them only conditionally.
+    // See issue #668 for an example of what happens otherwise.
+    v.decider.pcs.popUntilMark(preMark)
 
     (r, optRemainingTriggerTerms) match {
       case (Success(), Some(remainingTriggerTerms)) =>

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1266,6 +1266,7 @@ object evaluator extends EvaluationRules {
      */
 
     var optRemainingTriggerTerms: Option[Seq[Term]] = None
+    // Setting a mark pushes a scope that needs to be popped again later, see below.
     val preMark = v.decider.setPathConditionMark()
     var pcDelta = InsertionOrderedSet.empty[Term]
 
@@ -1306,6 +1307,9 @@ object evaluator extends EvaluationRules {
         optRemainingTriggerTerms = Some(remainingTriggerTerms)
         pcDelta = v1.decider.pcs.after(preMark).assumptions //decider.π -- πPre
         Success()})
+
+    // Pop back layer that was introduced when setting preMark layer above.
+    v.decider.pcs.popScope()
 
     (r, optRemainingTriggerTerms) match {
       case (Success(), Some(remainingTriggerTerms)) =>


### PR DESCRIPTION
Fixes issue #688. The problem in that issue is that when consuming a QP with an unsatisfiable condition, trigger evaluation results in more unsatisfiable assumptions. This is no problem if these assumptions are assumed conditionally under the quantifier condition, but they were not:
Since they were part of a path condition layer that did not contain the branch condition (this layer is introduced specifically before trigger evaluation to be able to identify the newly-added assumptions), they were assumed unconditionally, which is unsound.

This PR removed the new layer and all its assumptions after trigger evaluation. They are then assumed again only if the trigger could be evaluated successfully, but crucially, on the layer that contains the branch condition, so they will be assumed conditionally.