### PR TITLE
QP single-recvr merge Issue

### DIFF
--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1968,11 +1968,11 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       case qfc: QuantifiedFieldChunk if qfc.invs.isDefined =>
         Left(qfc.invs.get.invertibles, qfc.quantifiedVars, qfc.condition)
       case qfc: QuantifiedFieldChunk if qfc.singletonArguments.isDefined =>
-        Right(qfc.singletonArguments.get)
+        Right(qfc.singletonArguments.get, qfc.condition)
       case qpc: QuantifiedPredicateChunk if qpc.invs.isDefined =>
         Left(qpc.invs.get.invertibles, qpc.quantifiedVars, qpc.condition)
       case qpc: QuantifiedPredicateChunk if qpc.singletonArguments.isDefined =>
-        Right(qpc.singletonArguments.get)
+        Right(qpc.singletonArguments.get, qpc.condition)
       case _ => return None
     }
     val relevantChunks: Iterable[QuantifiedBasicChunk] = chunks.flatMap {
@@ -1982,19 +1982,25 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     val (receiverTerms, quantVars, cond) = lr match {
       case Left(tuple) => tuple
-      case Right(singletonArguments) =>
+      case Right((singletonArguments, cond)) =>
         return relevantChunks.find { ch =>
           val chunkInfo = ch match {
             case qfc: QuantifiedFieldChunk if qfc.singletonArguments.isDefined =>
-              Some(qfc.singletonArguments.get)
+              Some(qfc.singletonArguments.get, qfc.condition)
             case qpc: QuantifiedPredicateChunk if qpc.singletonArguments.isDefined =>
-              Some(qpc.singletonArguments.get)
+              Some(qpc.singletonArguments.get, qpc.condition)
             case _ => None
           }
           chunkInfo match {
-            case Some(cSingletonArguments) =>
+            case Some((cSingletonArguments, cCond)) =>
+
               val equalityTerm = And(singletonArguments.zip(cSingletonArguments).map { case (a, b) => a === b })
-              val result = v.decider.check(equalityTerm, Verifier.config.checkTimeout())
+              // The conditions of two chunks with the same receivers can differ if they originate from separate branches
+              // that were joined. In such cases, additional conjuncts might have been added to the conditions.
+              // Hence, we need to compare the conditions for equality in addition to verifying that the receivers match.
+              val equalityCond = And(cond.replace(chunk.quantifiedVars, singletonArguments),
+                cCond.replace(ch.quantifiedVars, cSingletonArguments))
+              val result = v.decider.check(And(equalityCond, equalityTerm), Verifier.config.checkTimeout())
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))


### PR DESCRIPTION
Currently, we merge QP single-receiver chunks if they have the same `singletonArguments`. This implicitly assumes that their conditions are also identical. However, this assumption does not hold when chunks with the same receiver originate from separate branches and are joined using `moreJoins`. In such cases, additional conjuncts may have been added to the conditions. Therefore, we need to verify that both the conditions and the receivers match before merging the chunks. 
The following example illustrates this issue more clearly:

```
field f: Int

// issue when run with --moreJoins 2
method foo(x: Ref, xs: Set[Ref])
    requires acc(x.f, 1/2)
    requires forall r: Ref :: { r in xs } r in xs ==> acc(r.f)
{
    var b: Bool

    if (b) {
        inhale acc(x.f, 1/2)
        // At this point, there are two separate single-receiver-qp-chunks:
        // 1) forall r: Ref :: (r == x ? 1/2 : Z)
        // 2) forall r: Ref :: (r == x ? 1/2 : Z)
        // These chunks are merged into a single combined chunk:
        //    `forall r: Ref :: (r == x ? W : Z)`
    } else {
        inhale acc(x.f, 1/2)
        // same here
    }

    assert acc(x.f)
    // After joining the two branches, we again have two chunks:
    // 1) forall r: Ref :: (b && r == x ? W : Z)
    // 2) forall r: Ref :: (!b && r == x ? W : Z)
    // The qp-merging logic assumes all chunks for the same receiver x share the same condition.
    // This assumption breaks because the conditions differ between the branches.
    // As a result, the chunks are merged by retaining the condition of the first chunk
    // and summing their permissions:
    //    (b && r == x ? 2/1 : Z)
}
```

**Q**: Should we add this example as a test case? If so, where should be add it?

Fixes: #883