### PR TITLE
Always use image functions for QPs

### DIFF
--- a/src/main/scala/rules/HavocSupporter.scala
+++ b/src/main/scala/rules/HavocSupporter.scala
@@ -26,7 +26,7 @@ object havocSupporter extends SymbolicExecutionRules {
   // should replace the snapshot. Different data is needed for `havoc` and `havocall`.
   // For more information, see `replacementCond`.
   sealed trait HavocHelperData
-  case class HavocallData(inverseFunctions: InverseFunctions) extends HavocHelperData
+  case class HavocallData(inverseFunctions: InverseFunctions, codomainQVars: Seq[Var], imagesOfCodomain: Seq[Term]) extends HavocHelperData
   case class HavocOneData(args: Seq[Term]) extends HavocHelperData
 
   /** Execute the statement `havoc c ==> R`, where c is a conditional expression and
@@ -130,8 +130,7 @@ object havocSupporter extends SymbolicExecutionRules {
           case false => createFailure(pve dueTo notInjectiveReason, v, s1)
           case true =>
             // Generate the inverse axioms
-            // TODO: Second return value (imagesOfCodomain) currently not used — OK?
-            val (inverseFunctions, _) = quantifiedChunkSupporter.getFreshInverseFunctions(
+            val (inverseFunctions, imagesOfCodomain) = quantifiedChunkSupporter.getFreshInverseFunctions(
               qvars = tVars,
               condition = tCond,
               invertibles = tArgs,
@@ -149,9 +148,9 @@ object havocSupporter extends SymbolicExecutionRules {
             // the HavocHelperData inside of a HavocAllData case.
             val newChunks =
               if (usesQPChunks(s1, resource))
-                havocQuantifiedResource(s1, tCond, resource, HavocallData(inverseFunctions), v1)
+                havocQuantifiedResource(s1, tCond, resource, HavocallData(inverseFunctions, codomainQVars, imagesOfCodomain), v1)
               else
-                havocNonQuantifiedResource(s1, tCond, resource, HavocallData(inverseFunctions), v1)
+                havocNonQuantifiedResource(s1, tCond, resource, HavocallData(inverseFunctions, codomainQVars, imagesOfCodomain), v1)
 
             Q(s1.copy(h = Heap(newChunks)), v1)
         }
@@ -291,9 +290,9 @@ object havocSupporter extends SymbolicExecutionRules {
       case HavocOneData(args) =>
         val eqs = And(chunkArgs.zip(args).map{ case (t1, t2) => t1 === t2 })
         And(lhs, eqs)
-      case HavocallData(inverseFunctions) =>
+      case HavocallData(inverseFunctions, codomainQVars, imagesOfCodomain) =>
         val replaceMap = inverseFunctions.qvarsToInversesOf(chunkArgs)
-        lhs.replace(replaceMap)
+        And(lhs.replace(replaceMap), And(imagesOfCodomain.map(_.replace(codomainQVars, chunkArgs))))
     }
   }
 

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -271,9 +271,15 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     val qvarsToInversesOfCodomain = inverseFunctions.qvarsToInversesOf(codomainQVars)
 
+    val receiverMatches =
+      And(
+        codomainQVars
+          .zip(arguments)
+          .map { case (x, a) => x === a }).replace(qvarsToInversesOfCodomain)
+
     val conditionalizedPermissions =
       Ite(
-        And(And(imagesOfCodomain), condition.replace(qvarsToInversesOfCodomain)),
+        And(And(imagesOfCodomain), receiverMatches, condition.replace(qvarsToInversesOfCodomain)),
         permissions.replace(qvarsToInversesOfCodomain),
         NoPerm)
 

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1666,7 +1666,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       inversesOfFcts(idx) = inv(invertibles)
       inversesOfCodomains(idx) = inv(codomainQVars)
 
-      if (qvar.sort != sorts.Int && qvar.sort != sorts.Ref) {
+      if (true) {
         // Types known to be infinite, thus there is no need to constrain the domain using image functions.
         val imgFun = v.decider.fresh("img", (additionalInvArgs map (_.sort)) ++ invertibles.map(_.sort), sorts.Bool)
         val img = (ts: Seq[Term]) => App(imgFun, additionalInvArgs ++ ts)

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1667,7 +1667,6 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       inversesOfFcts(idx) = inv(invertibles)
       inversesOfCodomains(idx) = inv(codomainQVars)
 
-      // Types known to be infinite, thus there is no need to constrain the domain using image functions.
       val imgFun = v.decider.fresh("img", (additionalInvArgs map (_.sort)) ++ invertibles.map(_.sort), sorts.Bool)
       val img = (ts: Seq[Term]) => App(imgFun, additionalInvArgs ++ ts)
 

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -271,15 +271,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     val qvarsToInversesOfCodomain = inverseFunctions.qvarsToInversesOf(codomainQVars)
 
-    val receiverMatches =
-      And(
-        codomainQVars
-          .zip(arguments)
-          .map { case (x, a) => x === a }).replace(qvarsToInversesOfCodomain)
-
     val conditionalizedPermissions =
       Ite(
-        And(And(imagesOfCodomain), receiverMatches, condition.replace(qvarsToInversesOfCodomain)),
+        And(And(imagesOfCodomain), condition.replace(qvarsToInversesOfCodomain)),
         permissions.replace(qvarsToInversesOfCodomain),
         NoPerm)
 
@@ -1666,19 +1660,13 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       inversesOfFcts(idx) = inv(invertibles)
       inversesOfCodomains(idx) = inv(codomainQVars)
 
-      if (true) {
-        // Types known to be infinite, thus there is no need to constrain the domain using image functions.
-        val imgFun = v.decider.fresh("img", (additionalInvArgs map (_.sort)) ++ invertibles.map(_.sort), sorts.Bool)
-        val img = (ts: Seq[Term]) => App(imgFun, additionalInvArgs ++ ts)
+      // Types known to be infinite, thus there is no need to constrain the domain using image functions.
+      val imgFun = v.decider.fresh("img", (additionalInvArgs map (_.sort)) ++ invertibles.map(_.sort), sorts.Bool)
+      val img = (ts: Seq[Term]) => App(imgFun, additionalInvArgs ++ ts)
 
-        imageFunctions(idx) = imgFun
-        imagesOfFcts(idx) = img(invertibles)
-        imagesOfCodomains(idx) = img(codomainQVars)
-      } else {
-        // imageFunctions(idx) remains null, will be filtered out later.
-        imagesOfFcts(idx) = True
-        imagesOfCodomains(idx) = True
-      }
+      imageFunctions(idx) = imgFun
+      imagesOfFcts(idx) = img(invertibles)
+      imagesOfCodomains(idx) = img(codomainQVars)
     }
 
     /* f_1(inv_1(rs), ..., inv_n(rs)), ...,  f_m(inv_1(rs), ..., inv_n(rs)) */

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1392,7 +1392,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       // converting to a Z3 term.
       // During function verification, we should not define macros, since they could contain resullt, which is not
       // defined elsewhere.
-      val declareMacro = false && s.functionRecorder == NoopFunctionRecorder // && !Verifier.config.useFlyweight
+      val declareMacro = s.functionRecorder == NoopFunctionRecorder // && !Verifier.config.useFlyweight
 
       val permsProvided = ch.perm
       val permsTaken = if (declareMacro) {

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1167,7 +1167,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                   case Complete() => rPerm
                   case Incomplete(remaining) => PermMinus(rPerm, remaining)
                 }
-                val (consumedChunk, _) = quantifiedChunkSupporter.createQuantifiedChunk(
+                val (consumedChunk, inverseFunctions) = quantifiedChunkSupporter.createQuantifiedChunk(
                   qvars,
                   condOfInvOfLoc,
                   resource,
@@ -1181,6 +1181,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                   v2,
                   s.program
                 )
+                v.decider.assume(FunctionPreconditionTransformer.transform(inverseFunctions.axiomInvertiblesOfInverses, s3.program))
+                v.decider.assume(inverseFunctions.axiomInvertiblesOfInverses)
                 val h2 = Heap(remainingChunks ++ otherChunks)
                 val s4 = s3.copy(smCache = smCache2,
                                  constrainableARPs = s.constrainableARPs)
@@ -1390,7 +1392,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       // converting to a Z3 term.
       // During function verification, we should not define macros, since they could contain resullt, which is not
       // defined elsewhere.
-      val declareMacro = s.functionRecorder == NoopFunctionRecorder // && !Verifier.config.useFlyweight
+      val declareMacro = false && s.functionRecorder == NoopFunctionRecorder // && !Verifier.config.useFlyweight
 
       val permsProvided = ch.perm
       val permsTaken = if (declareMacro) {


### PR DESCRIPTION
The current QP encoding is unsound for QPs that have trivial conditions and permission amounts that do not depend on the quantified variable(s), if the quantified variables are of type Int or Ref. Essentially, for such QPs, the encoding assumes that any receiver ``r`` can be mapped to some quantified value ``x`` s.t. the receiver ``e(x)`` is ``r``, which is obviously not always the case.

This PR fixes that by enforcing the use of image functions for all QPs (like in Carbon), i.e., by adding an explicit condition that for any reference ``r`` we only have permission to it if it is in the image of function ``e(x)``. This was previously only done when quantifying over types that might be finite (see PR #666). 

Additionally, this PR adjusts several parts in the QP and quasihavoc encoding that were previously not dealing with image functions correctly, which presumably wasn't noticed earlier because for many QPs image functions were not used, or because some tests may have relied on Silicon's unsoundness.

This fixes #833 