### PR TITLE
Adding missing debug old labels around heap-dependent func apps

### DIFF
--- a/src/main/scala/verifier/Verifier.scala
+++ b/src/main/scala/verifier/Verifier.scala
@@ -59,7 +59,7 @@ trait Verifier {
     */
   def getDebugOldLabel(s: State, pos: ast.Position, h: Option[Heap] = None): (String, String) = {
     val posString = pos match {
-      case column: ast.HasLineColumn => s"l:${column.line + 1}.${column.column + 1}"
+      case column: ast.HasLineColumn => s"l:${column.line}.${column.column}"
       case _ => s"l:unknown"
     }
     val heap = h match {


### PR DESCRIPTION
Also fixing line numbers in debug labels.

This fixes an issue found by Jack.