### PR TITLE
Fix macro transfer between verifiers in parallel branch verification

### DIFF
--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -129,10 +129,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     private var _proverOptions: Map[String, String] = Map.empty
     private var _proverResetOptions: Map[String, String] = Map.empty
     private val _debuggerAssumedTerms: mutable.Set[Term] = mutable.Set.empty
-
-
-    //private val TODODELETEtermSources = mutable.Map.empty[Term, DebugExp]
-
+    
     def functionDecls: Set[FunctionDecl] = _declaredFreshFunctions
     def macroDecls: Vector[MacroDecl] = _declaredFreshMacros
 

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -515,41 +515,25 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     def freshMacros: Vector[MacroDecl] = _declaredFreshMacros
 
     def declareAndRecordAsFreshFunctions(functions: Set[FunctionDecl], toSymbolStack: Boolean): Unit = {
-      if (!toSymbolStack) {
-        for (f <- functions) {
-          if (!_declaredFreshFunctions.contains(f))
-            prover.declare(f)
-
+      for (f <- functions) {
+        if (!_declaredFreshFunctions.contains(f)) {
+          prover.declare(f)
           _declaredFreshFunctions = _declaredFreshFunctions + f
-        }
-      } else {
-        for (f <- functions) {
-          if (!_declaredFreshFunctions.contains(f))
-            prover.declare(f)
-
-          _declaredFreshFunctions = _declaredFreshFunctions + f
-          _freshFunctionStack.foreach(s => s.add(f))
         }
       }
+      if (toSymbolStack)
+        _freshFunctionStack.foreach(s => s.addAll(functions))
     }
 
     def declareAndRecordAsFreshMacros(macros: Seq[MacroDecl], toStack: Boolean): Unit = {
-      if (!toStack) {
-        for (m <- macros) {
-          if (!_declaredFreshMacros.contains(m)) {
-            prover.declare(m)
-            _declaredFreshMacros = _declaredFreshMacros.appended(m)
-          }
-        }
-      } else {
-        for (m <- macros) {
-          if (!_declaredFreshMacros.contains(m)) {
-            prover.declare(m)
-            _declaredFreshMacros = _declaredFreshMacros.appended(m)
-          }
-          _freshMacroStack.foreach(l => l.append(m))
+      for (m <- macros) {
+        if (!_declaredFreshMacros.contains(m)) {
+          prover.declare(m)
+          _declaredFreshMacros = _declaredFreshMacros.appended(m)
         }
       }
+      if (toStack)
+        _freshMacroStack.foreach(l => l.appendAll(macros))
     }
 
     def pushSymbolStack(): Unit = {

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -250,8 +250,7 @@ object brancher extends BranchingRules {
       v.decider.prover.comment(s"Bulk-declaring functions")
       v.decider.declareAndRecordAsFreshFunctions(functionsOfElseBranchDecider, true)
       v.decider.prover.comment(s"Bulk-declaring macros")
-      // Declare macros without duplicates; we keep only the last occurrence of every declaration to avoid errors.
-      v.decider.declareAndRecordAsFreshMacros(macrosOfElseBranchDecider.reverse.distinct.reverse, true)
+      v.decider.declareAndRecordAsFreshMacros(macrosOfElseBranchDecider, true)
     }
     res
   }

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -148,12 +148,12 @@ object brancher extends BranchingRules {
             v1.decider.setCurrentBranchCondition(negatedCondition, (negatedConditionExp, negatedConditionExpNew))
 
             var functionsOfElseBranchdDeciderBefore: Set[FunctionDecl] = null
-            var macrosOfElseBranchDeciderBefore: Seq[MacroDecl] = null
+            var nMacrosOfElseBranchDeciderBefore: Int = 0
 
             if (v.uniqueId != v0.uniqueId) {
               v1.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
               if (s.underJoin) {
-                macrosOfElseBranchDeciderBefore = v1.decider.freshMacros
+                nMacrosOfElseBranchDeciderBefore = v1.decider.freshMacros.size
                 functionsOfElseBranchdDeciderBefore = v1.decider.freshFunctions
               }
             }
@@ -164,8 +164,7 @@ object brancher extends BranchingRules {
               v1.decider.setProverOptions(proverArgsOfElseBranchDecider)
               if (s.underJoin) {
                 functionsOfElseBranchDecider = v1.decider.freshFunctions -- functionsOfElseBranchdDeciderBefore
-                val elseMacrosBeforeSet = HashSet.from(macrosOfElseBranchDeciderBefore)
-                macrosOfElseBranchDecider = v1.decider.freshMacros.filter(m => !elseMacrosBeforeSet.contains(m))
+                macrosOfElseBranchDecider = v1.decider.freshMacros.drop(nMacrosOfElseBranchDeciderBefore)
               }
             }
             result

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -275,7 +275,7 @@ object executor extends ExecutionRules {
                     case (intermediateResult, (s1, pcs, ff1)) => /* [BRANCH-PARALLELISATION] ff1 */
                       val s2 = s1.copy(invariantContexts = sLeftover.h +: s1.invariantContexts)
                       intermediateResult combine executionFlowController.locally(s2, v1)((s3, v2) => {
-                        v2.decider.declareAndRecordAsFreshFunctions(ff1 -- v2.decider.freshFunctions, true) /* [BRANCH-PARALLELISATION] */
+                        v2.decider.declareAndRecordAsFreshFunctions(ff1 -- v2.decider.freshFunctions) /* [BRANCH-PARALLELISATION] */
                         v2.decider.assume(pcs.assumptions, Option.when(withExp)(DebugExp.createInstance("Loop invariant", pcs.assumptionExps)), false)
                         v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
                         if (v2.decider.checkSmoke())


### PR DESCRIPTION
- Simplifies the way we move function and macro declarations between prover instances when verifying different branches on different solvers in parallel
- Gets rid of the stack of declared functions and macros in the Decider 
- Should improve performance of the relevant code for large examples (we used to do a lot of checks if a vector contains a value, now we check this on a HashSet)
- Hopefully fixes some issues the more complex previous solution had in the process