### PR TITLE
Supporting MWSF in Z3 API

### DIFF
--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -181,7 +181,11 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     override def getProverOptions(): Map[String, String] = _proverOptions
 
     override def resetProverOptions(): Unit = {
-      _proverResetOptions.foreach { case (k, v) => _prover.setOption(k, v) }
+      try {
+        _proverResetOptions.foreach { case (k, v) => _prover.setOption(k, v) }
+      } catch {
+        case e: Exception => println(e)
+      }
       _proverResetOptions = Map.empty
       _proverOptions = Map.empty
     }
@@ -204,6 +208,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       _declaredFreshMacros = Vector.empty
       _freshMacroStack = Stack.empty
       _freshFunctionStack = Stack.empty
+      _proverOptions = Map.empty
     }
 
     def stop(): Unit = {

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -181,11 +181,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     override def getProverOptions(): Map[String, String] = _proverOptions
 
     override def resetProverOptions(): Unit = {
-      try {
-        _proverResetOptions.foreach { case (k, v) => _prover.setOption(k, v) }
-      } catch {
-        case e: Exception => println(e)
-      }
+      _proverResetOptions.foreach { case (k, v) => _prover.setOption(k, v) }
       _proverResetOptions = Map.empty
       _proverOptions = Map.empty
     }

--- a/src/main/scala/decider/TermToZ3APIConverter.scala
+++ b/src/main/scala/decider/TermToZ3APIConverter.scala
@@ -128,6 +128,7 @@ class TermToZ3APIConverter
 
       case sorts.FieldPermFunction() => ctx.mkUninterpretedSort("$FPM") // text("$FPM")
       case sorts.PredicatePermFunction() => ctx.mkUninterpretedSort("$PPM") // text("$PPM")
+      case sorts.MagicWandSnapFunction => ctx.mkUninterpretedSort("$MWSF")
     }
     sortCache.update(s, res)
     res
@@ -159,6 +160,7 @@ class TermToZ3APIConverter
 
       case sorts.FieldPermFunction() => Some(ctx.mkSymbol("$FPM")) // text("$FPM")
       case sorts.PredicatePermFunction() => Some(ctx.mkSymbol("$PPM")) // text("$PPM")
+      case sorts.MagicWandSnapFunction => Some(ctx.mkSymbol("$MWSF"))
     }
   }
 


### PR DESCRIPTION
PR #836 added Magic Wand Snapshot Functions but did not extend the Z3 API to support them. This PR adds that support.

The issue was found by @mlimbeck.

Also fixing prover options reset in test suite, which prevented the test suite from running properly with Z3 API once a Z3 option was set via an annotation once.