### PR TITLE
Fix silver's issue #688

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -290,8 +290,11 @@ object evaluator extends EvaluationRules {
             evalInOldState(s, lbl, e0, pve, v)(Q)}
 
       case ast.Let(x, e0, e1) =>
-        eval(s, e0, pve, v)((s1, t0, v1) =>
-          eval(s1.copy(g = s1.g + (x.localVar, t0)), e1, pve, v1)(Q))
+        eval(s, e0, pve, v)((s1, t0, v1) => {
+          val t = v.decider.fresh(x.name, v.symbolConverter.toSort(x.typ))
+          v.decider.assume(t === t0)
+          eval(s1.copy(g = s1.g + (x.localVar, t)), e1, pve, v1)(Q)
+        })
 
       /* Strict evaluation of AND */
       case ast.And(e0, e1) if Verifier.config.disableShortCircuitingEvaluations() =>

--- a/src/main/scala/state/Terms.scala
+++ b/src/main/scala/state/Terms.scala
@@ -2447,7 +2447,7 @@ object Let extends CondFlyweightTermFactory[(Map[Var, Term], Term), Let] {
   def apply(v: Var, t: Term, body: Term): Term = apply(Map(v -> t), body)
   def apply(vs: Seq[Var], ts: Seq[Term], body: Term): Term = apply(toMap(vs zip ts), body)
 
-  override def apply(v0: (Map[Var, Term], Term)) = {
+  override def apply(v0: (Map[Var, Term], Term)): Term = {
     val (bindings, body) = v0
     if (bindings.isEmpty) body
     else createIfNonExistent(v0)


### PR DESCRIPTION
Closes https://github.com/viperproject/silver/issues/688

This PR makes sure that the RHS of a let binding will always reach the SMT solver, even if the corresponding LHS is never used. This is useful when the purpose of a let binding is just to provide triggering terms.