### PR TITLE
symbexlog: fix conditionExp for big and/or

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1620,7 +1620,7 @@ object evaluator extends EvaluationRules {
         case `stop` => Q(s1, t0, v1) // Done, if last expression was true/false for or/and (optimisation)
         case _ =>
           joiner.join[Term, Term](s1, v1)((s2, v2, QB) =>
-            brancher.branch(s2.copy(parallelizeBranches = false), t0, Some(viper.silicon.utils.ast.BigAnd(exps)), v2, fromShortCircuitingAnd = true) _ tupled swapIfAnd(
+            brancher.branch(s2.copy(parallelizeBranches = false), t0, Some(exps.head), v2, fromShortCircuitingAnd = true) _ tupled swapIfAnd(
               (s3, v3) => QB(s3.copy(parallelizeBranches = s2.parallelizeBranches), constructor(Seq(t0)), v3),
               (s3, v3) => evalSeqShortCircuit(constructor, s3.copy(parallelizeBranches = s2.parallelizeBranches), exps.tail, pve, v3)(QB))
             ){case Seq(ent) =>


### PR DESCRIPTION
Hi! Noticed that sometimes the wrong branch condition is reported in the symbolic execution log. The branching record can contain both the expression (silver) and the term (smt-ish) for the branch, we prefer to render the expression when possible.

What I did:
- Checked all usages of `MemberSymbExLogger.insertBranchPoint`; there's just two:
	- In `Executor`, but this doesn't report any condition expressions anyway;
	- In `brancher.branch`, where the `conditionExp` is passed in to the method.

At every usage of `brancher.branch` I checked that the `conditionExp` that is passed is exactly the expression evaluated for the term that is passed. That is: this was the only place it did not match.