### PR TITLE
Re-enabling macros with API

### DIFF
--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1362,9 +1362,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       // ME: When using Z3 via API, it is beneficial to not use macros, since macro-terms will *always* be different
       // (leading to new terms that have to be translated), whereas without macros, we can usually use a term
       // that already exists.
+      // ME: Update: Actually, it seems better to use macros even with the API since Silicon terms can grow so large
+      // that e.g. the instantiate call in createPermissionConstraintAndDepletedCheck takes forever, before even
+      // converting to a Z3 term.
       // During function verification, we should not define macros, since they could contain resullt, which is not
       // defined elsewhere.
-      val declareMacro = s.functionRecorder == NoopFunctionRecorder && !Verifier.config.useFlyweight
+      val declareMacro = s.functionRecorder == NoopFunctionRecorder // && !Verifier.config.useFlyweight
 
       val permsProvided = ch.perm
       val permsTaken = if (declareMacro) {


### PR DESCRIPTION
Re-enabling macros with Z3 API. I thought these were not needed, since the size of the Z3 terms Silicon outputs does not matter in that setting. But it turns out (as I wrote in the comment) that the Silicon terms themselves can get so big that it becomes a problem, before any conversion to Z3 terms happen.