### PR TITLE
Fixing issue #845

### DIFF
--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1287,7 +1287,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             codomainQVars,
             relevantChunks,
             v1,
-            optSmDomainDefinitionCondition = if (s2.smDomainNeeded) Some(True) else None,
+            optSmDomainDefinitionCondition = None,
             optQVarsInstantiations = Some(arguments))
         val permsTaken = result match {
           case Complete() => rPerm
@@ -1332,7 +1332,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               resource = resource,
               codomainQVars = codomainQVars,
               relevantChunks = relevantChunks,
-              optSmDomainDefinitionCondition = if (s1.smDomainNeeded) Some(True) else None,
+              optSmDomainDefinitionCondition = None,
               optQVarsInstantiations = Some(arguments),
               v = v)
           val s2 = s1.copy(functionRecorder = s1.functionRecorder.recordFvfAndDomain(smDef1),

--- a/src/main/scala/state/SnapshotMapCache.scala
+++ b/src/main/scala/state/SnapshotMapCache.scala
@@ -46,7 +46,8 @@ case class SnapshotMapCache private (
          : Option[SnapshotMapCache.Value] = {
 
     cache.get(key) match {
-      case Some((smDef, totalPermissions, `optSmDomainDefinitionCondition`)) =>
+      case Some((smDef, totalPermissions, cachedSmDomainDefinitionCondition))
+          if !(cachedSmDomainDefinitionCondition.contains(false) && !optSmDomainDefinitionCondition.contains(false)) =>
         Some((smDef, totalPermissions))
 
       case _ =>

--- a/src/main/scala/state/SnapshotMapCache.scala
+++ b/src/main/scala/state/SnapshotMapCache.scala
@@ -44,12 +44,11 @@ case class SnapshotMapCache private (
   def get(key: SnapshotMapCache.Key,
           optSmDomainDefinitionCondition: Option[Term] = None)
          : Option[SnapshotMapCache.Value] = {
+    val actualSmDomainDefinitionCondition = optSmDomainDefinitionCondition.getOrElse(terms.True)
 
     cache.get(key) match {
       case Some((smDef, totalPermissions, cachedSmDomainDefinitionCondition))
-          if cachedSmDomainDefinitionCondition == optSmDomainDefinitionCondition ||
-             cachedSmDomainDefinitionCondition.isEmpty ||
-             cachedSmDomainDefinitionCondition.contains(terms.True) =>
+          if cachedSmDomainDefinitionCondition.getOrElse(terms.True) == actualSmDomainDefinitionCondition =>
         Some((smDef, totalPermissions))
 
       case _ =>

--- a/src/main/scala/state/SnapshotMapCache.scala
+++ b/src/main/scala/state/SnapshotMapCache.scala
@@ -44,11 +44,12 @@ case class SnapshotMapCache private (
   def get(key: SnapshotMapCache.Key,
           optSmDomainDefinitionCondition: Option[Term] = None)
          : Option[SnapshotMapCache.Value] = {
-    val actualSmDomainDefinitionCondition = optSmDomainDefinitionCondition.getOrElse(terms.True)
 
     cache.get(key) match {
       case Some((smDef, totalPermissions, cachedSmDomainDefinitionCondition))
-          if cachedSmDomainDefinitionCondition.getOrElse(terms.True) == actualSmDomainDefinitionCondition =>
+          if cachedSmDomainDefinitionCondition == optSmDomainDefinitionCondition ||  // defined under the same condition
+            (cachedSmDomainDefinitionCondition.contains(terms.True) && optSmDomainDefinitionCondition.isEmpty) // cached is always defined and we don't need a domain
+            =>
         Some((smDef, totalPermissions))
 
       case _ =>

--- a/src/main/scala/state/SnapshotMapCache.scala
+++ b/src/main/scala/state/SnapshotMapCache.scala
@@ -47,7 +47,9 @@ case class SnapshotMapCache private (
 
     cache.get(key) match {
       case Some((smDef, totalPermissions, cachedSmDomainDefinitionCondition))
-          if !(cachedSmDomainDefinitionCondition.contains(false) && !optSmDomainDefinitionCondition.contains(false)) =>
+          if cachedSmDomainDefinitionCondition == optSmDomainDefinitionCondition ||
+             cachedSmDomainDefinitionCondition.isEmpty ||
+             cachedSmDomainDefinitionCondition.contains(terms.True) =>
         Some((smDef, totalPermissions))
 
       case _ =>


### PR DESCRIPTION
- When we need a snapshot map without a domain, we can take a cached one that does have a domain if the domain condition is true
- When we create a new snapshot map to define the snapshot of consuming a single location, it does not need a domain.

Fixes #845 and #844.