### PR TITLE
Avoid using a quantifier for wildcard constraints for quantified resources

### DIFF
--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -387,6 +387,7 @@ object executor extends ExecutionRules {
               relevantChunks,
               Seq(`?r`),
               `?r` === tRcvr,
+              Some(Seq(tRcvr)),
               field,
               FullPerm,
               chunkOrderHeuristics,


### PR DESCRIPTION
... when that is possible because we actually know the value(s) of the quantified variable(s).

This addresses #816.