### PR TITLE
Remove restriction that disables MCE for function verification

### DIFF
--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -108,8 +108,7 @@ object chunkSupporter extends ChunkSupportRules {
         Q(s1, h, optCh.flatMap(ch => Some(ch.snap)), v1))
     } else {
       executionFlowController.tryOrFail2[Heap, Option[Term]](s.copy(h = h), v)((s1, v1, QS) =>
-        // 2022-05-07 MHS: MoreCompleteExhale isn't yet integrated into function verification, hence the limitation to method verification
-        if (s.isMethodVerification && s1.moreCompleteExhale) {
+        if (s1.moreCompleteExhale) {
           moreCompleteExhaleSupporter.consumeComplete(s1, s1.h, resource, args, perms, ve, v1)((s2, h2, snap2, v2) => {
             QS(s2.copy(h = s.h), h2, snap2, v2)
           })
@@ -206,7 +205,7 @@ object chunkSupporter extends ChunkSupportRules {
 
     executionFlowController.tryOrFail2[Heap, Term](s.copy(h = h), v)((s1, v1, QS) => {
       val lookupFunction =
-        if (s.isMethodVerification && s1.moreCompleteExhale) moreCompleteExhaleSupporter.lookupComplete _
+        if (s1.moreCompleteExhale) moreCompleteExhaleSupporter.lookupComplete _
         else lookupGreedy _
       lookupFunction(s1, s1.h, resource, args, ve, v1)((s2, tSnap, v2) =>
         QS(s2.copy(h = s.h), s2.h, tSnap, v2))

--- a/src/test/resources/moreCompleteExhale/disjunctiveAliasing.vpr
+++ b/src/test/resources/moreCompleteExhale/disjunctiveAliasing.vpr
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Int
+
+function fn(x: Ref, y: Ref, z: Ref): Int
+  requires acc(x.f) && acc(y.f)
+  requires (z == x) || (z == y)
+{
+  z.f
+}
+
+method m(x: Ref, y: Ref, z: Ref)
+  requires acc(x.f) && acc(y.f)
+  requires (z == x) || (z == y)
+{
+  var tmp: Int
+  tmp := z.f
+}
+


### PR DESCRIPTION
MCE was previously always disabled during function verification, presumably because at some point the MCE code did not yet record all its definitions in the FunctionRecorder, which would lead to Z3 complaining about undefined symbols being used. However, this has been fixed in the meantime, so we can actually enable MCE for function verification.

This does not break any code in the test suite or my usual test code (including SCION code), and it does give us more completeness during function verification, so this PR removes this restriction.