### PR TITLE
Tests for Smoke Detection Plugin

### DIFF
--- a/src/test/scala/SiliconTestsSmokeDetection.scala
+++ b/src/test/scala/SiliconTestsSmokeDetection.scala
@@ -1,0 +1,13 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2022 ETH Zurich.
+
+package viper.silicon.tests
+
+class SiliconTestsSmokeDetection extends SiliconTests {
+  override val testDirectories: Seq[String] = Seq("smoke")
+
+  override val commandLineArguments: Seq[String] = Seq("--enableSmokeDetection")
+}


### PR DESCRIPTION
Adds a test suite which runs Silicon with smoke detection enabled on the tests for the plugin.