### PR TITLE
No longer ignoring assertTimeout for generating model 

### DIFF
--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -382,7 +382,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
     def statistics(): Map[String, String] = prover.statistics()
 
-    override def generateModel(): Unit = proverAssert(False, None)
+    override def generateModel(): Unit = proverAssert(False, Verifier.config.assertTimeout.toOption)
 
     override def getModel(): Model = prover.getModel()
 


### PR DESCRIPTION
Sometimes we have to generate an additional Z3 assert to generate a counterexample. Previously, this assert was always run without a timeout. As a result, this assert could lead to non-termination (if the Z3 assert does not terminate) even if ``assertTimeout`` is set.
This PR fixes that to use the assertTimeout for this assert.