### PR TITLE
Report errors early with --parallelizeBranches

### DIFF
--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -311,7 +311,7 @@ class DefaultMainVerifier(config: Config,
           qpMagicWands = quantifiedMagicWands,
           predicateSnapMap = predSnapGenerator.snapMap,
           predicateFormalVarMap = predSnapGenerator.formalVarMap,
-          isMethodVerification = member.isInstanceOf[ast.Member],
+          currentMember = Some(member),
           heapDependentTriggers = resourceTriggers,
           moreCompleteExhale = Verifier.config.exhaleMode == ExhaleMode.MoreComplete)
   }
@@ -326,6 +326,7 @@ class DefaultMainVerifier(config: Config,
 
     State(
       program = program,
+      currentMember = None,
       functionData = functionData,
       predicateData = predicateData,
       qpFields = quantifiedFields,


### PR DESCRIPTION
When using option --parallelizeBranches, Silicon always verifies all paths in the program, whereas without it, it usually stops after finding an error in the current method. As a result, using --parallelizeBranches can be disadvantageous, since errors are reported only when the whole method with all its paths has been checked.

This PR modifies Silicon such that errors are reported via EntityFailureMessages through the Reporter interface as soon as they are found when using --parallelizeBranches.