### PR TITLE
MCE annotation

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -7,7 +7,7 @@
 package viper.silicon.rules
 
 import viper.silver.ast
-import viper.silver.verifier.{CounterexampleTransformer, PartialVerificationError, TypecheckerWarning}
+import viper.silver.verifier.{CounterexampleTransformer, PartialVerificationError, VerifierWarning}
 import viper.silver.verifier.errors.{ErrorWrapperWithExampleTransformer, PreconditionInAppFalse}
 import viper.silver.verifier.reasons._
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
@@ -23,7 +23,7 @@ import viper.silicon.verifier.Verifier
 import viper.silicon.{Map, TriggerSets}
 import viper.silicon.interfaces.state.{ChunkIdentifer, NonQuantifiedChunk}
 import viper.silicon.logger.records.data.{CondExpRecord, EvaluateRecord, ImpliesRecord}
-import viper.silver.reporter.WarningsDuringTypechecking
+import viper.silver.reporter.WarningsDuringVerification
 import viper.silver.ast.WeightedQuantifier
 
 /* TODO: With the current design w.r.t. parallelism, eval should never "move" an execution
@@ -1349,8 +1349,8 @@ object evaluator extends EvaluationRules {
         Q(s, cachedTriggerTerms ++ remainingTriggerTerms, v)
       case _ =>
         for (e <- remainingTriggerExpressions)
-          v.reporter.report(WarningsDuringTypechecking(Seq(
-            TypecheckerWarning(s"Might not be able to use trigger $e, since it is not evaluated while evaluating the body of the quantifier", e.pos))))
+          v.reporter.report(WarningsDuringVerification(Seq(
+            VerifierWarning(s"Might not be able to use trigger $e, since it is not evaluated while evaluating the body of the quantifier", e.pos))))
         Q(s, cachedTriggerTerms, v)
     }
   }

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -32,8 +32,8 @@ import viper.silicon.utils.Counter
 import viper.silver.ast.{BackendType, Member}
 import viper.silver.ast.utility.rewriter.Traverse
 import viper.silver.cfg.silver.SilverCfg
-import viper.silver.reporter.{ConfigurationConfirmation, ExecutionTraceReport, Reporter, VerificationResultMessage, VerificationTerminationMessage, QuantifierChosenTriggersMessage, WarningsDuringTypechecking}
-import viper.silver.verifier.TypecheckerWarning
+import viper.silver.reporter.{AnnotationWarning, ConfigurationConfirmation, ExecutionTraceReport, QuantifierChosenTriggersMessage, Reporter, VerificationResultMessage, VerificationTerminationMessage, WarningsDuringVerification}
+import viper.silver.verifier.VerifierWarning
 
 /* TODO: Extract a suitable MainVerifier interface, probably including
  *         - def verificationPoolManager: VerificationPoolManager)
@@ -166,13 +166,13 @@ class DefaultMainVerifier(config: Config,
         case forall: ast.Forall if forall.isPure =>
           val res = viper.silicon.utils.ast.autoTrigger(forall, forall.autoTrigger)
           if (res.triggers.isEmpty)
-            reporter.report(WarningsDuringTypechecking(Seq(TypecheckerWarning("No triggers provided or inferred for quantifier.", res.pos))))
+            reporter.report(WarningsDuringVerification(Seq(VerifierWarning("No triggers provided or inferred for quantifier.", res.pos))))
           reporter report QuantifierChosenTriggersMessage(res, res.triggers)
           res
         case exists: ast.Exists =>
           val res = viper.silicon.utils.ast.autoTrigger(exists, exists.autoTrigger)
           if (res.triggers.isEmpty)
-            reporter.report(WarningsDuringTypechecking(Seq(TypecheckerWarning("No triggers provided or inferred for quantifier.", res.pos))))
+            reporter.report(WarningsDuringVerification(Seq(VerifierWarning("No triggers provided or inferred for quantifier.", res.pos))))
           reporter report QuantifierChosenTriggersMessage(res, res.triggers)
           res
       }, Traverse.BottomUp)
@@ -303,6 +303,21 @@ class DefaultMainVerifier(config: Config,
       case r => r
     }
 
+    val mce = member.info.getUniqueInfo[ast.AnnotationInfo] match {
+      case Some(ai) if ai.values.contains("exhaleMode") =>
+        ai.values("exhaleMode") match {
+          case Seq("0") | Seq("greedy") =>
+            if (Verifier.config.counterexample.isSupplied)
+              reporter report AnnotationWarning(s"Member ${member.name} has exhaleMode annotation that may interfere with counterexample generation.")
+            false
+          case Seq("1") | Seq("mce") | Seq("moreCompleteExhale") => true
+          case v =>
+            reporter report AnnotationWarning(s"Member ${member.name} has invalid exhaleMode annotation value $v. Annotation will be ignored.")
+            Verifier.config.exhaleMode == ExhaleMode.MoreComplete
+        }
+      case _ => Verifier.config.exhaleMode == ExhaleMode.MoreComplete
+    }
+
     State(program = program,
           functionData = functionData,
           predicateData = predicateData,
@@ -313,7 +328,7 @@ class DefaultMainVerifier(config: Config,
           predicateFormalVarMap = predSnapGenerator.formalVarMap,
           currentMember = Some(member),
           heapDependentTriggers = resourceTriggers,
-          moreCompleteExhale = Verifier.config.exhaleMode == ExhaleMode.MoreComplete)
+          moreCompleteExhale = mce)
   }
 
   private def createInitialState(@unused cfg: SilverCfg,

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -306,7 +306,7 @@ class DefaultMainVerifier(config: Config,
     val mce = member.info.getUniqueInfo[ast.AnnotationInfo] match {
       case Some(ai) if ai.values.contains("exhaleMode") =>
         ai.values("exhaleMode") match {
-          case Seq("0") | Seq("greedy") =>
+          case Seq("0") | Seq("greedy") | Seq("2") | Seq("mceOnDemand") =>
             if (Verifier.config.counterexample.isSupplied)
               reporter report AnnotationWarning(s"Member ${member.name} has exhaleMode annotation that may interfere with counterexample generation.")
             false


### PR DESCRIPTION
Introduces an annotation to set the exhale mode for individual members, i.e., to override the mode set per command line parameter for this member.

The annotation is ``@exhaleMode("x")``, where ``x`` can be
- 0 or greedy to enable greedy mode
- 1 or mce or moreCompleteExhale to enable MCE

All other values (or multiple values) will result in a warning and the default will be used.
There will also be a warning when setting greedy mode per annotation when counterexamples are enables, since counterexamples generally don't work correctly with greedy mode.

Additionally, the PR changes type checker warnings that aren't type checker warnings to use a newly-added warning type (we were misusing type checker warnings previously because there were no verifier warnings).

Depends on a Silver PR that adds two new types of messages and also adds a test for the exhaleMode annotation. This PR must be merged before the quantifier weight annotation PR.