### PR TITLE
Recording some definitions for higher depth

### DIFF
--- a/src/main/scala/supporters/functions/FunctionRecorder.scala
+++ b/src/main/scala/supporters/functions/FunctionRecorder.scala
@@ -140,15 +140,15 @@ case class ActualFunctionRecorder(private val _data: FunctionData,
   }
 
   def recordFvfAndDomain(fvfDef: SnapshotMapDefinition): ActualFunctionRecorder =
-    if (depth <= 1) copy(freshFvfsAndDomains = freshFvfsAndDomains + fvfDef)
+    if (depth <= 2) copy(freshFvfsAndDomains = freshFvfsAndDomains + fvfDef)
     else this
 
   def recordFieldInv(inv: InverseFunctions): ActualFunctionRecorder =
-    if (depth <= 1) copy(freshFieldInvs = freshFieldInvs + inv)
+    if (depth <= 2) copy(freshFieldInvs = freshFieldInvs + inv)
     else this
 
   def recordArp(arp: Var, constraint: Term): ActualFunctionRecorder =
-    if (depth <= 1) copy(freshArps = freshArps + ((arp, constraint)))
+    if (depth <= 2) copy(freshArps = freshArps + ((arp, constraint)))
     else this
 
   def recordFreshSnapshot(snap: Function): ActualFunctionRecorder =


### PR DESCRIPTION
Silicon's FunctionRecorder only records definitions up to a depth of 1. The reason for this is outlined in the code. However, when using moreCompleteExhale to verify functions, this is no longer sufficient in very rare cases (there is a SCION example that crashes as a result of this). So we increment it to two.