### PR TITLE
viper-data-collection changes

### DIFF
--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -24,6 +24,7 @@ import viper.silicon.verifier.DefaultMainVerifier
 import viper.silicon.decider.{Cvc5ProverStdIO, Z3ProverStdIO}
 import viper.silver.cfg.silver.SilverCfg
 import viper.silver.logger.ViperStdOutLogger
+import viper.silver.utility.{FileProgramSubmitter, ProgramSubmitter}
 
 import scala.util.chaining._
 
@@ -404,6 +405,9 @@ class SiliconRunnerInstance extends SiliconFrontend(StdIOReporter()) {
   def runMain(args: Array[String]): Unit = {
     var exitCode = 1 /* Only 0 indicates no error - we're pessimistic here */
 
+    val submitter = new FileProgramSubmitter(this)
+    submitter.setArgs(args)
+
     try {
       execute(ArraySeq.unsafeWrapArray(args))
         /* Will call SiliconFrontend.createVerifier and SiliconFrontend.configureVerifier */
@@ -452,6 +456,7 @@ class SiliconRunnerInstance extends SiliconFrontend(StdIOReporter()) {
          *       the process to kill has no input/output data left in the
          *       corresponding streams.
          */
+      submitter.submit()
     }
 
     sys.exit(exitCode)

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -24,7 +24,7 @@ import viper.silicon.verifier.DefaultMainVerifier
 import viper.silicon.decider.{Cvc5ProverStdIO, Z3ProverStdIO}
 import viper.silver.cfg.silver.SilverCfg
 import viper.silver.logger.ViperStdOutLogger
-import viper.silver.utility.{FileProgramSubmitter, ProgramSubmitter}
+import viper.silver.utility.{FileProgramSubmitter}
 
 import scala.util.chaining._
 


### PR DESCRIPTION
This PR should only be accepted after [this Silver PR](https://github.com/viperproject/silver/pull/766) has been merged and the Silver submodule in this repository has been updated. 

Added code to `SiliconRunnerInstance` to  submit programs which are verified through Silicon directly to the [viper-data-collection backend](https://github.com/viperproject/viper-data-collection). (`submitter.submit()` won’t do anything unless `—submitForEvaluation` is explicitly passed.)