### PR TITLE
Fixing issue #842

### DIFF
--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -122,9 +122,9 @@ object consumer extends ConsumptionRules {
       if (tlcs.tail.isEmpty)
         wrappedConsumeTlc(s, h, a, pve, v)(Q)
       else
-        wrappedConsumeTlc(s, h, a, pve, v)((s1, h1, snap1, v1) =>
+        wrappedConsumeTlc(s, h, a, pve, v)((s1, h1, snap1, v1) => {
           consumeTlcs(s1, h1, tlcs.tail, pves.tail, v1)((s2, h2, snap2, v2) =>
-            Q(s2, h2, Combine(snap1, snap2), v2)))
+            Q(s2, h2, Combine(snap1, snap2), v2))})
     }
   }
 
@@ -234,8 +234,9 @@ object consumer extends ConsumptionRules {
         val optTrigger =
           if (forall.triggers.isEmpty) None
           else Some(forall.triggers)
+
         evalQuantified(s, Forall, forall.variables, Seq(cond), Seq(acc.perm, acc.loc.rcv), optTrigger, qid.name, pve, v) {
-          case (s1, qvars, Seq(tCond), Seq(tPerm, tRcvr), tTriggers, (auxGlobals, auxNonGlobals), v1) =>
+          case (s1, qvars, Seq(tCond), Some((Seq(tPerm, tRcvr), tTriggers, (auxGlobals, auxNonGlobals))), v1) =>
             quantifiedChunkSupporter.consume(
               s = s1,
               h = h,
@@ -255,6 +256,7 @@ object consumer extends ConsumptionRules {
               notInjectiveReason = QPAssertionNotInjective(acc.loc),
               insufficientPermissionReason = InsufficientPermission(acc.loc),
               v1)(Q)
+          case (s1, _, _, None, v1) => Q(s1, h, True, v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, acc: ast.PredicateAccessPredicate) =>
@@ -272,7 +274,7 @@ object consumer extends ConsumptionRules {
           if (forall.triggers.isEmpty) None
           else Some(forall.triggers)
         evalQuantified(s, Forall, forall.variables, Seq(cond), acc.perm +: acc.loc.args, optTrigger, qid.name, pve, v) {
-          case (s1, qvars, Seq(tCond), Seq(tPerm, tArgs @ _*), tTriggers, (auxGlobals, auxNonGlobals), v1) =>
+          case (s1, qvars, Seq(tCond), Some((Seq(tPerm, tArgs @ _*), tTriggers, (auxGlobals, auxNonGlobals))), v1) =>
             quantifiedChunkSupporter.consume(
               s = s1,
               h = h,
@@ -292,6 +294,7 @@ object consumer extends ConsumptionRules {
               notInjectiveReason = QPAssertionNotInjective(acc.loc),
               insufficientPermissionReason = InsufficientPermission(acc.loc),
               v1)(Q)
+          case (s1, _, _, None, v1) => Q(s1, h, True, v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, wand: ast.MagicWand) =>
@@ -304,7 +307,7 @@ object consumer extends ConsumptionRules {
         val ePerm = ast.FullPerm()()
         val tPerm = FullPerm
         evalQuantified(s, Forall, forall.variables, Seq(cond), bodyVars, optTrigger, qid, pve, v) {
-          case (s1, qvars, Seq(tCond), tArgs, tTriggers, (auxGlobals, auxNonGlobals), v1) =>
+          case (s1, qvars, Seq(tCond), Some((tArgs, tTriggers, (auxGlobals, auxNonGlobals))), v1) =>
             quantifiedChunkSupporter.consume(
               s = s1,
               h = h,
@@ -324,6 +327,7 @@ object consumer extends ConsumptionRules {
               notInjectiveReason = sys.error("Quantified wand not injective"), /*ReceiverNotInjective(...)*/
               insufficientPermissionReason = MagicWandChunkNotFound(wand), /*InsufficientPermission(...)*/
               v1)(Q)
+          case (s1, _, _, None, v1) => Q(s1, h, True, v1)
         }
 
       case ast.AccessPredicate(loc @ ast.FieldAccess(eRcvr, field), ePerm)

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1124,11 +1124,11 @@ object evaluator extends EvaluationRules {
                     (Q: (State,
                          Seq[Var], /* Variables from vars */
                          Seq[Term], /* Terms from es1 */
-                         Option[ /* None if es2 or trigger evaluation did not result in a term because es1 is unsatisfiable */
-                           (Seq[Term], /* Terms from es2 */
+                         Option[( /* None if es2 or trigger evaluation did not result in a term because es1 is unsatisfiable */
+                            Seq[Term], /* Terms from es2 */
                             Seq[Trigger], /* Triggers from optTriggers */
-                            (Seq[Term], Seq[Quantification])) /* Global and non-global auxiliary assumptions */
-                         ],
+                            (Seq[Term], Seq[Quantification]) /* Global and non-global auxiliary assumptions */
+                         )],
                          Verifier) => VerificationResult)
                     : VerificationResult = {
 
@@ -1158,7 +1158,7 @@ object evaluator extends EvaluationRules {
               v3.decider.pcs.after(preMark).quantified(quant, tVars, tTriggers, s"$name-aux", isGlobal = false, bc)
             val additionalPossibleTriggers: Map[ast.Exp, Term] =
               if (s.recordPossibleTriggers) s5.possibleTriggers else Map()
-            es2AndTriggerTerms = Some((ts2, tTriggers, (auxGlobals, auxNonGlobalQuants), additionalPossibleTriggers)) // QB((s5, ts1, Some((ts2, tTriggers, (auxGlobals, auxNonGlobalQuants), additionalPossibleTriggers))))
+            es2AndTriggerTerms = Some((ts2, tTriggers, (auxGlobals, auxNonGlobalQuants), additionalPossibleTriggers))
             finalState = s5
             Success()
           })})

--- a/src/main/scala/rules/HavocSupporter.scala
+++ b/src/main/scala/rules/HavocSupporter.scala
@@ -104,7 +104,7 @@ object havocSupporter extends SymbolicExecutionRules {
       pve   = pve,
       v     = v)
     {
-      case (s1, tVars, Seq(tCond), tArgs, Seq(), _, v1) =>
+      case (s1, tVars, Seq(tCond), Some((tArgs, Seq(), _)), v1) =>
         // Seq() represents an empty list of Triggers
         // TODO: unnamed argument is (tAuxGlobal, tAux). How should these be handled?
 
@@ -154,6 +154,7 @@ object havocSupporter extends SymbolicExecutionRules {
 
             Q(s1.copy(h = Heap(newChunks)), v1)
         }
+      case (s1, _, _, None, v1) => Q(s1, v1)
     }
   }
 

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -411,7 +411,7 @@ object producer extends ProductionRules {
           if (forall.triggers.isEmpty) None
           else Some(forall.triggers)
         evalQuantified(s, Forall, forall.variables, Seq(cond), Seq(acc.loc.rcv, acc.perm), optTrigger, qid, pve, v) {
-          case (s1, qvars, Seq(tCond), Seq(tRcvr, tPerm), tTriggers, (auxGlobals, auxNonGlobals), v1) =>
+          case (s1, qvars, Seq(tCond), Some((Seq(tRcvr, tPerm), tTriggers, (auxGlobals, auxNonGlobals))), v1) =>
             val tSnap = sf(sorts.FieldValueFunction(v1.symbolConverter.toSort(acc.loc.field.typ), acc.loc.field.name), v1)
 //            v.decider.assume(PermAtMost(tPerm, FullPerm()))
             quantifiedChunkSupporter.produce(
@@ -432,6 +432,7 @@ object producer extends ProductionRules {
               QPAssertionNotInjective(acc.loc),
               v1
             )(Q)
+          case (s1, _, _, None, v1) => Q(s1, v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, acc: ast.PredicateAccessPredicate) =>
@@ -442,7 +443,7 @@ object producer extends ProductionRules {
           if (forall.triggers.isEmpty) None
           else Some(forall.triggers)
         evalQuantified(s, Forall, forall.variables, Seq(cond), acc.perm +: acc.loc.args, optTrigger, qid, pve, v) {
-          case (s1, qvars, Seq(tCond), Seq(tPerm, tArgs @ _*), tTriggers, (auxGlobals, auxNonGlobals), v1) =>
+          case (s1, qvars, Seq(tCond), Some((Seq(tPerm, tArgs @ _*), tTriggers, (auxGlobals, auxNonGlobals))), v1) =>
             val tSnap = sf(sorts.PredicateSnapFunction(s1.predicateSnapMap(predicate), predicate.name), v1)
             quantifiedChunkSupporter.produce(
               s1,
@@ -464,6 +465,7 @@ object producer extends ProductionRules {
               QPAssertionNotInjective(acc.loc),
               v1
             )(Q)
+          case (s1, _, _, None, v1) => Q(s1, v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, wand: ast.MagicWand) =>
@@ -474,7 +476,7 @@ object producer extends ProductionRules {
           else Some(forall.triggers)
         val qid = MagicWandIdentifier(wand, s.program).toString
         evalQuantified(s, Forall, forall.variables, Seq(cond), bodyVars, optTrigger, qid, pve, v) {
-          case (s1, qvars, Seq(tCond), tArgs, tTriggers, (auxGlobals, auxNonGlobals), v1) =>
+          case (s1, qvars, Seq(tCond), Some((tArgs, tTriggers, (auxGlobals, auxNonGlobals))), v1) =>
             val tSnap = sf(sorts.PredicateSnapFunction(sorts.Snap, qid), v1)
             quantifiedChunkSupporter.produce(
               s1,
@@ -496,6 +498,7 @@ object producer extends ProductionRules {
               QPAssertionNotInjective(wand),
               v1
             )(Q)
+          case (s1, _, _, None, v1) => Q(s1, v1)
         }
 
       case _: ast.InhaleExhaleExp =>


### PR DESCRIPTION
When producing or consuming a QP, ``evalQuantified`` first evaluates and assumes the QP's condition. This condition could of course be unsatisfiable, in which case producing or consuming the QP should not affect the state and verification should continue.

Currently, however, the following is possible:
- The QP's condition is unsatisfiable, thus ``evalQuantified`` locally assumes false (as it should)
- When evaluating the argument and permission amount expressions of the QP, a smoke check is triggered and succeeds, in which case no value is returned and the continuation of this evaluation is never invoked.
- Since the continuation of ``evalQuantified`` itself is invoked only from said continuation, verification just stops at this point, and any subsequent conjuncts are never produced/consumed and any subsequent statements never executed. This is obviously unsound (see issue #842 for an example), since only the path in the quantifier where its condition is true was unreachable, not the entire path the quantifier is on. 

This PR changes ``evalQuantified`` s.t. its continuation is always called, now with an optional result to tell the caller if the above scenario happened and the quantifier is therefore trivially satisfied.