### PR TITLE
Consolidating quantified field and predicate chunks

### DIFF
--- a/src/main/scala/interfaces/state/Chunks.scala
+++ b/src/main/scala/interfaces/state/Chunks.scala
@@ -20,7 +20,6 @@ trait GeneralChunk extends Chunk {
   def applyCondition(newCond: Term): GeneralChunk
   def permMinus(perm: Term): GeneralChunk
   def permPlus(perm: Term): GeneralChunk
-  def withPerm(perm: Term): GeneralChunk
 }
 
 trait NonQuantifiedChunk extends GeneralChunk {
@@ -29,7 +28,7 @@ trait NonQuantifiedChunk extends GeneralChunk {
   override def applyCondition(newCond: Term): NonQuantifiedChunk
   override def permMinus(perm: Term): NonQuantifiedChunk
   override def permPlus(perm: Term): NonQuantifiedChunk
-  override def withPerm(perm: Term): NonQuantifiedChunk
+  def withPerm(perm: Term): NonQuantifiedChunk
   def withSnap(snap: Term): NonQuantifiedChunk
 }
 
@@ -40,6 +39,5 @@ trait QuantifiedChunk extends GeneralChunk {
   override def applyCondition(newCond: Term): QuantifiedChunk
   override def permMinus(perm: Term): QuantifiedChunk
   override def permPlus(perm: Term): QuantifiedChunk
-  override def withPerm(perm: Term): QuantifiedChunk
   def withSnapshotMap(snap: Term): QuantifiedChunk
 }

--- a/src/main/scala/interfaces/state/Chunks.scala
+++ b/src/main/scala/interfaces/state/Chunks.scala
@@ -17,12 +17,18 @@ trait GeneralChunk extends Chunk {
   val resourceID: ResourceID
   val id: ChunkIdentifer
   val perm: Term
+  def applyCondition(newCond: Term): GeneralChunk
+  def permMinus(perm: Term): GeneralChunk
+  def permPlus(perm: Term): GeneralChunk
   def withPerm(perm: Term): GeneralChunk
 }
 
 trait NonQuantifiedChunk extends GeneralChunk {
   val args: Seq[Term]
   val snap: Term
+  override def applyCondition(newCond: Term): NonQuantifiedChunk
+  override def permMinus(perm: Term): NonQuantifiedChunk
+  override def permPlus(perm: Term): NonQuantifiedChunk
   override def withPerm(perm: Term): NonQuantifiedChunk
   def withSnap(snap: Term): NonQuantifiedChunk
 }
@@ -31,6 +37,9 @@ trait QuantifiedChunk extends GeneralChunk {
   val quantifiedVars: Seq[Var]
   def snapshotMap: Term
   def valueAt(arguments: Seq[Term]): Term
+  override def applyCondition(newCond: Term): QuantifiedChunk
+  override def permMinus(perm: Term): QuantifiedChunk
+  override def permPlus(perm: Term): QuantifiedChunk
   override def withPerm(perm: Term): QuantifiedChunk
   def withSnapshotMap(snap: Term): QuantifiedChunk
 }

--- a/src/main/scala/logger/records/data/SingleMergeRecord.scala
+++ b/src/main/scala/logger/records/data/SingleMergeRecord.scala
@@ -8,13 +8,13 @@ package viper.silicon.logger.records.data
 
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.decider.PathConditionStack
-import viper.silicon.interfaces.state.NonQuantifiedChunk
+import viper.silicon.interfaces.state.{Chunk, NonQuantifiedChunk}
 import viper.silicon.state._
 import viper.silicon.state.terms.Term
 import viper.silver.ast
 
-class SingleMergeRecord(val destChunks: Seq[NonQuantifiedChunk],
-                        val newChunks: Seq[NonQuantifiedChunk],
+class SingleMergeRecord(val destChunks: Seq[Chunk],
+                        val newChunks: Seq[Chunk],
                         p: PathConditionStack) extends DataRecord {
   val value: ast.Node = null
   val state: State = null

--- a/src/main/scala/logger/writer/SymbExLogReportWriter.scala
+++ b/src/main/scala/logger/writer/SymbExLogReportWriter.scala
@@ -58,7 +58,7 @@ object SymbExLogReportWriter {
         "perm" -> TermWriter.toJSON(perm)
       )
 
-    case QuantifiedFieldChunk(id, fvf, condition, perm, invs, cond, receiver, hints) =>
+    case QuantifiedFieldChunk(id, fvf, condition, perm, invs, receiver, hints) =>
       JsObject(
         "type" -> JsString("quantified_field_chunk"),
         "field" -> JsString(id.toString),
@@ -66,12 +66,11 @@ object SymbExLogReportWriter {
         "condition" -> TermWriter.toJSON(condition),
         "perm" -> TermWriter.toJSON(perm),
         "invs" -> invs.map(inverseFunctionsToJSON).getOrElse(JsNull),
-        "cond" -> cond.map(TermWriter.toJSON).getOrElse(JsNull),
         "receiver" -> receiver.map(TermWriter.toJSON).getOrElse(JsNull),
         "hints" -> (if (hints.nonEmpty) JsArray(hints.map(TermWriter.toJSON).toVector) else JsNull)
       )
 
-    case QuantifiedPredicateChunk(id, vars, psf, condition, perm, invs, cond, singletonArgs, hints) =>
+    case QuantifiedPredicateChunk(id, vars, psf, condition, perm, invs, singletonArgs, hints) =>
       JsObject(
         "type" -> JsString("quantified_predicate_chunk"),
         "vars" -> JsArray(vars.map(TermWriter.toJSON).toVector),
@@ -80,12 +79,11 @@ object SymbExLogReportWriter {
         "condition" -> TermWriter.toJSON(condition),
         "perm" -> TermWriter.toJSON(perm),
         "invs" -> invs.map(inverseFunctionsToJSON).getOrElse(JsNull),
-        "cond" -> cond.map(TermWriter.toJSON).getOrElse(JsNull),
         "singleton_args" -> singletonArgs.map(as => JsArray(as.map(TermWriter.toJSON).toVector)).getOrElse(JsNull),
         "hints" -> (if (hints.nonEmpty) JsArray(hints.map(TermWriter.toJSON).toVector) else JsNull)
       )
 
-    case QuantifiedMagicWandChunk(id, vars, wsf, perm, invs, cond, singletonArgs, hints) =>
+    case QuantifiedMagicWandChunk(id, vars, wsf, perm, invs, singletonArgs, hints) =>
       JsObject(
         "type" -> JsString("quantified_magic_wand_chunk"),
         "vars" -> JsArray(vars.map(TermWriter.toJSON).toVector),
@@ -93,7 +91,6 @@ object SymbExLogReportWriter {
         "wand_snap_function" -> TermWriter.toJSON(wsf),
         "perm" -> TermWriter.toJSON(perm),
         "invs" -> invs.map(inverseFunctionsToJSON).getOrElse(JsNull),
-        "cond" -> cond.map(TermWriter.toJSON).getOrElse(JsNull),
         "singleton_args" -> singletonArgs.map(as => JsArray(as.map(TermWriter.toJSON).toVector)).getOrElse(JsNull),
         "hints" -> (if (hints.nonEmpty) JsArray(hints.map(TermWriter.toJSON).toVector) else JsNull)
       )

--- a/src/main/scala/logger/writer/SymbExLogReportWriter.scala
+++ b/src/main/scala/logger/writer/SymbExLogReportWriter.scala
@@ -58,11 +58,12 @@ object SymbExLogReportWriter {
         "perm" -> TermWriter.toJSON(perm)
       )
 
-    case QuantifiedFieldChunk(id, fvf, perm, invs, cond, receiver, hints) =>
+    case QuantifiedFieldChunk(id, fvf, condition, perm, invs, cond, receiver, hints) =>
       JsObject(
         "type" -> JsString("quantified_field_chunk"),
         "field" -> JsString(id.toString),
         "field_value_function" -> TermWriter.toJSON(fvf),
+        "condition" -> TermWriter.toJSON(condition),
         "perm" -> TermWriter.toJSON(perm),
         "invs" -> invs.map(inverseFunctionsToJSON).getOrElse(JsNull),
         "cond" -> cond.map(TermWriter.toJSON).getOrElse(JsNull),
@@ -70,12 +71,13 @@ object SymbExLogReportWriter {
         "hints" -> (if (hints.nonEmpty) JsArray(hints.map(TermWriter.toJSON).toVector) else JsNull)
       )
 
-    case QuantifiedPredicateChunk(id, vars, psf, perm, invs, cond, singletonArgs, hints) =>
+    case QuantifiedPredicateChunk(id, vars, psf, condition, perm, invs, cond, singletonArgs, hints) =>
       JsObject(
         "type" -> JsString("quantified_predicate_chunk"),
         "vars" -> JsArray(vars.map(TermWriter.toJSON).toVector),
         "predicate" -> JsString(id.toString),
         "predicate_snap_function" -> TermWriter.toJSON(psf),
+        "condition" -> TermWriter.toJSON(condition),
         "perm" -> TermWriter.toJSON(perm),
         "invs" -> invs.map(inverseFunctionsToJSON).getOrElse(JsNull),
         "cond" -> cond.map(TermWriter.toJSON).getOrElse(JsNull),

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -49,12 +49,6 @@ trait ChunkSupportRules extends SymbolicExecutionRules {
                 v: Verifier)
                : Option[CH]
 
-  def findMatchingChunk[CH <: NonQuantifiedChunk: ClassTag]
-                       (chunks: Iterable[Chunk],
-                        chunk: CH,
-                        v: Verifier)
-                       : Option[CH]
-
   def findChunksWithID[CH <: NonQuantifiedChunk: ClassTag]
                       (chunks: Iterable[Chunk],
                        id: ChunkIdentifer)
@@ -241,11 +235,6 @@ object chunkSupporter extends ChunkSupportRules {
                : Option[CH] = {
     val relevantChunks = findChunksWithID[CH](chunks, id)
     findChunkLiterally(relevantChunks, args) orElse findChunkWithProver(relevantChunks, args, v)
-  }
-
-  def findMatchingChunk[CH <: NonQuantifiedChunk: ClassTag]
-                       (chunks: Iterable[Chunk], chunk: CH, v: Verifier): Option[CH] = {
-    findChunk[CH](chunks, chunk.id, chunk.args, v)
   }
 
   def findChunksWithID[CH <: NonQuantifiedChunk: ClassTag](chunks: Iterable[Chunk], id: ChunkIdentifer): Iterable[CH] = {

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1797,11 +1797,11 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
   override def findChunk(chunks: Iterable[Chunk], chunk: QuantifiedChunk, v: Verifier): Option[QuantifiedChunk] = {
     val lr = chunk match {
       case qfc: QuantifiedFieldChunk if qfc.invs.isDefined =>
-        Left(qfc.invs.get.invertibles, qfc.quantifiedVars, qfc.invs.get.condition)
+        Left(qfc.invs.get.invertibles, qfc.quantifiedVars, qfc.condition)
       case qfc: QuantifiedFieldChunk if qfc.singletonArguments.isDefined =>
         Right(qfc.singletonArguments.get)
       case qpc: QuantifiedPredicateChunk if qpc.invs.isDefined =>
-        Left(qpc.invs.get.invertibles, qpc.quantifiedVars, qpc.invs.get.condition)
+        Left(qpc.invs.get.invertibles, qpc.quantifiedVars, qpc.condition)
       case qpc: QuantifiedPredicateChunk if qpc.singletonArguments.isDefined =>
         Right(qpc.singletonArguments.get)
       case _ => return None
@@ -1838,9 +1838,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     relevantChunks.find { ch =>
       val chunkInfo = ch match {
         case qfc: QuantifiedFieldChunk if qfc.invs.isDefined =>
-          Some(qfc.invs.get.invertibles, qfc.quantifiedVars, qfc.invs.get.condition)
+          Some(qfc.invs.get.invertibles, qfc.quantifiedVars, qfc.condition)
         case qpc: QuantifiedPredicateChunk if qpc.invs.isDefined =>
-          Some(qpc.invs.get.invertibles, qpc.quantifiedVars, qpc.invs.get.condition)
+          Some(qpc.invs.get.invertibles, qpc.quantifiedVars, qpc.condition)
         case _ => None
       }
       chunkInfo match {

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -366,7 +366,6 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           condition,
           permissions,
           optInverseFunctions,
-          Some(conditionalizedPermissions),
           optSingletonArguments.map(_.head),
           hints)
 
@@ -378,7 +377,6 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           condition,
           permissions,
           optInverseFunctions,
-          Some(conditionalizedPermissions),
           optSingletonArguments,
           hints)
 
@@ -389,7 +387,6 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           sm,
           conditionalizedPermissions,
           optInverseFunctions,
-          Some(conditionalizedPermissions),
           optSingletonArguments,
           hints)
 

--- a/src/main/scala/rules/StateConsolidator.scala
+++ b/src/main/scala/rules/StateConsolidator.scala
@@ -195,15 +195,13 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
       val (fr2, combinedSnap, snapEq) = combineSnapshots(fr1, snap1, snap2, perm1, perm2, v)
 
       Some(fr2, BasicChunk(rid1, id1, args1, combinedSnap, PermPlus(perm1, perm2)), snapEq)
-    case (l@QuantifiedFieldChunk(id1, fvf1, condition1, perm1, invs1, initialCond1, _, hints1), r@QuantifiedFieldChunk(_, fvf2, _, perm2, _, _, singletonRcvr2, hints2)) =>
+    case (l@QuantifiedFieldChunk(id1, fvf1, condition1, perm1, invs1, initialCond1, singletonRcvr1, hints1), r@QuantifiedFieldChunk(_, fvf2, _, perm2, _, _, _, hints2)) =>
       assert(l.quantifiedVars == Seq(`?r`))
       assert(r.quantifiedVars == Seq(`?r`))
       // We need to use l.perm/r.perm here instead of perm1 and perm2 since the permission amount might be dependent on the condition/domain
       val (fr2, combinedSnap, snapEq) = quantifiedChunkSupporter.combineFieldSnapshotMaps(fr1, id1.name, fvf1, fvf2, l.perm, r.perm, v)
-      // TODO: Deal with hints
-      // TODO: Store multiple known singleton receivers for better heuristics?
-      Some(fr2, QuantifiedFieldChunk(id1, combinedSnap, condition1, PermPlus(perm1, perm2), invs1, initialCond1, singletonRcvr2, hints1), snapEq)
-    case (l@QuantifiedPredicateChunk(id1, qVars1, psf1, _, perm1, _, _, _, hints1), r@QuantifiedPredicateChunk(_, qVars2, psf2, condition2, perm2, initialCond2, invs2, singletonArgs2, hints2)) =>
+      Some(fr2, QuantifiedFieldChunk(id1, combinedSnap, condition1, PermPlus(perm1, perm2), invs1, initialCond1, singletonRcvr1, if (hints1.nonEmpty) hints1 else hints2), snapEq)
+    case (l@QuantifiedPredicateChunk(id1, qVars1, psf1, _, perm1, _, _, singletonArgs1, hints1), r@QuantifiedPredicateChunk(_, qVars2, psf2, condition2, perm2, initialCond2, invs2, singletonArgs2, hints2)) =>
       val (fr2, combinedSnap, snapEq) = quantifiedChunkSupporter.combinePredicateSnapshotMaps(fr1, id1.name, qVars2, psf1, psf2, l.perm.replace(qVars1, qVars2), r.perm, v)
 
       Some(fr2, QuantifiedPredicateChunk(id1, qVars2, combinedSnap, condition2, PermPlus(perm1.replace(qVars1, qVars2), perm2), initialCond2, invs2, singletonArgs2, hints2), snapEq)

--- a/src/main/scala/state/Chunks.scala
+++ b/src/main/scala/state/Chunks.scala
@@ -57,7 +57,6 @@ sealed trait QuantifiedBasicChunk extends QuantifiedChunk {
   override def applyCondition(newCond: Term): QuantifiedBasicChunk
   override def permMinus(perm: Term): QuantifiedBasicChunk
   override def permPlus(perm: Term): QuantifiedBasicChunk
-  override def withPerm(perm: Term): QuantifiedBasicChunk
   override def withSnapshotMap(snap: Term): QuantifiedBasicChunk
   def singletonArguments: Option[Seq[Term]]
   def hints: Seq[Term]
@@ -99,7 +98,6 @@ case class QuantifiedFieldChunk(id: BasicChunkIdentifier,
   override def applyCondition(newCond: Term) = QuantifiedFieldChunk(id, fvf, terms.And(newCond, condition), permValue, invs, singletonRcvr, hints)
   override def permMinus(newPerm: Term) = QuantifiedFieldChunk(id, fvf, condition, PermMinus(permValue, newPerm), invs, singletonRcvr, hints)
   override def permPlus(newPerm: Term) = QuantifiedFieldChunk(id, fvf, condition, PermPlus(permValue, newPerm), invs, singletonRcvr, hints)
-  override def withPerm(newPerm: Term) = throw new RuntimeException("Should not be used with quantified field chunks")
   override def withSnapshotMap(newFvf: Term) = QuantifiedFieldChunk(id, newFvf, condition, permValue, invs, singletonRcvr, hints)
 
   override lazy val toString = s"${terms.Forall} ${`?r`} :: ${`?r`}.$id -> $fvf # $perm"
@@ -129,7 +127,6 @@ case class QuantifiedPredicateChunk(id: BasicChunkIdentifier,
   override def applyCondition(newCond: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, terms.And(newCond, condition), permValue, invs, singletonArgs, hints)
   override def permMinus(newPerm: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, condition, PermMinus(permValue, newPerm), invs, singletonArgs, hints)
   override def permPlus(newPerm: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, condition, PermPlus(permValue, newPerm), invs, singletonArgs, hints)
-  override def withPerm(newPerm: Term) = throw new RuntimeException("Should not be used with quantified predicate chunks")
   override def withSnapshotMap(newPsf: Term) = QuantifiedPredicateChunk(id, quantifiedVars, newPsf, condition, permValue, invs, singletonArgs, hints)
 
   override lazy val toString = s"${terms.Forall} ${quantifiedVars.mkString(",")} :: $id(${quantifiedVars.mkString(",")}) -> $psf # $perm"
@@ -157,7 +154,7 @@ case class QuantifiedMagicWandChunk(id: MagicWandIdentifier,
   override def applyCondition(newCond: Term) = withPerm(Ite(newCond, perm, NoPerm))
   override def permMinus(newPerm: Term) = withPerm(PermMinus(perm, newPerm))
   override def permPlus(newPerm: Term) = withPerm(PermPlus(perm, newPerm))
-  override def withPerm(newPerm: Term) = QuantifiedMagicWandChunk(id, quantifiedVars, wsf, newPerm, invs, singletonArgs, hints)
+  def withPerm(newPerm: Term) = QuantifiedMagicWandChunk(id, quantifiedVars, wsf, newPerm, invs, singletonArgs, hints)
   override def withSnapshotMap(newWsf: Term) = QuantifiedMagicWandChunk(id, quantifiedVars, newWsf, perm, invs, singletonArgs, hints)
 
   override lazy val toString = s"${terms.Forall} ${quantifiedVars.mkString(",")} :: $id(${quantifiedVars.mkString(",")}) -> $wsf # $perm"

--- a/src/main/scala/state/Chunks.scala
+++ b/src/main/scala/state/Chunks.scala
@@ -73,7 +73,6 @@ case class QuantifiedFieldChunk(id: BasicChunkIdentifier,
                                 condition: Term,
                                 permValue: Term,
                                 invs: Option[InverseFunctions],
-                                initialCond: Option[Term],
                                 singletonRcvr: Option[Term],
                                 hints: Seq[Term] = Nil)
     extends QuantifiedBasicChunk {
@@ -97,11 +96,11 @@ case class QuantifiedFieldChunk(id: BasicChunkIdentifier,
     Lookup(id.name, fvf, arguments.head)
   }
 
-  override def applyCondition(newCond: Term) = QuantifiedFieldChunk(id, fvf, terms.And(newCond, condition), permValue, invs, initialCond, singletonRcvr, hints)
-  override def permMinus(newPerm: Term) = QuantifiedFieldChunk(id, fvf, condition, PermMinus(permValue, newPerm), invs, initialCond, singletonRcvr, hints)
-  override def permPlus(newPerm: Term) = QuantifiedFieldChunk(id, fvf, condition, PermPlus(permValue, newPerm), invs, initialCond, singletonRcvr, hints)
+  override def applyCondition(newCond: Term) = QuantifiedFieldChunk(id, fvf, terms.And(newCond, condition), permValue, invs, singletonRcvr, hints)
+  override def permMinus(newPerm: Term) = QuantifiedFieldChunk(id, fvf, condition, PermMinus(permValue, newPerm), invs, singletonRcvr, hints)
+  override def permPlus(newPerm: Term) = QuantifiedFieldChunk(id, fvf, condition, PermPlus(permValue, newPerm), invs, singletonRcvr, hints)
   override def withPerm(newPerm: Term) = throw new RuntimeException("Should not be used with quantified field chunks")
-  override def withSnapshotMap(newFvf: Term) = QuantifiedFieldChunk(id, newFvf, condition, permValue, invs, initialCond, singletonRcvr, hints)
+  override def withSnapshotMap(newFvf: Term) = QuantifiedFieldChunk(id, newFvf, condition, permValue, invs, singletonRcvr, hints)
 
   override lazy val toString = s"${terms.Forall} ${`?r`} :: ${`?r`}.$id -> $fvf # $perm"
 }
@@ -112,7 +111,6 @@ case class QuantifiedPredicateChunk(id: BasicChunkIdentifier,
                                     condition: Term,
                                     permValue: Term,
                                     invs: Option[InverseFunctions],
-                                    initialCond: Option[Term],
                                     singletonArgs: Option[Seq[Term]],
                                     hints: Seq[Term] = Nil)
     extends QuantifiedBasicChunk {
@@ -128,11 +126,11 @@ case class QuantifiedPredicateChunk(id: BasicChunkIdentifier,
 
   override def valueAt(args: Seq[Term]) = PredicateLookup(id.name, psf, args)
 
-  override def applyCondition(newCond: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, terms.And(newCond, condition), permValue, invs, initialCond, singletonArgs, hints)
-  override def permMinus(newPerm: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, condition, PermMinus(permValue, newPerm), invs, initialCond, singletonArgs, hints)
-  override def permPlus(newPerm: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, condition, PermPlus(permValue, newPerm), invs, initialCond, singletonArgs, hints)
+  override def applyCondition(newCond: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, terms.And(newCond, condition), permValue, invs, singletonArgs, hints)
+  override def permMinus(newPerm: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, condition, PermMinus(permValue, newPerm), invs, singletonArgs, hints)
+  override def permPlus(newPerm: Term) = QuantifiedPredicateChunk(id, quantifiedVars, psf, condition, PermPlus(permValue, newPerm), invs, singletonArgs, hints)
   override def withPerm(newPerm: Term) = throw new RuntimeException("Should not be used with quantified predicate chunks")
-  override def withSnapshotMap(newPsf: Term) = QuantifiedPredicateChunk(id, quantifiedVars, newPsf, condition, permValue, invs, initialCond, singletonArgs, hints)
+  override def withSnapshotMap(newPsf: Term) = QuantifiedPredicateChunk(id, quantifiedVars, newPsf, condition, permValue, invs, singletonArgs, hints)
 
   override lazy val toString = s"${terms.Forall} ${quantifiedVars.mkString(",")} :: $id(${quantifiedVars.mkString(",")}) -> $psf # $perm"
 }
@@ -142,7 +140,6 @@ case class QuantifiedMagicWandChunk(id: MagicWandIdentifier,
                                     wsf: Term,
                                     perm: Term,
                                     invs: Option[InverseFunctions],
-                                    initialCond: Option[Term],
                                     singletonArgs: Option[Seq[Term]],
                                     hints: Seq[Term] = Nil)
     extends QuantifiedBasicChunk {
@@ -160,8 +157,8 @@ case class QuantifiedMagicWandChunk(id: MagicWandIdentifier,
   override def applyCondition(newCond: Term) = withPerm(Ite(newCond, perm, NoPerm))
   override def permMinus(newPerm: Term) = withPerm(PermMinus(perm, newPerm))
   override def permPlus(newPerm: Term) = withPerm(PermPlus(perm, newPerm))
-  override def withPerm(newPerm: Term) = QuantifiedMagicWandChunk(id, quantifiedVars, wsf, newPerm, invs, initialCond, singletonArgs, hints)
-  override def withSnapshotMap(newWsf: Term) = QuantifiedMagicWandChunk(id, quantifiedVars, newWsf, perm, invs, initialCond, singletonArgs, hints)
+  override def withPerm(newPerm: Term) = QuantifiedMagicWandChunk(id, quantifiedVars, wsf, newPerm, invs, singletonArgs, hints)
+  override def withSnapshotMap(newWsf: Term) = QuantifiedMagicWandChunk(id, quantifiedVars, newWsf, perm, invs, singletonArgs, hints)
 
   override lazy val toString = s"${terms.Forall} ${quantifiedVars.mkString(",")} :: $id(${quantifiedVars.mkString(",")}) -> $wsf # $perm"
 }

--- a/src/main/scala/state/State.scala
+++ b/src/main/scala/state/State.scala
@@ -267,7 +267,7 @@ object State {
     h map (c => {
       c match {
         case c: GeneralChunk =>
-          c.withPerm(Ite(cond, c.perm, NoPerm))
+          c.applyCondition(cond)
         case _ => sys.error("Chunk type not conditionalizable.")
       }
     })


### PR DESCRIPTION
I noticed that state consolidation only merges basic chunks. I've been running into issues where if I have a lot of quantified field chunks things become very slow. In particular I have some files where a method verifies fine on it's own but it's welldefinedness can not be re-verified at the call site because the heap becomes too fragmented.

A similar issue is highlighted in #831 where if we're unlucky with the chunk ordering in removePermissions we have to "remove" some amount of permissions from a lot of unrelated chunks which obviously scales badly if we have a lot of chunks.

This PR enables merging quantified chunks (with the exception of magic wands) if their condition and arguments are the same. This seems to significantly speed up the above mentioned files (allowing the first example to verify and the example with 19 quantifiers from #831 now runs in 21 seconds) and not have a (significant) negative effect on other files. I've run the Silicon test suite and the VerCors test suite and saw no significant differences. 

I did also try running Gobra on the router package from the VerifiedSCION repository which results in 1 error after ~30 minutes:
```
Error at: <./router/dataplane.go:937:15> Loop invariant might not be preserved. Permission to msgs[i].Mem() might not suffice.
```

Since I cannot find another example where this PR has a negative impact and I don't know how to get a small Viper file from Gobra to test this specific case I thought I'd submit my PR anyway.

There are also still some open questions:
- When merging singleton chunks I'm currently only keeping the singletonArguments/singletonReceiver of the most recently added chunk which might have a negative impact on chunk ordering because we cannot match syntactically on the receiver that we throw away. Would it make sense to store a set of (sequences of) singleton arguments instead?
- When merging chunks I'm also throwing away the hints since I couldn't think of a good way to merge them. In the examples I have from VerCors the hint tends to be rather useless anyway since, for example, every array access is only done by applying the `aloc` function anyway. Is it worth it to find a way to preserve these hints?
- To determine if two chunks can be merged I'm checking if their condition is the same. However, the decision of what is and isn't a part of a chunk's condition is somewhat arbitrary. For example, the expression `forall i: Int :: 0 <= i && i < n ==> acc(aloc(x,i), write)` would yield a chunk with the condition `0 <= i && i < n` and the permission value `write`, whereas the expression `forall i: Int :: true ==> acc(aloc(x, i), 0 <= i && i < n ? write : none)` would yield a chunk with the condition `true` and the permission value `0 <= i && i < n ? write : none`. There is a trade-off here regarding when we do and don't want to merge chunks. In fact, if we conditionalize all the permissions (i.e. push the condition into the permission value) you could merge all chunks referring to the same field. But of course doing that would yield a single very complicated quantified heap chunk where we can't use heuristics to find a good chunk ordering anymore. Somewhere there is a good balance of merging chunks to simplify the state (i.e. instead of having two chunks containing half of the permission requiring 4 checks in removePermissions in the best case you can have one chunk containing all the permission requiring only 2 checks in the best case) and keeping chunks separate to enable reasoning about them separately.
- I have not attempted to merge quantified magic wands since I felt like there would be little benefit and I wasn't sure what all the assumptions are surrounding these chunks
- I mentioned above that this PR speeds up #831 but it seem to also do this if I disable merging quantified heap chunks by returning None before the equality check in findChunk, I am not sure why. Even without merging the chunks it seems that the removePermissions calls now select the right ordering every time. For the other example file I've been testing with merging the quantified heap chunks *is* crucial though.

Let me know what you think of these changes and if I can improve them in some way