### PR TITLE
Fixing --conditionalizePermissions for old function permission semantics flag

### DIFF
--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -484,7 +484,7 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
     val s1 = s.copy(functionRecorder = newFr)
 
-    v.decider.assert(totalPermTaken !== NoPerm) {
+    v.decider.assert(Implies(PermLess(NoPerm, perms), totalPermTaken !== NoPerm)) {
       case true =>
         val constraintExp = permsExp.map(pe => ast.EqCmp(pe, totalPermTakenExp.get)())
         v.decider.assume(perms === totalPermTaken, Option.when(withExp)(DebugExp.createInstance(constraintExp, constraintExp)))

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -191,7 +191,7 @@ class DefaultMainVerifier(config: Config,
     // TODO: Autotrigger for cfgs.
 
     if (config.conditionalizePermissions()) {
-      program = new ConditionalPermissionRewriter().rewrite(program).asInstanceOf[ast.Program]
+      program = new ConditionalPermissionRewriter().rewrite(program, !config.respectFunctionPrePermAmounts()).asInstanceOf[ast.Program]
     }
 
     if (config.printTranslatedProgram()) {


### PR DESCRIPTION
Letting the ConditionalPermissionRewriter create conditional wildcards in functions only if the new function permission semantics is used, i.e., when --respectFunctionPrePermAmounts is not set.