### PR TITLE
Function application as QP hints

### DIFF
--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1723,7 +1723,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       arguments.flatMap {
         case SeqAt(seq, _) => Some(seq)
         case MapLookup(map, _) => Some(map)
-        // TODO: Add a case for (domain or heap-dep.) function applications, i.e. fun(_)
+        case App(f, _) => Some(AppHint(f))
         case _ => None
       }
 

--- a/src/main/scala/state/Terms.scala
+++ b/src/main/scala/state/Terms.scala
@@ -245,6 +245,13 @@ object App extends ((Applicable, Seq[Term]) => App) {
 }
 
 /*
+ * Applicable without arguments, only to be used as a hint for quantified chunks.
+ */
+case class AppHint(applicable: Applicable) extends Term {
+  val sort = applicable.resultSort
+}
+
+/*
  * Terms
  */
 


### PR DESCRIPTION
Adding function applications of all kinds as possible QP hints, using a new kind of hint term that is just an application without arguments (since the arguments might depend on the quantified variable).