### PR TITLE
Disabling non-linear integer arithmetics

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -230,6 +230,12 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
+  val disableNLRI: ScallopOption[Boolean] = opt[Boolean]("disableNLRI",
+    descr = "Disable non-linear integer arithetics (prover must be Z3)",
+    default = Some(false),
+    noshort = true
+  )
+
   private val rawProverSaturationTimeout = opt[Int]("proverSaturationTimeout",
     descr = (  "Timeout (in ms) used for the prover's state saturation calls (default: 100). "
              + "A timeout of 0 disables all saturation checks."
@@ -811,6 +817,11 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
       Left(s"Option ${ideModeAdvanced.name} is not supported in combination with ${parallelizeBranches.name}")
     case other =>
       sys.error(s"Unexpected combination: $other")
+  }
+
+  validateOpt(disableNLRI, prover) {
+    case (Some(true), n) if n != Some(Z3ProverStdIO.name) => Left(s"Option ${disableNLRI.name} is only supported with prover ${Z3ProverStdIO.name}")
+    case _ => Right(())
   }
 
   validateOpt(counterexample, moreCompleteExhale, exhaleModeOption) {

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -820,8 +820,8 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
   }
 
   validateOpt(disableNL, prover) {
-    case (Some(true), n) if n != Some(Z3ProverStdIO.name) =>
-        Left(s"Option ${disableNL.name} is only supported with prover ${Z3ProverStdIO.name}")
+    case (Some(true), n) if (n != Some(Z3ProverStdIO.name) && n != Some(Z3ProverAPI.name)) =>
+        Left(s"Option ${disableNL.name} is only supported with Z3")
     case _ => Right(())
   }
 

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -230,7 +230,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
-  val disableNLRI: ScallopOption[Boolean] = opt[Boolean]("disableNLRI",
+  val disableNL: ScallopOption[Boolean] = opt[Boolean]("disableNL",
     descr = "Disable non-linear integer arithmetic when using Z3",
     default = Some(false),
     noshort = true
@@ -819,9 +819,9 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
       sys.error(s"Unexpected combination: $other")
   }
 
-  validateOpt(disableNLRI, prover) {
+  validateOpt(disableNL, prover) {
     case (Some(true), n) if n != Some(Z3ProverStdIO.name) =>
-        Left(s"Option ${disableNLRI.name} is only supported with prover ${Z3ProverStdIO.name}")
+        Left(s"Option ${disableNL.name} is only supported with prover ${Z3ProverStdIO.name}")
     case _ => Right(())
   }
 

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -231,7 +231,7 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
   )
 
   val disableNLRI: ScallopOption[Boolean] = opt[Boolean]("disableNLRI",
-    descr = "Disable non-linear integer arithetics (prover must be Z3)",
+    descr = "Disable non-linear integer arithmetic when using Z3",
     default = Some(false),
     noshort = true
   )

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -820,7 +820,8 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
   }
 
   validateOpt(disableNLRI, prover) {
-    case (Some(true), n) if n != Some(Z3ProverStdIO.name) => Left(s"Option ${disableNLRI.name} is only supported with prover ${Z3ProverStdIO.name}")
+    case (Some(true), n) if n != Some(Z3ProverStdIO.name) =>
+        Left(s"Option ${disableNLRI.name} is only supported with prover ${Z3ProverStdIO.name}")
     case _ => Right(())
   }
 

--- a/src/main/scala/decider/Z3ProverAPI.scala
+++ b/src/main/scala/decider/Z3ProverAPI.scala
@@ -135,6 +135,9 @@ class Z3ProverAPI(uniqueId: String,
       case (k, v) =>
         params.add(removeSmtPrefix(k), v)
     }
+    if (Verifier.config.disableNL.getOrElse(false)) {
+      params.add("arith.nl", false)
+    }
     val userProvidedArgs = Verifier.config.proverConfigArgs
     prover = ctx.mkSolver()
     val descrs = prover.getParameterDescriptions

--- a/src/main/scala/decider/Z3ProverStdIO.scala
+++ b/src/main/scala/decider/Z3ProverStdIO.scala
@@ -65,5 +65,11 @@ class Z3ProverStdIO(uniqueId: String,
     Paths.get(Verifier.config.z3Exe)
   }
 
-  override def emitSettings(contents: Iterable[String]): Unit = emit(contents)
+  override def emitSettings(contents: Iterable[String]): Unit = {
+    emit(contents)
+    if(Verifier.config.disableNLRI.getOrElse(false)) {
+      comment("We disable non-linear integer arithmetics")
+      writeLine(s"(set-option :smt.arith.nl false)")
+    }
+  }
 }

--- a/src/main/scala/decider/Z3ProverStdIO.scala
+++ b/src/main/scala/decider/Z3ProverStdIO.scala
@@ -68,7 +68,7 @@ class Z3ProverStdIO(uniqueId: String,
   override def emitSettings(contents: Iterable[String]): Unit = {
     emit(contents)
     if(Verifier.config.disableNLRI.getOrElse(false)) {
-      comment("We disable non-linear integer arithmetics")
+      comment("We disable non-linear integer arithmetic")
       writeLine(s"(set-option :smt.arith.nl false)")
       readSuccess()
     }

--- a/src/main/scala/decider/Z3ProverStdIO.scala
+++ b/src/main/scala/decider/Z3ProverStdIO.scala
@@ -67,7 +67,7 @@ class Z3ProverStdIO(uniqueId: String,
 
   override def emitSettings(contents: Iterable[String]): Unit = {
     emit(contents)
-    if(Verifier.config.disableNL.getOrElse(false)) {
+    if (Verifier.config.disableNL.getOrElse(false)) {
       comment("We disable non-linear integer arithmetic")
       writeLine(s"(set-option :smt.arith.nl false)")
       readSuccess()

--- a/src/main/scala/decider/Z3ProverStdIO.scala
+++ b/src/main/scala/decider/Z3ProverStdIO.scala
@@ -70,6 +70,7 @@ class Z3ProverStdIO(uniqueId: String,
     if(Verifier.config.disableNLRI.getOrElse(false)) {
       comment("We disable non-linear integer arithmetics")
       writeLine(s"(set-option :smt.arith.nl false)")
+      readSuccess()
     }
   }
 }

--- a/src/main/scala/decider/Z3ProverStdIO.scala
+++ b/src/main/scala/decider/Z3ProverStdIO.scala
@@ -67,7 +67,7 @@ class Z3ProverStdIO(uniqueId: String,
 
   override def emitSettings(contents: Iterable[String]): Unit = {
     emit(contents)
-    if(Verifier.config.disableNLRI.getOrElse(false)) {
+    if(Verifier.config.disableNL.getOrElse(false)) {
       comment("We disable non-linear integer arithmetic")
       writeLine(s"(set-option :smt.arith.nl false)")
       readSuccess()

--- a/src/test/resources/misc/disableNL.vpr
+++ b/src/test/resources/misc/disableNL.vpr
@@ -1,0 +1,7 @@
+method f(x: Int, y: Int) returns (res: Int)
+  requires 0 <= x <= 10
+  requires 0 <= y <= 10
+  ensures 0 <= res <= 100 // this fails with --disableNL
+{
+  res := x * y
+}


### PR DESCRIPTION
Adds a flag in silicon to disable non-linear integer arithmetics when Z3 via STDIO is used.