### PR TITLE
Frontend API classes

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -14,7 +14,7 @@ import ch.qos.logback.classic.{Level, Logger}
 import com.typesafe.scalalogging.LazyLogging
 import org.slf4j.LoggerFactory
 import viper.silver.ast
-import viper.silver.frontend.{DefaultStates, SilFrontend}
+import viper.silver.frontend.{DefaultStates, MinimalViperFrontendAPI, SilFrontend, ViperFrontendAPI}
 import viper.silver.reporter._
 import viper.silver.verifier.{AbstractVerificationError => SilAbstractVerificationError, Failure => SilFailure, Success => SilSuccess, TimeoutOccurred => SilTimeoutOccurred, VerificationResult => SilVerificationResult, Verifier => SilVerifier}
 import viper.silicon.interfaces.Failure
@@ -376,6 +376,25 @@ class SiliconFrontend(override val reporter: Reporter,
     _config = siliconInstance.config
   }
 }
+
+/**
+  * Silicon "frontend" for use by actual Viper frontends.
+  * Performs consistency check and verification.
+  * See [[viper.silver.frontend.ViperFrontendAPI]] for usage information.
+  */
+class SiliconFrontendAPI(override val reporter: Reporter,
+                         override implicit val logger: Logger = ViperStdOutLogger("SiliconFrontendAPI", "INFO").get)
+  extends SiliconFrontend(reporter, logger) with ViperFrontendAPI
+
+/**
+  * Silicon "frontend" for use by actual Viper frontends.
+  * Performs only verification (no consistency check).
+  * See [[viper.silver.frontend.ViperFrontendAPI]] for usage information.
+  */
+class MinimalSiliconFrontendAPI(override val reporter: Reporter,
+                                override implicit val logger: Logger = ViperStdOutLogger("MinimalSiliconFrontendAPI", "INFO").get)
+  extends SiliconFrontend(reporter, logger) with MinimalViperFrontendAPI
+
 
 object SiliconRunner extends SiliconRunnerInstance {
   def main(args: Array[String]): Unit = {

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -382,18 +382,16 @@ class SiliconFrontend(override val reporter: Reporter,
   * Performs consistency check and verification.
   * See [[viper.silver.frontend.ViperFrontendAPI]] for usage information.
   */
-class SiliconFrontendAPI(override val reporter: Reporter,
-                         override implicit val logger: Logger = ViperStdOutLogger("SiliconFrontendAPI", "INFO").get)
-  extends SiliconFrontend(reporter, logger) with ViperFrontendAPI
+class SiliconFrontendAPI(override val reporter: Reporter)
+  extends SiliconFrontend(reporter) with ViperFrontendAPI
 
 /**
   * Silicon "frontend" for use by actual Viper frontends.
   * Performs only verification (no consistency check).
   * See [[viper.silver.frontend.ViperFrontendAPI]] for usage information.
   */
-class MinimalSiliconFrontendAPI(override val reporter: Reporter,
-                                override implicit val logger: Logger = ViperStdOutLogger("MinimalSiliconFrontendAPI", "INFO").get)
-  extends SiliconFrontend(reporter, logger) with MinimalViperFrontendAPI
+class MinimalSiliconFrontendAPI(override val reporter: Reporter)
+  extends SiliconFrontend(reporter) with MinimalViperFrontendAPI
 
 
 object SiliconRunner extends SiliconRunnerInstance {


### PR DESCRIPTION
Silicon versions of the new ``ViperFrontendAPI`` (see https://github.com/viperproject/silver/pull/732).