### PR TITLE
Optional Snapshot Generation in Consume

### DIFF
--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -29,7 +29,7 @@ trait ChunkSupportRules extends SymbolicExecutionRules {
               argsExp: Option[Seq[ast.Exp]],
               perms: Term,
               permsExp: Option[ast.Exp],
-              SnapNeeded: Boolean,
+              returnSnap: Boolean,
               ve: VerificationError,
               v: Verifier,
               description: String)
@@ -72,14 +72,14 @@ object chunkSupporter extends ChunkSupportRules {
               argsExp: Option[Seq[ast.Exp]],
               perms: Term,
               permsExp: Option[ast.Exp],
-              SnapNeeded: Boolean,
+              returnSnap: Boolean,
               ve: VerificationError,
               v: Verifier,
               description: String)
              (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
              : VerificationResult = {
 
-    consume2(s, h, resource, args, argsExp, perms, permsExp, SnapNeeded, ve, v)((s2, h2, optSnap, v2) =>
+    consume2(s, h, resource, args, argsExp, perms, permsExp, returnSnap, ve, v)((s2, h2, optSnap, v2) =>
       optSnap match {
         case Some(snap) =>
           Q(s2, h2, Some(snap.convert(sorts.Snap)), v2)
@@ -104,7 +104,7 @@ object chunkSupporter extends ChunkSupportRules {
                        argsExp: Option[Seq[ast.Exp]],
                        perms: Term,
                        permsExp: Option[ast.Exp],
-                       SnapNeeded: Boolean,
+                       returnSnap: Boolean,
                        ve: VerificationError,
                        v: Verifier)
                       (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -115,7 +115,7 @@ object chunkSupporter extends ChunkSupportRules {
     if (s.exhaleExt) {
       val failure = createFailure(ve, v, s, "chunk consume in package")
       magicWandSupporter.transfer(s, perms, permsExp, failure, Seq(), v)(consumeGreedy(_, _, id, args, _, _, _))((s1, optCh, v1) =>
-        if(returnSnap){
+        if (returnSnap){
           Q(s1, h, optCh.flatMap(ch => Some(ch.snap)), v1)
         } else {
           Q(s1, h, None, v1)

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -133,8 +133,8 @@ object consumer extends ConsumptionRules {
           consumeTlcs(s1, h1, tlcs.tail, returnSnap, pves.tail, v1)((s2, h2, snap2, v2) =>
 
             (snap1, snap2) match {
-              case (Some(sn1), Some(sn2)) => Q(s2, h2, Some(Combine(sn1, sn2)), v2)
-              case (None, None) => Q(s2, h2, None, v2)
+              case (Some(sn1), Some(sn2)) if returnSnap => Q(s2, h2, Some(Combine(sn1, sn2)), v2)
+              case (None, None) if !returnSnap => Q(s2, h2, None, v2)
               case (_, _) =>  sys.error(s"Consume returned unexpected snapshot: ${(returnSnap, (snap1, snap2))}")
             })
         })
@@ -278,7 +278,7 @@ object consumer extends ConsumptionRules {
               notInjectiveReason = QPAssertionNotInjective(acc.loc),
               insufficientPermissionReason = InsufficientPermission(acc.loc),
               v1)(Q)
-          case (s1, _, _, _, _, None, v1) => Q(s1, h, if(returnSnap) Some(Unit) else None, v1)
+          case (s1, _, _, _, _, None, v1) => Q(s1, h, if (returnSnap) Some(Unit) else None, v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, acc: ast.PredicateAccessPredicate) =>
@@ -324,7 +324,7 @@ object consumer extends ConsumptionRules {
               notInjectiveReason = QPAssertionNotInjective(acc.loc),
               insufficientPermissionReason = InsufficientPermission(acc.loc),
               v1)(Q)
-          case (s1, _, _, _, _, None, v1) => Q(s1, h, if(returnSnap) Some(Unit) else None, v1)
+          case (s1, _, _, _, _, None, v1) => Q(s1, h, if (returnSnap) Some(Unit) else None, v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, wand: ast.MagicWand) =>
@@ -366,7 +366,7 @@ object consumer extends ConsumptionRules {
               notInjectiveReason = sys.error("Quantified wand not injective"), /*ReceiverNotInjective(...)*/
               insufficientPermissionReason = MagicWandChunkNotFound(wand), /*InsufficientPermission(...)*/
               v1)(Q)
-          case (s1, _, _, _, _, None, v1) => Q(s1, h, if(returnSnap) Some(Unit) else None, v1)
+          case (s1, _, _, _, _, None, v1) => Q(s1, h, if (returnSnap) Some(Unit) else None, v1)
         }
 
       case accPred@ast.AccessPredicate(loc @ ast.FieldAccess(eRcvr, field), ePerm)
@@ -573,8 +573,8 @@ object consumer extends ConsumptionRules {
               ),
               // Assume that entry1.pcs is inverse of entry2.pcs
               (entry1.data._2, entry2.data._2) match {
-                case (Some(t1), Some(t2)) => Some(Ite(And(entry1.pathConditions.branchConditions), t1, t2))
-                case (None, None) => None
+                case (Some(t1), Some(t2)) if returnSnap => Some(Ite(And(entry1.pathConditions.branchConditions), t1, t2))
+                case (None, None) if !returnSnap => None
                 case (_, _) => sys.error(s"Unexpected join data entries: $entries")
               }
             )
@@ -631,7 +631,7 @@ object consumer extends ConsumptionRules {
       val s5 = s4.copy(h = s.h,
                        reserveHeaps = s.reserveHeaps,
                        exhaleExt = s.exhaleExt)
-      Q(s5, if(returnSnap) Some(Unit) else None, v4)
+      Q(s5, if (returnSnap) Some(Unit) else None, v4)
     })
   }
 }

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -127,7 +127,7 @@ object consumer extends ConsumptionRules {
       val pve = pves.head
 
       if (tlcs.tail.isEmpty)
-        wrappedConsumeTlc(s, h, a, returnSnap,  pve, v)(Q)
+        wrappedConsumeTlc(s, h, a, returnSnap, pve, v)(Q)
       else
         wrappedConsumeTlc(s, h, a, returnSnap, pve, v)((s1, h1, snap1, v1) => {
           consumeTlcs(s1, h1, tlcs.tail, returnSnap, pves.tail, v1)((s2, h2, snap2, v2) =>

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -36,8 +36,8 @@ trait ConsumptionRules extends SymbolicExecutionRules {
     *          consumed partial heap.
     * @return The result of the continuation.
     */
-  def consume(s: State, a: ast.Exp, pve: PartialVerificationError, v: Verifier)
-             (Q: (State, Term, Verifier) => VerificationResult)
+  def consume(s: State, a: ast.Exp, SnapNeeded: Boolean, pve: PartialVerificationError, v: Verifier)
+             (Q: (State, Option[Term], Verifier) => VerificationResult)
              : VerificationResult
 
   /** Subsequently consumes the assertions `as` (from head to tail), starting in state `s`.
@@ -56,9 +56,10 @@ trait ConsumptionRules extends SymbolicExecutionRules {
     */
   def consumes(s: State,
                as: Seq[ast.Exp],
+               SnapNeeded: Boolean,
                pvef: ast.Exp => PartialVerificationError,
                v: Verifier)
-              (Q: (State, Term, Verifier) => VerificationResult)
+              (Q: (State, Option[Term], Verifier) => VerificationResult)
               : VerificationResult
 }
 
@@ -71,11 +72,11 @@ object consumer extends ConsumptionRules {
    */
 
   /** @inheritdoc */
-  def consume(s: State, a: ast.Exp, pve: PartialVerificationError, v: Verifier)
-             (Q: (State, Term, Verifier) => VerificationResult)
+  def consume(s: State, a: ast.Exp, SnapNeeded: Boolean, pve: PartialVerificationError, v: Verifier)
+             (Q: (State, Option[Term], Verifier) => VerificationResult)
              : VerificationResult = {
 
-    consumeR(s, s.h, a.whenExhaling, pve, v)((s1, h1, snap, v1) => {
+    consumeR(s, s.h, a.whenExhaling, SnapNeeded, pve, v)((s1, h1, snap, v1) => {
       val s2 = s1.copy(h = h1,
                        partiallyConsumedHeap = s.partiallyConsumedHeap)
       Q(s2, snap, v1)})
@@ -84,9 +85,10 @@ object consumer extends ConsumptionRules {
   /** @inheritdoc */
   def consumes(s: State,
                as: Seq[ast.Exp],
+               SnapNeeded: Boolean,
                pvef: ast.Exp => PartialVerificationError,
                v: Verifier)
-              (Q: (State, Term, Verifier) => VerificationResult)
+              (Q: (State, Option[Term], Verifier) => VerificationResult)
               : VerificationResult = {
 
     val allTlcs = mutable.ListBuffer[ast.Exp]()
@@ -100,7 +102,7 @@ object consumer extends ConsumptionRules {
       allPves ++= pves
     })
 
-    consumeTlcs(s, s.h, allTlcs.result(), allPves.result(), v)((s1, h1, snap1, v1) => {
+    consumeTlcs(s, s.h, allTlcs.result(), SnapNeeded, allPves.result(), v)((s1, h1, snap1, v1) => {
       val s2 = s1.copy(h = h1,
                        partiallyConsumedHeap = s.partiallyConsumedHeap)
       Q(s2, snap1, v1)
@@ -110,34 +112,42 @@ object consumer extends ConsumptionRules {
   private def consumeTlcs(s: State,
                           h: Heap,
                           tlcs: Seq[ast.Exp],
+                          SnapNeeded: Boolean,
                           pves: Seq[PartialVerificationError],
                           v: Verifier)
-                         (Q: (State, Heap, Term, Verifier) => VerificationResult)
+                         (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                          : VerificationResult = {
 
     if (tlcs.isEmpty)
-      Q(s, h, Unit, v)
+      Q(s, h, Some(Unit), v)
     else {
       val a = tlcs.head
       val pve = pves.head
 
       if (tlcs.tail.isEmpty)
-        wrappedConsumeTlc(s, h, a, pve, v)(Q)
+        wrappedConsumeTlc(s, h, a, SnapNeeded,  pve, v)(Q)
       else
-        wrappedConsumeTlc(s, h, a, pve, v)((s1, h1, snap1, v1) => {
-          consumeTlcs(s1, h1, tlcs.tail, pves.tail, v1)((s2, h2, snap2, v2) =>
-            Q(s2, h2, Combine(snap1, snap2), v2))})
+        wrappedConsumeTlc(s, h, a, SnapNeeded, pve, v)((s1, h1, snap1, v1) => {
+          consumeTlcs(s1, h1, tlcs.tail, SnapNeeded, pves.tail, v1)((s2, h2, snap2, v2) =>
+
+            (snap1, snap2) match {
+              case (Some(sn1), Some(sn2)) => Q(s2, h2, Some(Combine(sn1, sn2)), v2)
+              case (Some(_), _) => Q(s2, h2, snap1, v2)
+              case (None, Some(_)) => Q(s2, h2, snap2, v2)
+              case (None, None) => Q(s2, h2, None, v2)
+            })
+        })
     }
   }
 
-  private def consumeR(s: State, h: Heap, a: ast.Exp, pve: PartialVerificationError, v: Verifier)
-                      (Q: (State, Heap, Term, Verifier) => VerificationResult)
+  private def consumeR(s: State, h: Heap, a: ast.Exp, SnapNeeded: Boolean, pve: PartialVerificationError, v: Verifier)
+                      (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                       : VerificationResult = {
 
     val tlcs = a.topLevelConjuncts
     val pves = Seq.fill(tlcs.length)(pve)
 
-    consumeTlcs(s, h, tlcs, pves, v)(Q)
+    consumeTlcs(s, h, tlcs, SnapNeeded, pves, v)(Q)
   }
 
   /** Wrapper/decorator for consume that injects the following operations:
@@ -147,9 +157,10 @@ object consumer extends ConsumptionRules {
   protected def wrappedConsumeTlc(s: State,
                                   h: Heap,
                                   a: ast.Exp,
+                                  SnapNeeded: Boolean,
                                   pve: PartialVerificationError,
                                   v: Verifier)
-                                 (Q: (State, Heap, Term, Verifier) => VerificationResult)
+                                 (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                                  : VerificationResult = {
 
     /* tryOrFail effects the "main" heap s.h, so we temporarily set the consume-heap h to be the
@@ -157,20 +168,20 @@ object consumer extends ConsumptionRules {
      * consume.
      */
     val sInit = s.copy(h = h)
-    executionFlowController.tryOrFail2[Heap, Term](sInit, v)((s0, v1, QS) => {
+    executionFlowController.tryOrFail2[Heap, Option[Term]](sInit, v)((s0, v1, QS) => {
       val h0 = s0.h /* h0 is h, but potentially consolidated */
       val s1 = s0.copy(h = s.h) /* s1 is s, but the retrying flag might be set */
 
       val sepIdentifier = v1.symbExLog.openScope(new ConsumeRecord(a, s1, v.decider.pcs))
 
-      consumeTlc(s1, h0, a, pve, v1)((s2, h2, snap2, v2) => {
+      consumeTlc(s1, h0, a, SnapNeeded, pve, v1)((s2, h2, snap2, v2) => {
         v2.symbExLog.closeScope(sepIdentifier)
         QS(s2, h2, snap2, v2)})
     })(Q)
   }
 
-  private def consumeTlc(s: State, h: Heap, a: ast.Exp, pve: PartialVerificationError, v: Verifier)
-                        (Q: (State, Heap, Term, Verifier) => VerificationResult)
+  private def consumeTlc(s: State, h: Heap, a: ast.Exp, SnapNeeded: Boolean, pve: PartialVerificationError, v: Verifier)
+                        (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                         : VerificationResult = {
 
     /* ATTENTION: Expressions such as `perm(...)` must be evaluated in-place,
@@ -190,7 +201,7 @@ object consumer extends ConsumptionRules {
       case imp @ ast.Implies(e0, a0) if !a.isPure && s.moreJoins.id >= JoinMode.Impure.id =>
         val impliesRecord = new ImpliesRecord(imp, s, v.decider.pcs, "consume")
         val uidImplies = v.symbExLog.openScope(impliesRecord)
-        consumeConditionalTlcMoreJoins(s, h, e0, a0, None, uidImplies, pve, v)(Q)
+        consumeConditionalTlcMoreJoins(s, h, e0, a0, None, uidImplies, SnapNeeded, pve, v)(Q)
 
       case imp @ ast.Implies(e0, a0) if !a.isPure =>
         val impliesRecord = new ImpliesRecord(imp, s, v.decider.pcs, "consume")
@@ -198,19 +209,19 @@ object consumer extends ConsumptionRules {
 
         evaluator.eval(s, e0, pve, v)((s1, t0, e0New, v1) =>
           branch(s1, t0, (e0, e0New), v1)(
-            (s2, v2) => consumeR(s2, h, a0, pve, v2)((s3, h1, t1, v3) => {
+            (s2, v2) => consumeR(s2, h, a0, SnapNeeded, pve, v2)((s3, h1, t1, v3) => {
               v3.symbExLog.closeScope(uidImplies)
               Q(s3, h1, t1, v3)
             }),
             (s2, v2) => {
               v2.symbExLog.closeScope(uidImplies)
-              Q(s2, h, Unit, v2)
+              Q(s2, h, Some(Unit), v2)
             }))
 
       case ite @ ast.CondExp(e0, a1, a2) if !a.isPure && s.moreJoins.id >= JoinMode.Impure.id =>
         val condExpRecord = new CondExpRecord(ite, s, v.decider.pcs, "consume")
         val uidCondExp = v.symbExLog.openScope(condExpRecord)
-        consumeConditionalTlcMoreJoins(s, h, e0, a1, Some(a2), uidCondExp, pve, v)(Q)
+        consumeConditionalTlcMoreJoins(s, h, e0, a1, Some(a2), uidCondExp, SnapNeeded, pve, v)(Q)
 
       case ite @ ast.CondExp(e0, a1, a2) if !a.isPure =>
         val condExpRecord = new CondExpRecord(ite, s, v.decider.pcs, "consume")
@@ -218,11 +229,11 @@ object consumer extends ConsumptionRules {
 
         eval(s, e0, pve, v)((s1, t0, e0New, v1) =>
           branch(s1, t0, (e0, e0New), v1)(
-            (s2, v2) => consumeR(s2, h, a1, pve, v2)((s3, h1, t1, v3) => {
+            (s2, v2) => consumeR(s2, h, a1, SnapNeeded, pve, v2)((s3, h1, t1, v3) => {
               v3.symbExLog.closeScope(uidCondExp)
               Q(s3, h1, t1, v3)
             }),
-            (s2, v2) => consumeR(s2, h, a2, pve, v2)((s3, h1, t1, v3) => {
+            (s2, v2) => consumeR(s2, h, a2, SnapNeeded, pve, v2)((s3, h1, t1, v3) => {
               v3.symbExLog.closeScope(uidCondExp)
               Q(s3, h1, t1, v3)
             })))
@@ -260,12 +271,13 @@ object consumer extends ConsumptionRules {
               eArgs = permRcvrOpt.map(permRcvr => Seq(permRcvr(1))),
               tPerm = tPerm,
               ePerm = permRcvrOpt.map(_(0)),
+              SnapNeeded = SnapNeeded,
               pve = pve,
               negativePermissionReason = NegativePermission(acc.perm),
               notInjectiveReason = QPAssertionNotInjective(acc.loc),
               insufficientPermissionReason = InsufficientPermission(acc.loc),
               v1)(Q)
-          case (s1, _, _, _, _, None, v1) => Q(s1, h, True, v1)
+          case (s1, _, _, _, _, None, v1) => Q(s1, h, Some(True), v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, acc: ast.PredicateAccessPredicate) =>
@@ -305,12 +317,13 @@ object consumer extends ConsumptionRules {
               eArgs = permArgsNew.map(_.tail),
               tPerm = tPerm,
               ePerm = permArgsNew.map(_.head),
+              SnapNeeded = SnapNeeded,
               pve = pve,
               negativePermissionReason = NegativePermission(acc.perm),
               notInjectiveReason = QPAssertionNotInjective(acc.loc),
               insufficientPermissionReason = InsufficientPermission(acc.loc),
               v1)(Q)
-          case (s1, _, _, _, _, None, v1) => Q(s1, h, True, v1)
+          case (s1, _, _, _, _, None, v1) => Q(s1, h, Some(True), v1)
         }
 
       case QuantifiedPermissionAssertion(forall, cond, wand: ast.MagicWand) =>
@@ -346,12 +359,13 @@ object consumer extends ConsumptionRules {
               eArgs = bodyVarsNew,
               tPerm = tPerm,
               ePerm = Option.when(withExp)(ePerm),
+              SnapNeeded = SnapNeeded,
               pve = pve,
               negativePermissionReason = NegativePermission(ePerm),
               notInjectiveReason = sys.error("Quantified wand not injective"), /*ReceiverNotInjective(...)*/
               insufficientPermissionReason = MagicWandChunkNotFound(wand), /*InsufficientPermission(...)*/
               v1)(Q)
-          case (s1, _, _, _, _, None, v1) => Q(s1, h, True, v1)
+          case (s1, _, _, _, _, None, v1) => Q(s1, h, Some(True), v1)
         }
 
       case accPred@ast.AccessPredicate(loc @ ast.FieldAccess(eRcvr, field), ePerm)
@@ -387,6 +401,7 @@ object consumer extends ConsumptionRules {
               loc,
               loss,
               lossExp,
+              SnapNeeded,
               None,
               pve,
               v2
@@ -431,6 +446,7 @@ object consumer extends ConsumptionRules {
               loc,
               loss,
               lossExp,
+              SnapNeeded,
               None,
               pve,
               v2
@@ -442,7 +458,7 @@ object consumer extends ConsumptionRules {
       case let: ast.Let if !let.isPure =>
         letSupporter.handle[ast.Exp](s, let, pve, v)((s1, g1, body, v1) => {
           val s2 = s1.copy(g = s1.g + g1)
-          consumeR(s2, h, body, pve, v1)(Q)})
+          consumeR(s2, h, body, SnapNeeded, pve, v1)(Q)})
 
       case ast.AccessPredicate(locacc: ast.LocationAccess, perm) =>
         eval(s, perm, pve, v)((s1, tPerm, permNew, v1) =>
@@ -456,7 +472,7 @@ object consumer extends ConsumptionRules {
               val lossExp = permNew.map(p => ast.PermMul(p, s3.permissionScalingFactorExp.get)(p.pos, p.info, p.errT))
               val ve = pve dueTo InsufficientPermission(locacc)
               val description = s"consume ${a.pos}: $a"
-              chunkSupporter.consume(s3, h, resource, tArgs, eArgs, loss, lossExp, ve, v3, description)((s4, h1, snap1, v4) => {
+              chunkSupporter.consume(s3, h, resource, tArgs, eArgs, loss, lossExp, SnapNeeded, ve, v3, description)((s4, h1, snap1, v4) => {
                 val s5 = s4.copy(partiallyConsumedHeap = Some(h1),
                                  constrainableARPs = s.constrainableARPs)
                 Q(s5, h1, snap1, v4)})})))
@@ -496,6 +512,7 @@ object consumer extends ConsumptionRules {
             wand,
             loss,
             lossExp,
+            SnapNeeded,
             None,
             pve,
             v1
@@ -508,12 +525,12 @@ object consumer extends ConsumptionRules {
         magicWandSupporter.evaluateWandArguments(s, wand, pve, v)((s1, tArgs, eArgs, v1) => {
           val ve = pve dueTo MagicWandChunkNotFound(wand)
           val description = s"consume wand $wand"
-          chunkSupporter.consume(s1, h, wand, tArgs, eArgs, FullPerm, Option.when(withExp)(ast.FullPerm()(wand.pos, wand.info, wand.errT)), ve, v1, description)(Q)
+          chunkSupporter.consume(s1, h, wand, tArgs, eArgs, FullPerm, Option.when(withExp)(ast.FullPerm()(wand.pos, wand.info, wand.errT)), SnapNeeded, ve, v1, description)(Q)
         })
 
       case _ =>
         evalAndAssert(s, a, pve, v)((s1, t, v1) => {
-          Q(s1, h, t, v1)
+          Q(s1, h, Some(t), v1)
         })
     }
 
@@ -521,26 +538,27 @@ object consumer extends ConsumptionRules {
   }
 
   private def consumeConditionalTlcMoreJoins(s: State, h: Heap, e0: ast.Exp, a1: ast.Exp, a2: Option[ast.Exp], scopeUid: Int,
+                                             SnapNeeded: Boolean,
                                              pve: PartialVerificationError, v: Verifier)
-                                            (Q: (State, Heap, Term, Verifier) => VerificationResult)
+                                            (Q: (State, Heap, Option[Term], Verifier) => VerificationResult)
                                             : VerificationResult = {
     eval(s, e0, pve, v)((s1, t0, e0New, v1) =>
-      joiner.join[(Heap, Term), (Heap, Term)](s1, v1, resetState = false)((s1, v1, QB) => {
+      joiner.join[(Heap, Option[Term]), (Heap, Option[Term])](s1, v1, resetState = false)((s1, v1, QB) => {
         branch(s1.copy(parallelizeBranches = false), t0, (e0, e0New), v1)(
           (s2, v2) =>
-            consumeR(s2.copy(parallelizeBranches = s1.parallelizeBranches), h, a1, pve, v2)((s3, h1, t1, v3) => {
+            consumeR(s2.copy(parallelizeBranches = s1.parallelizeBranches), h, a1, SnapNeeded, pve, v2)((s3, h1, t1, v3) => {
             v3.symbExLog.closeScope(scopeUid)
             QB(s3, (h1, t1), v3)
           }),
           (s2, v2) =>
             a2 match {
-              case Some(a2) => consumeR(s2.copy(parallelizeBranches = s1.parallelizeBranches), h, a2, pve, v2)((s3, h1, t1, v3) => {
+              case Some(a2) => consumeR(s2.copy(parallelizeBranches = s1.parallelizeBranches), h, a2, SnapNeeded, pve, v2)((s3, h1, t1, v3) => {
                 v3.symbExLog.closeScope(scopeUid)
                 QB(s3, (h1, t1), v3)
               })
               case None =>
                 v2.symbExLog.closeScope(scopeUid)
-                QB(s2.copy(parallelizeBranches = s1.parallelizeBranches), (h, Unit), v2)
+                QB(s2.copy(parallelizeBranches = s1.parallelizeBranches), (h, Some(Unit)), v2)
             })
       })(entries => {
         val s2 = entries match {
@@ -552,8 +570,8 @@ object consumer extends ConsumptionRules {
                 entry1.data._1, And(entry1.pathConditions.branchConditions), Option.when(withExp)(BigAnd(entry1.pathConditions.branchConditionExps.map(_._2.get))),
                 entry2.data._1, And(entry2.pathConditions.branchConditions), Option.when(withExp)(BigAnd(entry2.pathConditions.branchConditionExps.map(_._2.get))),
               ),
-              // Asume that entry1.pcs is inverse of entry2.pcs
-              Ite(And(entry1.pathConditions.branchConditions), entry1.data._2, entry2.data._2)
+              // Assume that entry1.pcs is inverse of entry2.pcs
+              Some(Ite(And(entry1.pathConditions.branchConditions), entry1.data._2.get, entry2.data._2.get))
             )
             (entry1.pathConditionAwareMergeWithoutConsolidation(entry2, v1), mergedData)
           case _ =>

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -220,8 +220,7 @@ object evaluator extends EvaluationRules {
                * quantifier in whose body field 'fa.field' was accessed)
                * which is protected by a trigger term that we currently don't have.
                */
-              v1.decider.prover.comment("reemit")
-              //v1.decider.assume(And(fvfDef.valueDefinitions), Option.when(withExp)(DebugExp.createInstance("Value definitions", isInternal_ = true)))
+              v1.decider.assume(And(fvfDef.valueDefinitions), Option.when(withExp)(DebugExp.createInstance("Value definitions", isInternal_ = true)))
               if (s1.heapDependentTriggers.contains(fa.field)){
                 val trigger = FieldTrigger(fa.field.name, fvfDef.sm, tRcvr)
                 val triggerExp = Option.when(withExp)(DebugExp.createInstance(s"FieldTrigger(${eRcvr.toString()}.${fa.field.name})"))

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1030,7 +1030,7 @@ object evaluator extends EvaluationRules {
           => Q(s4, r4._1, r4._2, v4))
 
       case ast.Asserting(eAss, eIn) =>
-        consume(s, eAss, pve, v)((s2, _, v2) => {
+        consume(s, eAss, false, pve, v)((s2, _, v2) => {
           val s3 = s2.copy(g = s.g, h = s.h)
           eval(s3, eIn, pve, v2)(Q)
         })

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -435,7 +435,7 @@ object executor extends ExecutionRules {
             val resource = fa.res(s.program)
             val ve = pve dueTo InsufficientPermission(fa)
             val description = s"consume ${ass.pos}: $ass"
-            chunkSupporter.consume(s2, s2.h, resource, Seq(tRcvr), eRcvrNew.map(Seq(_)), FullPerm, Option.when(withExp)(ast.FullPerm()(ass.pos, ass.info, ass.errT)), true, ve, v2, description)((s3, h3, _, v3) => {
+            chunkSupporter.consume(s2, s2.h, resource, Seq(tRcvr), eRcvrNew.map(Seq(_)), FullPerm, Option.when(withExp)(ast.FullPerm()(ass.pos, ass.info, ass.errT)), false, ve, v2, description)((s3, h3, _, v3) => {
               val (tSnap, _) = ssaifyRhs(tRhs, rhs, rhsNew, field.name, field.typ, v3, s3)
               val id = BasicChunkIdentifier(field.name)
               val newChunk = BasicChunk(FieldID, id, Seq(tRcvr), eRcvrNew.map(Seq(_)), tSnap, FullPerm, Option.when(withExp)(ast.FullPerm()(ass.pos, ass.info, ass.errT)))

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -516,7 +516,7 @@ object executor extends ExecutionRules {
            * hUsed (reserveHeaps.head) instead of consuming them. hUsed is later discarded and replaced
            * by s.h. By copying hUsed to s.h the contained permissions remain available inside the wand.
            */
-          consume(s, a, true, pve, v)((s2, _, v1) => {
+          consume(s, a, false, pve, v)((s2, _, v1) => {
             Q(s2.copy(h = s2.reserveHeaps.head), v1)
           })
         } else

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -268,7 +268,7 @@ object executor extends ExecutionRules {
                 })})
             combine executionFlowController.locally(s, v)((s0, v0) => {
                 v0.decider.prover.comment("Loop head block: Establish invariant")
-                consumes(s0, invs, LoopInvariantNotEstablished, v0)((sLeftover, _, v1) => {
+                consumes(s0, invs, false, LoopInvariantNotEstablished, v0)((sLeftover, _, v1) => {
                   v1.decider.prover.comment("Loop head block: Execute statements of loop head block (in invariant state)")
                   phase1data.foldLeft(Success(): VerificationResult) {
                     case (result, _) if !result.continueVerification => result
@@ -302,7 +302,7 @@ object executor extends ExecutionRules {
              * attempting to re-establish the invariant.
              */
             v.decider.prover.comment("Loop head block: Re-establish invariant")
-            consumes(s, invs, e => LoopInvariantNotPreserved(e), v)((_, _, _) =>
+            consumes(s, invs, false, e => LoopInvariantNotPreserved(e), v)((_, _, _) =>
               Success())
         }
     }
@@ -435,7 +435,7 @@ object executor extends ExecutionRules {
             val resource = fa.res(s.program)
             val ve = pve dueTo InsufficientPermission(fa)
             val description = s"consume ${ass.pos}: $ass"
-            chunkSupporter.consume(s2, s2.h, resource, Seq(tRcvr), eRcvrNew.map(Seq(_)), FullPerm, Option.when(withExp)(ast.FullPerm()(ass.pos, ass.info, ass.errT)), ve, v2, description)((s3, h3, _, v3) => {
+            chunkSupporter.consume(s2, s2.h, resource, Seq(tRcvr), eRcvrNew.map(Seq(_)), FullPerm, Option.when(withExp)(ast.FullPerm()(ass.pos, ass.info, ass.errT)), true, ve, v2, description)((s3, h3, _, v3) => {
               val (tSnap, _) = ssaifyRhs(tRhs, rhs, rhsNew, field.name, field.typ, v3, s3)
               val id = BasicChunkIdentifier(field.name)
               val newChunk = BasicChunk(FieldID, id, Seq(tRcvr), eRcvrNew.map(Seq(_)), tSnap, FullPerm, Option.when(withExp)(ast.FullPerm()(ass.pos, ass.info, ass.errT)))
@@ -486,7 +486,7 @@ object executor extends ExecutionRules {
 
       case exhale @ ast.Exhale(a) =>
         val pve = ExhaleFailed(exhale)
-        consume(s, a, pve, v)((s1, _, v1) =>
+        consume(s, a, false, pve, v)((s1, _, v1) =>
           Q(s1, v1))
 
       case assert @ ast.Assert(a: ast.FalseLit) =>
@@ -500,7 +500,7 @@ object executor extends ExecutionRules {
 
       case assert @ ast.Assert(a) if Verifier.config.disableSubsumption() =>
         val r =
-          consume(s, a, AssertFailed(assert), v)((_, _, _) =>
+          consume(s, a, false, AssertFailed(assert), v)((_, _, _) =>
             Success())
 
         r combine Q(s, v)
@@ -516,11 +516,11 @@ object executor extends ExecutionRules {
            * hUsed (reserveHeaps.head) instead of consuming them. hUsed is later discarded and replaced
            * by s.h. By copying hUsed to s.h the contained permissions remain available inside the wand.
            */
-          consume(s, a, pve, v)((s2, _, v1) => {
+          consume(s, a, true, pve, v)((s2, _, v1) => {
             Q(s2.copy(h = s2.reserveHeaps.head), v1)
           })
         } else
-          consume(s, a, pve, v)((s1, _, v1) => {
+          consume(s, a, false, pve, v)((s1, _, v1) => {
             val s2 = s1.copy(h = s.h, reserveHeaps = s.reserveHeaps)
             Q(s2, v1)})
 
@@ -578,7 +578,7 @@ object executor extends ExecutionRules {
             tArgs zip Seq.fill(tArgs.size)(None)
           val s2 = s1.copy(g = Store(fargs.zip(argsWithExp)),
                            recordVisited = true)
-          consumes(s2, meth.pres, _ => pvePre, v1)((s3, _, v2) => {
+          consumes(s2, meth.pres, false, _ => pvePre, v1)((s3, _, v2) => {
             v2.symbExLog.closeScope(preCondId)
             val postCondLog = new CommentRecord("Postcondition", s3, v2.decider.pcs)
             val postCondId = v2.symbExLog.openScope(postCondLog)

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -32,6 +32,39 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
   final case class FreshSummarisingSnapshot(snapshot: Term) extends TaggedSummarisingSnapshot
   final case class ReusedSummarisingSnapshot(snapshot: Term) extends TaggedSummarisingSnapshot
 
+  private def permSummariseOnly(s: State,
+                            relevantChunks: Seq[NonQuantifiedChunk],
+                            resource: ast.Resource,
+                            args: Seq[Term],
+                            argsExp: Option[Seq[ast.Exp]],
+                            v: Verifier)
+  : (State, Term, Option[ast.Exp]) = {
+    Verifier.config.mapCache(s.ssCache.get((resource, relevantChunks, args))) match {
+      case Some((_, _ ,_permissionSum, _permissionSumExp)) =>
+        return (s, _permissionSum, _permissionSumExp)
+      case _ =>
+      /* Cache miss */
+    }
+    var permissionSum: Term = NoPerm
+    var permissionSumExp: Option[ast.Exp] = Option.when(withExp)(ast.NoPerm()())
+    relevantChunks.foreach(ch => {
+      val argumentEqualities =
+        And(ch.args.zip(args).map { case (t1, t2) => t1 === t2 })
+      val argumentEqualitiesExp =
+        Option.when(withExp)(BigAnd(ch.argsExp.get.zip(argsExp.get).map { case (e1, e2) => ast.EqCmp(e1, e2)() }))
+
+      permissionSum =
+        PermPlus(permissionSum, Ite(argumentEqualities, ch.perm, NoPerm))
+
+      permissionSumExp = permissionSumExp.map(pse =>
+        ast.PermAdd(pse, ast.CondExp(argumentEqualitiesExp.get, ch.permExp.get, ast.NoPerm()())())())
+    })
+    val ssc1 = s.ssCache + ((resource, relevantChunks, args) -> (None, None, permissionSum, permissionSumExp))
+    val s1 = s.copy(ssCache = ssc1)
+
+    (s1, permissionSum, permissionSumExp)
+  }
+
   private def summariseOnly(s: State,
                             relevantChunks: Seq[NonQuantifiedChunk],
                             resource: ast.Resource,
@@ -50,7 +83,7 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     //       could be cached, and ?a1 etc. would be replaced before returning the summary to the caller.
 
     Verifier.config.mapCache(s.ssCache.get((resource, relevantChunks, args))) match {
-      case Some((_taggedSummarisingSnapshot, _summarisingSnapshotDefinitions, _permissionSum, _permissionSumExp)) =>
+      case Some((Some(_taggedSummarisingSnapshot), Some(_summarisingSnapshotDefinitions), _permissionSum, _permissionSumExp)) =>
         return (s, _taggedSummarisingSnapshot, _summarisingSnapshotDefinitions, _permissionSum, _permissionSumExp)
       case _ =>
         /* Cache miss */
@@ -65,8 +98,6 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
     val `?s` = Var(Identifier("?s"), sort, false)
     var summarisingSnapshotDefinitions: Seq[Term] = Vector.empty
-    var permissionSum: Term = NoPerm
-    var permissionSumExp: Option[ast.Exp] = Option.when(withExp)(ast.NoPerm()())
 
     relevantChunks.foreach(ch => {
       val argumentEqualities =
@@ -76,12 +107,6 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
       summarisingSnapshotDefinitions :+=
         Implies(And(argumentEqualities, IsPositive(ch.perm)), `?s` === ch.snap)
-
-      permissionSum =
-        PermPlus(permissionSum, Ite(argumentEqualities, ch.perm, NoPerm))
-
-      permissionSumExp = permissionSumExp.map(pse =>
-        ast.PermAdd(pse, ast.CondExp(argumentEqualitiesExp.get, ch.permExp.get, ast.NoPerm()())())())
     })
 
     val taggedSummarisingSnapshot =
@@ -119,7 +144,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     summarisingSnapshotDefinitions =
       summarisingSnapshotDefinitions map (_.replace(`?s`, summarisingSnapshot))
 
-    val ssc1 = s.ssCache + ((resource, relevantChunks, args) -> (taggedSummarisingSnapshot, summarisingSnapshotDefinitions, permissionSum, permissionSumExp))
+    val (_, permissionSum, permissionSumExp) = permSummariseOnly(s, relevantChunks, resource, args, argsExp, v)
+
+    val ssc1 = s.ssCache + ((resource, relevantChunks, args) -> (Some(taggedSummarisingSnapshot), Some(summarisingSnapshotDefinitions), permissionSum, permissionSumExp))
     val s1 = s.copy(ssCache = ssc1)
 
     (s1, taggedSummarisingSnapshot, summarisingSnapshotDefinitions, permissionSum, permissionSumExp)
@@ -132,9 +159,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                         argsExp: Option[Seq[ast.Exp]],
                         knownValue: Option[Option[Term]], // None if we have not yet checked for a definite alias,
                                                           // Some(v) if we have checked and the result was v
-                        returnSnap: Boolean,
                         v: Verifier)
-                       (Q: (State, Option[Term], Seq[Term], Term, Option[ast.Exp], Verifier) => VerificationResult)
+                       (Q: (State, Term, Term, Option[ast.Exp], Verifier) => VerificationResult)
                        : VerificationResult = {
     // Don't use the shortcut if we want a counterexample; in that case, we need the decider to perform a single
     // query to check if the permission amount we have is sufficient to get the correct counterexample. If we perform
@@ -143,33 +169,28 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     if (relevantChunks.size == 1 &&  !Verifier.config.counterexample.isDefined) {
       val chunk = relevantChunks.head
       if (v.decider.check(And(chunk.args.zip(args).map { case (t1, t2) => t1 === t2 }), Verifier.config.checkTimeout())) {
-        return Q(s, if (returnSnap) Some(chunk.snap) else None, Seq(), chunk.perm, chunk.permExp, v)
+        return Q(s, chunk.snap, chunk.perm, chunk.permExp, v)
       } else {
-        return Q(s, if (returnSnap) Some(chunk.snap) else None, Seq(), NoPerm, Option.when(withExp)(ast.NoPerm()()), v)
+        return Q(s, chunk.snap, NoPerm, Option.when(withExp)(ast.NoPerm()()), v)
       }
     }
 
     val (s1, taggedSnap, snapDefs, permSum, permSumExp) = summariseOnly(s, relevantChunks, resource, args, argsExp, knownValue, v)
+    v.decider.assumeDefinition(And(snapDefs), Option.when(withExp)(DebugExp.createInstance("Snapshot", true)))
+    //    v.decider.assume(PermAtMost(permSum, FullPerm())) /* Done in StateConsolidator instead */
 
-    if(returnSnap) {
-      v.decider.assumeDefinition(And(snapDefs), Option.when(withExp)(DebugExp.createInstance("Snapshot", true)))
-      //    v.decider.assume(PermAtMost(permSum, FullPerm())) /* Done in StateConsolidator instead */
+    val s2 =
+      taggedSnap match {
+        case _: FreshSummarisingSnapshot =>
+          val smd = SnapshotMapDefinition(resource, taggedSnap.snapshot, snapDefs, Seq.empty)
+          val fr2 = s1.functionRecorder.recordFvfAndDomain(smd)
 
-      val s2 =
-        taggedSnap match {
-          case _: FreshSummarisingSnapshot =>
-            val smd = SnapshotMapDefinition(resource, taggedSnap.snapshot, snapDefs, Seq.empty)
-            val fr2 = s1.functionRecorder.recordFvfAndDomain(smd)
+          s1.copy(functionRecorder = fr2)
+        case _ =>
+          s1
+      }
 
-            s1.copy(functionRecorder = fr2)
-          case _ =>
-            s1
-        }
-
-      Q(s2, Some(taggedSnap.snapshot), snapDefs, permSum, permSumExp, v)
-    } else {
-      Q(s1,None, snapDefs, permSum, permSumExp, v)
-    }
+    Q(s2, taggedSnap.snapshot, permSum, permSumExp, v)
   }
 
   def lookupComplete(s: State,
@@ -192,10 +213,10 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         createFailure(ve, v, s, False, "branch is dead")
       }
     } else {
-      summarise(s, relevantChunks, resource, args, argsExp, None, true, v)((s1, snap, _, permSum, permSumExp, v1) =>
+      summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
         v.decider.assert(IsPositive(permSum)) {
           case true =>
-            Q(s1, snap.get, v1)
+            Q(s1, snap, v1)
           case false =>
             createFailure(ve, v, s1, IsPositive(permSum), permSumExp.map(IsPositive(_)()))
         })
@@ -235,14 +256,23 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
     val id = ChunkIdentifier(resource, s.program)
     val relevantChunks = findChunksWithID[NonQuantifiedChunk](h.values, id).toSeq
-
-    summarise(s, relevantChunks, resource, args, argsExp, None, returnSnap, v)((s1, snap, _, permSum, permSumExp, v1) =>
+    if (returnSnap) {
+      summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
+        v.decider.assert(IsPositive(permSum)) {
+          case true =>
+            Q(s1, h, Some(snap), v1)
+          case false =>
+            createFailure(ve, v, s1, IsPositive(permSum), permSumExp.map(IsPositive(_)()))
+        })
+    } else {
+      val (s1, permSum, permSumExp) = permSummariseOnly(s, relevantChunks, resource, args, argsExp, v)
       v.decider.assert(IsPositive(permSum)) {
         case true =>
-          Q(s1, h, snap, v1)
+          Q(s1, h, None, v)
         case false =>
           createFailure(ve, v, s1, IsPositive(permSum), permSumExp.map(IsPositive(_)()))
-      })
+      }
+    }
   }
 
   private def actualConsumeComplete(s: State,
@@ -354,16 +384,15 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
         val s0 = s.copy(functionRecorder = currentFunctionRecorder)
 
-        summarise(s0, relevantChunks.toSeq, resource, args, argsExp, Some(definiteAlias.map(_.snap)), returnSnap, v)((s1, snap, _, _, _, v1) => {
-          val condSnap = if (returnSnap) {
-            Some(if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout())) {
-              snap.get
+
+
+        if (returnSnap) {
+          summarise(s0, relevantChunks.toSeq, resource, args, argsExp, Some(definiteAlias.map(_.snap)), v)((s1, snap, _, _, v1) => {
+            val condSnap = Some(if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout())) {
+              snap
             } else {
-              Ite(IsPositive(perms), snap.get.convert(sorts.Snap), Unit)
+              Ite(IsPositive(perms), snap.convert(sorts.Snap), Unit)
             })
-          } else {
-            None
-          }
           if (!moreNeeded) {
             Q(s1, newHeap, condSnap, v1)
           } else {
@@ -375,6 +404,18 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
             }
           }
         })
+        } else {
+          if (!moreNeeded) {
+            Q(s, newHeap, None, v)
+          } else {
+            v.decider.assert(pNeeded === NoPerm) {
+              case true =>
+                Q(s, newHeap, None, v)
+              case false =>
+                createFailure(ve, v, s, pNeeded === NoPerm, pNeededExp.map(pn => ast.EqCmp(pn, ast.NoPerm()())(pn.pos, pn.info, pn.errT)))
+            }
+          }
+        }
       }
     }
   }
@@ -450,15 +491,17 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
       case true =>
         val constraintExp = permsExp.map(pe => ast.EqCmp(pe, totalPermTakenExp.get)())
         v.decider.assume(perms === totalPermTaken, Option.when(withExp)(DebugExp.createInstance(constraintExp, constraintExp)))
-        summarise(s1, relevantChunks.toSeq, resource, args, argsExp, None, returnSnap, v)((s2, snap, _, _, _, v1) =>
-          Q(s2, updatedChunks, snap, v1))
+        if (returnSnap) {
+          summarise(s1, relevantChunks.toSeq, resource, args, argsExp, None, v)((s2, snap, _, _, v1) =>
+            Q(s2, updatedChunks, Some(snap), v1))
+        } else {
+          Q(s1, updatedChunks, None, v)
+        }
       case false =>
         v.decider.finishDebugSubExp(s"consume permissions for ${resource.toString()}")
         createFailure(ve, v, s, totalPermTaken !== NoPerm, totalPermTakenExp.map(tpt => ast.NeCmp(tpt, ast.NoPerm()())()))
     }
-
   }
-
 
   private val freeReceiver = Var(Identifier("?rcvr"), sorts.Ref, false)
   private val freeReceiverExp = ast.LocalVar("?rcvr", ast.Ref)()

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -70,16 +70,16 @@ object predicateSupporter extends PredicateSupportRules {
     val s1 = s.copy(g = gIns,
                     smDomainNeeded = true)
               .scalePermissionFactor(tPerm, ePerm)
-    consume(s1, body, pve, v)((s1a, snap, v1) => {
+    consume(s1, body, true, pve, v)((s1a, snap, v1) => {
       if (!Verifier.config.disableFunctionUnfoldTrigger()) {
         val predTrigger = App(s1a.predicateData(predicate).triggerFunction,
-          snap.convert(terms.sorts.Snap) +: tArgs)
+          snap.get.convert(terms.sorts.Snap) +: tArgs)
         val eArgsString = eArgs.mkString(", ")
         v1.decider.assume(predTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${predicate.name}($eArgsString))")))
       }
       val s2 = s1a.setConstrainable(constrainableWildcards, false)
       if (s2.qpPredicates.contains(predicate)) {
-        val predSnap = snap.convert(s2.predicateSnapMap(predicate))
+        val predSnap = snap.get.convert(s2.predicateSnapMap(predicate))
         val formalArgs = s2.predicateFormalVarMap(predicate)
         val (sm, smValueDef) =
           quantifiedChunkSupporter.singletonSnapshotMap(s2, predicate, tArgs, predSnap, v1)
@@ -113,7 +113,7 @@ object predicateSupporter extends PredicateSupportRules {
                          functionRecorder = s2.functionRecorder.recordFvfAndDomain(smDef))
         Q(s3, v1)
       } else {
-        val ch = BasicChunk(PredicateID, BasicChunkIdentifier(predicate.name), tArgs, eArgs, snap.convert(sorts.Snap), tPerm, ePerm)
+        val ch = BasicChunk(PredicateID, BasicChunkIdentifier(predicate.name), tArgs, eArgs, snap.get.convert(sorts.Snap), tPerm, ePerm)
         val s3 = s2.copy(g = s.g,
                          smDomainNeeded = s.smDomainNeeded,
                          permissionScalingFactor = s.permissionScalingFactor,
@@ -156,18 +156,19 @@ object predicateSupporter extends PredicateSupportRules {
         pa,
         tPerm,
         ePerm,
+        true,
         None,
         pve,
         v
       )((s2, h2, snap, v1) => {
         val s3 = s2.copy(g = gIns, h = h2)
                    .setConstrainable(constrainableWildcards, false)
-        produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
+        produce(s3, toSf(snap.get), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
           if (!Verifier.config.disableFunctionUnfoldTrigger()) {
             val predicateTrigger =
               App(s4.predicateData(predicate).triggerFunction,
-                snap.convert(terms.sorts.Snap) +: tArgs)
+                snap.get.convert(terms.sorts.Snap) +: tArgs)
             val eargs = eArgs.mkString(", ")
             v2.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${predicate.name}($eargs))")))
           }
@@ -179,14 +180,14 @@ object predicateSupporter extends PredicateSupportRules {
     } else {
       val ve = pve dueTo InsufficientPermission(pa)
       val description = s"consume ${pa.pos}: $pa"
-      chunkSupporter.consume(s1, s1.h, predicate, tArgs, eArgs, s1.permissionScalingFactor, s1.permissionScalingFactorExp, ve, v, description)((s2, h1, snap, v1) => {
+      chunkSupporter.consume(s1, s1.h, predicate, tArgs, eArgs, s1.permissionScalingFactor, s1.permissionScalingFactorExp, true, ve, v, description)((s2, h1, snap, v1) => {
         val s3 = s2.copy(g = gIns, h = h1)
                    .setConstrainable(constrainableWildcards, false)
-        produce(s3, toSf(snap), body, pve, v1)((s4, v2) => {
+        produce(s3, toSf(snap.get), body, pve, v1)((s4, v2) => {
           v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
           if (!Verifier.config.disableFunctionUnfoldTrigger()) {
             val predicateTrigger =
-              App(s4.predicateData(predicate).triggerFunction, snap +: tArgs)
+              App(s4.predicateData(predicate).triggerFunction, snap.get +: tArgs)
             val eargs = eArgs.mkString(", ")
             v2.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${pa.predicateName}($eargs))")))
           }

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1376,7 +1376,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               permissionRemovalResult match {
                 case (Complete(), s2, remainingChunks) =>
                   val h3 = Heap(remainingChunks ++ otherChunks)
-                  if(returnSnap) {
+                  if (returnSnap) {
                     val optSmDomainDefinitionCondition2 =
                       if (s2.smDomainNeeded) Some(And(condOfInvOfLoc, IsPositive(lossOfInvOfLoc), And(And(imagesOfFormalQVars))))
                       else None

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -595,11 +595,6 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         SetIn(qvar, PredicateDomain(MagicWandIdentifier(wand, s.program).toString, sm))
     }
 
-    val resourceIdentifier = resource match {
-      case wand: ast.MagicWand => MagicWandIdentifier(wand, s.program)
-      case r => r
-    }
-
     val valueDefinitions =
       relevantChunks map (chunk => {
         val lookupSummary = ResourceLookup(resource, sm, Seq(qvar), s.program)
@@ -611,11 +606,10 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           if (codomainQVars.nonEmpty) qvar !== Unit
           else qvar === Unit // TODO: Consider if axioms can be simplified in case codomainQVars is empty
 
-        val effectiveCondition = {
+        val effectiveCondition =
           And(
             transformedOptSmDomainDefinitionCondition.getOrElse(True), /* Alternatively: qvarInDomainOfSummarisingSm */
             IsPositive(chunk.perm).replace(snapToCodomainTermsSubstitution))
-        }
 
         Forall(
           qvar,
@@ -625,6 +619,10 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           isGlobal = relevantQvars.isEmpty)
       })
 
+    val resourceIdentifier = resource match {
+      case wand: ast.MagicWand => MagicWandIdentifier(wand, s.program)
+      case r => r
+    }
     val resourceAndValueDefinitions = if (s.heapDependentTriggers.contains(resourceIdentifier)){
       val resourceTriggerDefinition =
         Forall(
@@ -813,6 +811,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             (smDef, s.smCache + (key, value))
           }
       }
+
     emitSnapshotMapDefinition(s, smDef, v, optQVarsInstantiations)
 
     (smDef, smCache)
@@ -1353,7 +1352,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                 optCh match {
                   case Some(ch) if returnSnap => Q(s4, s4.h, Some(ch.snapshotMap.convert(sorts.Snap)), v3)
                   case None if returnSnap =>
-                    Q(s4, s4.h, Some(freshSnap(sorts.Snap, v3)), v3) //Why do we not record this new snapshot?
+                    Q(s4, s4.h, Some(freshSnap(sorts.Snap, v3)), v3)
                   case _ => Q(s4, s4.h, None, v3)
                 }
               )
@@ -1479,7 +1478,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             val snap = ResourceLookup(resource, ch.snapshotMap, arguments, s4.program).convert(sorts.Snap)
             Q(s4, s4.h, Some(snap), v2)
           case None if returnSnap =>
-            Q(s4, s4.h, Some(freshSnap(sorts.Snap, v2)), v2) //Why do we not record this new snapshot?
+            Q(s4, s4.h, Some(freshSnap(sorts.Snap, v2)), v2)
           case _ => Q(s4, s4.h, None, v2)
         }
       )

--- a/src/main/scala/state/package.scala
+++ b/src/main/scala/state/package.scala
@@ -21,5 +21,5 @@ package object state {
   type SsCache =
     Map[
       (ast.Resource, Seq[NonQuantifiedChunk], Seq[Term]),
-      (TaggedSummarisingSnapshot, Seq[Term], Term, Option[ast.Exp])]
+      (Option[TaggedSummarisingSnapshot], Option[Seq[Term]], Term, Option[ast.Exp])]
 }

--- a/src/main/scala/supporters/MethodSupporter.scala
+++ b/src/main/scala/supporters/MethodSupporter.scala
@@ -111,7 +111,7 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
             && {
                executionFlowController.locally(s2a, v2)((s3, v3) =>  {
                   exec(s3, body, v3)((s4, v4) =>
-                    consumes(s4, posts, true, postViolated, v4)((_, _, _) =>
+                    consumes(s4, posts, false, postViolated, v4)((_, _, _) =>
                       Success()))}) }  )})})
 
       v.decider.resetProverOptions()

--- a/src/main/scala/supporters/MethodSupporter.scala
+++ b/src/main/scala/supporters/MethodSupporter.scala
@@ -111,7 +111,7 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
             && {
                executionFlowController.locally(s2a, v2)((s3, v3) =>  {
                   exec(s3, body, v3)((s4, v4) =>
-                    consumes(s4, posts, postViolated, v4)((_, _, _) =>
+                    consumes(s4, posts, true, postViolated, v4)((_, _, _) =>
                       Success()))}) }  )})})
 
       v.decider.resetProverOptions()

--- a/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
+++ b/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
@@ -264,7 +264,7 @@ trait DefaultFunctionVerificationUnitProvider extends VerifierComponent { v: Ver
                 Some(DebugExp.createInstance(e, eNew))
               } else { None }
               decider.assume(BuiltinEquals(data.formalResult, tBody), debugExp)
-              consumes(s2, posts, true, postconditionViolated, v)((s3, _, _) => {
+              consumes(s2, posts, false, postconditionViolated, v)((s3, _, _) => {
                 recorders :+= s3.functionRecorder
                 Success()})})})}
 

--- a/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
+++ b/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
@@ -264,7 +264,7 @@ trait DefaultFunctionVerificationUnitProvider extends VerifierComponent { v: Ver
                 Some(DebugExp.createInstance(e, eNew))
               } else { None }
               decider.assume(BuiltinEquals(data.formalResult, tBody), debugExp)
-              consumes(s2, posts, postconditionViolated, v)((s3, _, _) => {
+              consumes(s2, posts, true, postconditionViolated, v)((s3, _, _) => {
                 recorders :+= s3.functionRecorder
                 Success()})})})}
 


### PR DESCRIPTION
During the execution of certain statements, consume generates snapshots that are unused. For consuming QP-Chunks, this results in unnecessary snapshot map definitions being triggered, increasing the number of quantifier instantiations and negatively impacting performance.

To address this, snapshot generation is now prevented for these cases. While the primary performance improvement applies to consuming QP-Chunks, the change is also applied to consuming non-QP-Chunks to ensure consistent behavior across all scenarios.

**Example:** 
```
var rs: Set[Ref]
var x: Ref
var val: Int
assume x in rs
inhale forall r: Ref :: r in rs ==> acc(r.f)

val := x.f // This will trigger all snapshot map definitions related to x.f.

exhale forall r: Ref :: r in rs ==> acc(r.f, 1/3) 
exhale forall r: Ref :: r in rs ==> acc(r.f, 1/3) 
// The exhales will create new snapshot map definitions which are never needed but still triggered.
```

**Affected Statements:**

Field assignments
Method calls (consume of pres)
Exhale statements
Assert statements
While loops (consume of invariants)
