### PR TITLE
Not pushing conditions using permission introspection further in

### DIFF
--- a/src/test/resources/conditionalizePermissions/carbon_0179.vpr
+++ b/src/test/resources/conditionalizePermissions/carbon_0179.vpr
@@ -1,0 +1,19 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+predicate P1(r$: Ref)
+
+predicate P3(r$: Ref)
+
+method test2()
+{
+    var b: Ref
+    var k: Perm
+
+    inhale acc(P1(b))
+    inhale acc(P3(b))
+
+    exhale perm(P3(b)) >= write ? acc(P3(b)) : (perm(P1(b)) > none ? acc(P1(b), write - perm(P3(b))) : true)
+
+    assert perm(P1(b)) == write
+}

--- a/src/test/resources/conditionalizePermissions/let.vpr
+++ b/src/test/resources/conditionalizePermissions/let.vpr
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Int
+
+function ok(): Bool
+
+
+function val(): Ref
+    requires ok()
+
+method test()
+{
+    inhale ok() ==> let x == (val()) in acc(x.f)
+}

--- a/src/test/resources/conditionalizePermissions/let.vpr
+++ b/src/test/resources/conditionalizePermissions/let.vpr
@@ -11,5 +11,8 @@ function val(): Ref
 
 method test()
 {
+    // Test that the condition is not pushed inside the let expression to get e.g.
+    // inhale let x == (val()) in acc(x.f, ok() ? write : none)
+    // which would not be well-defined.
     inhale ok() ==> let x == (val()) in acc(x.f)
 }

--- a/src/test/resources/conditionalizePermissions/silicon_0008.vpr
+++ b/src/test/resources/conditionalizePermissions/silicon_0008.vpr
@@ -1,0 +1,15 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+field f: Int
+
+method deAlias(x: Ref, y: Ref, k: Perm)
+  requires k >= none
+  requires acc(x.f, k) && acc(y.f, k)
+  // The following postcondition should fail in default greedy Silicon because --conditionalizePermissions creates a
+  // situation where the two chunks may or may not alias in the same branch, so they cannot definitively be merged,
+  // so greedy Silicon cannot prove the postcondition using any individual chunk.
+  //:: ExpectedOutput(postcondition.violated:insufficient.permission)
+  ensures x == y ==> acc(x.f, 2 * k)
+{}

--- a/src/test/resources/conditionalizePermissions/silicon_0713.vpr
+++ b/src/test/resources/conditionalizePermissions/silicon_0713.vpr
@@ -1,0 +1,27 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+field int: Int
+field unrelated: Int
+
+method conv_layer(a: Set[Ref])
+  requires (forall r: Ref :: r in a ==> acc(r.int, write))
+{
+  label beforeFrame
+  while (true)
+    invariant true ==>
+      (forall r: Ref :: r in a ==> acc(r.int, write)) &&
+      [
+        // on inhale
+        (forperm
+          obj: Ref [obj.unrelated] :: obj.unrelated ==
+          old[beforeFrame](obj.unrelated)) &&
+        (forperm
+          obj: Ref [obj.int] :: obj.int == old[beforeFrame](obj.int)),
+
+        // on exhale
+        true
+      ]
+  { inhale false }
+}

--- a/src/test/resources/conditionalizePermissions/welldef.vpr
+++ b/src/test/resources/conditionalizePermissions/welldef.vpr
@@ -1,0 +1,16 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+field f: Int
+
+function ok(): Bool
+
+
+function val(): Ref
+    requires ok()
+
+
+method test()
+{
+    inhale ok() ==> acc(val().f)
+}

--- a/src/test/scala/SiliconTestsConditionalizePermissions.scala
+++ b/src/test/scala/SiliconTestsConditionalizePermissions.scala
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2022 ETH Zurich.
+
+package viper.silicon.tests
+
+class SiliconTestsConditionalizePermissions extends SiliconTests {
+  override val testDirectories: Seq[String] = Seq("conditionalizePermissions")
+
+ override val commandLineArguments: Seq[String] = Seq(
+    "--timeout", "300" /* seconds */,
+    "--conditionalizePermissions")
+}


### PR DESCRIPTION
The ``--conditionalizePermissions`` command line option rewrites implications and ternary expressions to avoid branching. 
The general pattern is that ``e1 ==> acc(e2.f, e3)`` is rewritten to ``acc(e2.f, e1 ? e3 : none``. 

This rewriting is not always sound if the condition (``e1`` in this case) uses permission introspection.
Example:
```
inhale P1(x)
exhale perm(P1(x)) >= write ==> (P1(x) && P1(x))
```
must not be rewritten to
```
inhale P1(x)
exhale acc(P1(x), perm(P1(x)) >= write ? write : none) && acc(P1(x), perm(P1(x)) >= write ? write : none)
```
since the value of ``perm(P1(x)) >= write`` changes.

This PR conservatively prevents any rewriting where the condition contains ``perm`` or ``forperm``.
This fixes one issue mentioned in #851.