### PR TITLE
Resetting scaling factor after folding quantified predicate

### DIFF
--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -93,6 +93,7 @@ object predicateSupporter extends PredicateSupportRules {
         val s3 = s2.copy(g = s.g,
                          h = h3,
                          smCache = smCache,
+                         permissionScalingFactor = s.permissionScalingFactor,
                          functionRecorder = s2.functionRecorder.recordFvfAndDomain(smDef))
         Q(s3, v1)
       } else {


### PR DESCRIPTION
Fixes issue #695: Permission scaling was not reset after folding a predicate that is used in a QP somewhere.