### PR TITLE
Adding an annotation to set prover arguments per method

### DIFF
--- a/src/main/scala/decider/ProverStdIO.scala
+++ b/src/main/scala/decider/ProverStdIO.scala
@@ -195,6 +195,15 @@ abstract class ProverStdIO(uniqueId: String,
     readSuccess()
   }
 
+  override def setOption(name: String, value: String): String = {
+    writeLine(s"(get-option :${name})")
+    val oldVal = readLine()
+    if (oldVal == "unsupported")
+      throw ProverInteractionFailed(uniqueId, s"Prover does not support option $name")
+    emit(s"(set-option :$name $value)")
+    oldVal
+  }
+
 //  private val quantificationLogger = bookkeeper.logfiles("quantification-problems")
 
   def assume(term: Term): Unit = {

--- a/src/main/scala/decider/Z3ProverAPI.scala
+++ b/src/main/scala/decider/Z3ProverAPI.scala
@@ -20,7 +20,7 @@ import java.nio.file.Path
 import scala.collection.mutable
 import com.microsoft.z3._
 import com.microsoft.z3.enumerations.Z3_param_kind
-import viper.silicon.reporting.ExternalToolError
+import viper.silicon.reporting.{ExternalToolError, ProverInteractionFailed}
 
 import scala.jdk.CollectionConverters.MapHasAsJava
 import scala.util.Random
@@ -234,6 +234,10 @@ class Z3ProverAPI(uniqueId: String,
       Z3ProverAPI.randomizeSeedsOptions.foreach(o => params.add(o, Random.nextInt(10000)))
       prover.setParameters(params)
     }
+  }
+
+  override def setOption(name: String, value: String): String = {
+    throw new ProverInteractionFailed(uniqueId, "Dynamically setting prover options via Z3 API is currently not supported.")
   }
 
   def assume(term: Term): Unit = {

--- a/src/main/scala/interfaces/decider/Prover.scala
+++ b/src/main/scala/interfaces/decider/Prover.scala
@@ -22,6 +22,7 @@ trait ProverLike {
   def emit(content: String): Unit
   def emit(contents: Iterable[String]): Unit = { contents foreach emit }
   def emitSettings(contents: Iterable[String]): Unit
+  def setOption(name: String, value: String): String
   def assume(term: Term): Unit
   def declare(decl: Decl): Unit
   def comment(content: String): Unit

--- a/src/main/scala/supporters/MethodSupporter.scala
+++ b/src/main/scala/supporters/MethodSupporter.scala
@@ -19,6 +19,7 @@ import viper.silicon.state.State.OldHeaps
 import viper.silicon.verifier.{Verifier, VerifierComponent}
 import viper.silicon.utils.freshSnap
 import viper.silver.reporter.AnnotationWarning
+import viper.silicon.{Map, toMap}
 
 /* TODO: Consider changing the DefaultMethodVerificationUnitProvider into a SymbolicExecutionRule */
 
@@ -45,22 +46,23 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
       logger.debug("\n\n" + "-" * 10 + " METHOD " + method.name + "-" * 10 + "\n")
       decider.prover.comment("%s %s %s".format("-" * 10, method.name, "-" * 10))
 
-      val toReset = method.info.getUniqueInfo[ast.AnnotationInfo] match {
+      val proverOptions: Map[String, String] = method.info.getUniqueInfo[ast.AnnotationInfo] match {
         case Some(ai) if ai.values.contains("proverArgs") =>
-          ai.values("proverArgs").flatMap(o => {
+          toMap(ai.values("proverArgs").flatMap(o => {
             val index = o.indexOf("=")
             if (index == -1) {
-              reporter report AnnotationWarning(s"Invalid proverArgs annotation ${o} on method ${method.name}. Required format for each option is optionName=value.")
+              reporter report AnnotationWarning(s"Invalid proverArgs annotation ${o} on method ${method.name}. " +
+                s"Required format for each option is optionName=value.")
               None
             } else {
               val (name, value) = (o.take(index), o.drop(index + 1))
-              val oldVal = v.decider.prover.setOption(name, value)
-              Some((name, oldVal))
+              Some((name, value))
             }
-          })
+          }))
         case _ =>
-          Seq()
+          Map.empty
       }
+      v.decider.setProverOptions(proverOptions)
 
       openSymbExLogger(method)
 
@@ -112,7 +114,7 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
                     consumes(s4, posts, postViolated, v4)((_, _, _) =>
                       Success()))}) }  )})})
 
-      toReset.foreach(o => v.decider.prover.setOption(o._1, o._2))
+      v.decider.resetProverOptions()
 
       symbExLog.closeMemberScope()
       Seq(result)

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -150,6 +150,11 @@ class DefaultMainVerifier(config: Config,
       decider.prover.emitSettings(contents)
       _verificationPoolManager.pooledVerifiers.emitSettings(contents)
     }
+
+    override def setOption(name: String, value: String): String = {
+      decider.prover.setOption(name, value)
+      _verificationPoolManager.pooledVerifiers.setOption(name, value)
+    }
   }
 
   /* Program verification */

--- a/src/main/scala/verifier/VerificationPoolManager.scala
+++ b/src/main/scala/verifier/VerificationPoolManager.scala
@@ -37,6 +37,9 @@ class VerificationPoolManager(mainVerifier: MainVerifier) extends StatefulCompon
 
     override def emitSettings(contents: Iterable[String]): Unit =
       workerVerifiers foreach (_.decider.prover.emitSettings(contents))
+
+    override def setOption(name: String, value: String): String =
+      (workerVerifiers map (_.decider.prover.setOption(name, value))).head
   }
 
   /* Verifier pool management */


### PR DESCRIPTION
Adding an annotation ``@proverArgs(key=value)`` to set prover configuration parameters per method.

Example usage: 

```
@proverArgs("smt.arith.nl=false")
method m2(i: Int, i2: Int)
    requires i >= 0
    requires i2 >= 0
{
    //:: ExpectedOutput(assert.failed:assertion.false)
    assert i * i2 >= 0
}
```