### PR TITLE
Find Z3 within PATH env

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -6,7 +6,7 @@
 
 package viper.silicon
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.{Files, Path, Paths}
 import scala.collection.immutable.ArraySeq
 import scala.util.matching.Regex
 import scala.util.Properties._
@@ -451,9 +451,19 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
   lazy val z3Exe: String = {
     val isWindows = System.getProperty("os.name").toLowerCase.startsWith("windows")
 
-    rawZ3Exe.toOption.getOrElse(
-      envOrNone(Z3ProverStdIO.exeEnvironmentalVariable)
-        .getOrElse("z3" + (if (isWindows) ".exe" else "")))
+    rawZ3Exe.toOption match {
+      case Some(exe) => exe
+      case None =>
+        Option(System getenv Z3ProverStdIO.exeEnvironmentalVariable) match {
+          case Some(exe) => exe
+          case None =>
+            val filename = "z3" + (if (isWindows) ".exe" else "")
+            System.getenv("PATH").split(if (isWindows) ";" else ":").find(dirname => Files.exists(Paths.get(dirname, filename))) match {
+              case Some(dirname) => Paths.get(dirname, filename).toString
+              case None => filename
+            }
+        }
+    }
   }
 
   private val rawCvc5Exe = opt[String]("cvc5Exe",

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -451,19 +451,15 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
   lazy val z3Exe: String = {
     val isWindows = System.getProperty("os.name").toLowerCase.startsWith("windows")
 
-    rawZ3Exe.toOption match {
-      case Some(exe) => exe
-      case None =>
-        Option(System getenv Z3ProverStdIO.exeEnvironmentalVariable) match {
-          case Some(exe) => exe
-          case None =>
-            val filename = "z3" + (if (isWindows) ".exe" else "")
-            System.getenv("PATH").split(if (isWindows) ";" else ":").find(dirname => Files.exists(Paths.get(dirname, filename))) match {
-              case Some(dirname) => Paths.get(dirname, filename).toString
-              case None => filename
-            }
+    rawZ3Exe.toOption.getOrElse({
+      Option(System getenv Z3ProverStdIO.exeEnvironmentalVariable).getOrElse({
+        val filename = "z3" + (if (isWindows) ".exe" else "")
+        System.getenv("PATH").split(if (isWindows) ";" else ":").find(dirname => Files.exists(Paths.get(dirname, filename))) match {
+          case Some(dirname) => Paths.get(dirname, filename).toString
+          case None => filename
         }
-    }
+      })
+    })
   }
 
   private val rawCvc5Exe = opt[String]("cvc5Exe",


### PR DESCRIPTION
Currently, when using Silicon one has to explicitly define the location of the Z3 binary. Either via the `--z3Exe` option or via the `Z3_EXE` environment variable. My contribution allows the user to have Z3 referenced via its PATH environment variable. This mimics the behavior of the shell. So when it is possible to run `z3 --version` on the command line, one should also be able to run Silicon without any further configuration.

Already set config values are observed before running the PATH lookup, so this PR does not change the behavior of existing setups.