### PR TITLE
Opaque function annotation

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -773,7 +773,7 @@ object evaluator extends EvaluationRules {
                 case Some(a) if a.values.contains("opaque") =>
                   val funcAppAnn = fapp.info.getUniqueInfo[AnnotationInfo]
                   funcAppAnn match {
-                    case Some(a) if a.values.contains("useDef") => App(v3.symbolConverter.toFunction(func), snap1 :: tArgs)
+                    case Some(a) if a.values.contains("reveal") => App(v3.symbolConverter.toFunction(func), snap1 :: tArgs)
                     case _ => App(functionSupporter.limitedVersion(v3.symbolConverter.toFunction(func)), snap1 :: tArgs)
                   }
                 case _ => App(v3.symbolConverter.toFunction(func), snap1 :: tArgs)

--- a/src/main/scala/supporters/functions/FunctionData.scala
+++ b/src/main/scala/supporters/functions/FunctionData.scala
@@ -259,9 +259,13 @@ class FunctionData(val programFunction: ast.Function,
       val pre = preconditionFunctionApplication
       val nestedDefinitionalAxioms = generateNestedDefinitionalAxioms
       val body = And(nestedDefinitionalAxioms ++ List(Implies(pre, And(functionApplication === translatedBody))))
+      val funcAnn = programFunction.info.getUniqueInfo[ast.AnnotationInfo]
+      val actualPredicateTriggers = funcAnn match {
+        case Some(a) if a.values.contains("opaque") => Seq()
+        case _ => predicateTriggers.values.map(pt => Trigger(Seq(triggerFunctionApplication, pt)))
+      }
       val allTriggers = (
-           Seq(Trigger(functionApplication))
-        ++ predicateTriggers.values.map(pt => Trigger(Seq(triggerFunctionApplication, pt))))
+           Seq(Trigger(functionApplication)) ++ actualPredicateTriggers)
 
       Forall(arguments, body, allTriggers)})
   }

--- a/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
+++ b/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
@@ -133,7 +133,7 @@ class HeapAccessReplacingExpressionTranslator(symbolConverter: SymbolConverter,
           case Some(a) if a.values.contains("opaque") =>
             val funcAppAnn = eFApp.info.getUniqueInfo[AnnotationInfo]
             funcAppAnn match {
-              case Some(a) if a.values.contains("useDef") => symbolConverter.toFunction(silverFunc)
+              case Some(a) if a.values.contains("reveal") => symbolConverter.toFunction(silverFunc)
               case _ => functionSupporter.limitedVersion(symbolConverter.toFunction(silverFunc))
             }
           case _ => symbolConverter.toFunction(silverFunc)


### PR DESCRIPTION
Adds the ability to annotate functions as ``@opaque()``, which will result in the function body not being known by default. The precondition of the function will still aways be checked, and the postcondition of the function is always known.
Individual function applications can then be annotated with ``@reveal()`` to reveal the function definition for that specific usage. 

Example:
```
@opaque()
function isGreaterOne(i: Int): Bool
{ i > 1 }

method mDef(j: Int)
    requires j > -50
{
    assume isGreaterOne(j)
    assert j > 1 // fails
}

method mDef2(j: Int)
    requires j > -50
{
    assume @reveal() isGreaterOne(j)
    assert j > 1 // succeeds
}
```

Internally, applications of opaque functions are encoded using the existing limited version of the function. ``@reveal()`` forces the use of the normal version of the function that triggers the definitional axiom.