### PR TITLE
Discard empty triggers and partially evaluated ones

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1287,7 +1287,7 @@ object evaluator extends EvaluationRules {
        *         incompletenesses because the corresponding quantifiers will not be triggered.
        */
 
-      Q(s1, tTriggersSets map Trigger, v1)})
+      Q(s1, tTriggersSets.filter(_.nonEmpty) map Trigger, v1)})
   }
 
   /** Evaluates the given list of trigger sets `eTriggerSets` (expressions) and passes the result
@@ -1404,7 +1404,7 @@ object evaluator extends EvaluationRules {
         for (e <- remainingTriggerExpressions)
           v.reporter.report(WarningsDuringVerification(Seq(
             VerifierWarning(s"Might not be able to use trigger $e, since it is not evaluated while evaluating the body of the quantifier", e.pos))))
-        Q(s, cachedTriggerTerms, v)
+        Q(s, Seq(), v)
     }
   }
 


### PR DESCRIPTION
Previously, when Silicon could not use a provided trigger (because it could not evaluate at least one of the trigger expressions), 
- it could end up emitting a trigger containing no terms at all
- it could end up emitting a trigger that contains a subset of the terms that should have been in it

The first issue seems to lead to weird behavior where Z3 seems to interpret the empty trigger as "pick a trigger yourself", or something else happened, but the result was that adding a trigger that could not be used made programs verify.
The second issue could lead to the trigger that is actually used being either invalid or more permissive than intended (because it was missing one or more terms). 

Since Silicon emits a warning when a trigger cannot be used (and thus the user knows they should change it), this PR changes the behavior s.t. empty or partially-usable triggers are discarded completely. 