### PR TITLE
Simplify quantifier with preconditions for QP injectivity check

### DIFF
--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -987,11 +987,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val receiverInjectivityCheck =
           if (!Verifier.config.assumeInjectivityOnInhale()) {
             val simplifiedAssumptions = FunctionPreconditionTransformer.transform(Forall(qvars, Implies.actualCreate((And(tCond, IsPositive(tPerm)), And(tArgs.map(a => BuiltinEquals.actualCreate((a, a)))))), Nil, s"$qid-rcvrInjPreconditions"), s.program)
-            val simplifiedAssumptionsWithTrigger = simplifiedAssumptions match {
-              case quantification: Quantification => v.quantifierSupporter.autoTrigger(quantification)
-              case _ => simplifiedAssumptions
-            }
-            v.decider.assume(simplifiedAssumptionsWithTrigger, Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
+            v.decider.assume(simplifiedAssumptions, Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
             quantifiedChunkSupporter.injectivityAxiom(
               qvars     = qvars,
               // TODO: Adding ResourceTriggerFunction requires a summarising snapshot map of the current heap
@@ -1259,11 +1255,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             program = s.program)
         v.decider.prover.comment("Check receiver injectivity")
         val simplifiedAssumptions = FunctionPreconditionTransformer.transform(Forall(qvars, Implies.actualCreate((And(tCond, IsPositive(tPerm)), And(tArgs.map(a => BuiltinEquals.actualCreate((a, a)))))), Nil, s"$qid-rcvrInjNew"), s.program)
-        val simplifiedAssumptionsWithTrigger = simplifiedAssumptions match {
-          case quantification: Quantification => v.quantifierSupporter.autoTrigger(quantification)
-          case _ => simplifiedAssumptions
-        }
-        v.decider.assume(simplifiedAssumptionsWithTrigger, Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
+        v.decider.assume(simplifiedAssumptions, Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
         v.decider.assert(receiverInjectivityCheck) {
           case true =>
             val qvarsToInvOfLoc = inverseFunctions.qvarsToInversesOf(formalQVars)

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -998,10 +998,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           }
         val comment = "Check receiver injectivity"
         v.decider.prover.comment(comment)
+        v.decider.pushScope()
         v.decider.assume(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program),
           Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
         v.decider.assert(receiverInjectivityCheck) {
           case true =>
+            v.decider.popScope()
             val ax = inverseFunctions.axiomInversesOfInvertibles
             val inv = inverseFunctions.copy(axiomInversesOfInvertibles = Forall(ax.vars, ax.body, effectiveTriggers))
 
@@ -1072,8 +1074,11 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                      conservedPcs = conservedPcs,
                      smCache = smCache1)
             Q(s1, v)
-          case false =>
-            createFailure(pve dueTo notInjectiveReason, v, s, receiverInjectivityCheck, "QP receiver is injective")}
+          case false => {
+            v.decider.popScope()
+            createFailure(pve dueTo notInjectiveReason, v, s, receiverInjectivityCheck, "QP receiver is injective")
+          }
+        }
       case false =>
         createFailure(pve dueTo negativePermissionReason, v, s, nonNegImplication, nonNegImplicationExp)}
   }
@@ -1252,9 +1257,11 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             qidPrefix = qid,
             program = s.program)
         v.decider.prover.comment("Check receiver injectivity")
+        v.decider.pushScope()
         v.decider.assume(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
         v.decider.assert(receiverInjectivityCheck) {
           case true =>
+            v.decider.popScope();
             val qvarsToInvOfLoc = inverseFunctions.qvarsToInversesOf(formalQVars)
             val condOfInvOfLoc = tCond.replace(qvarsToInvOfLoc)
             val lossOfInvOfLoc = loss.replace(qvarsToInvOfLoc)
@@ -1395,8 +1402,10 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                 case (Incomplete(_, _), s2, _) =>
                   createFailure(pve dueTo insufficientPermissionReason, v, s2, "QP consume")}
             }
-          case false =>
+          case false => {
+            v.decider.popScope();
             createFailure(pve dueTo notInjectiveReason, v, s, receiverInjectivityCheck, "QP receiver injective")}
+        }
       case false =>
         createFailure(pve dueTo negativePermissionReason, v, s, nonNegTerm, nonNegExp)}
   }
@@ -1701,7 +1710,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     v.decider.prover.comment("Done removing quantified permissions")
     v.symbExLog.closeScope(sepIdentifier)
-    
+
     (success, s.copy(functionRecorder = currentFunctionRecorder), remainingChunks)
   }
 


### PR DESCRIPTION
Hi,
I've been looking into improving Silicon's performance on some of the VerCors case studies that I am trying out.  Most of the bottlenecks that I run into have to do with the quantified permission support. I'm hoping to contribute more ideas/PRs in the future. (I do have some things in mind, but I haven't quite made them concrete yet)

## The problem
When investigating a slow verification using SMTScope I noticed that the quantifier that is inhaled before the injectivity check for quantified permissions was instantiated unusually often. I had noticed this before on other files, but given the name `fieldname-rcvrInj` I had assumed it was a quantifier expressing injectivity. But, it is a quantifier that says that the preconditions of the functions used in the expression are true. 

## The improvement
It seemed to me that this quantifier would only be needed for this injectivity check. So I added a push/pop around it which worked great for the Viper test suite, but I found some examples in the VerCors test suite that broke due to the now missing knowledge. Here is a minimized example:
<details><summary>Example</summary>
<p>

```viper
domain Array  {
  function array_loc(a: Array, i: Int): Ref

  function alen(a: Array): Int

  function loc_inv_1(loc: Ref): Array

  function loc_inv_2(loc: Ref): Int

  axiom {
    (forall a: Array, i: Int ::
      { array_loc(a, i) }
      loc_inv_1(array_loc(a, i)) == a && loc_inv_2(array_loc(a, i)) == i)
  }

  axiom {
    (forall a: Array :: { alen(a) } alen(a) >= 0)
  }
}


field int: Int

function aloc(a: Array, i: Int): Ref
  requires 0 <= i
  requires i < alen(a)
  ensures loc_inv_1(result) == a
  ensures loc_inv_2(result) == i
  decreases
{
  array_loc(a, i)
}

function scale(amount: Perm): Perm
  requires amount >= 0 * write
  ensures result >= 0 * write
  decreases
{
  amount
}

predicate main(arr: Array) {
    (forall i: Int :: { aloc(arr, i) } 0 <= i && i < alen(arr) ==> acc(aloc(arr, i).int, scale(write) * write)) &&
    (forall i: Int :: { aloc(arr, i) } 0 <= i && i < alen(arr) ==> 0 <= aloc(arr, i).int)
}
```

With the added push/pop this breaks because when accessing `aloc(arr, i).int` in the last line it can no longer determine that `scale(write) * write` is greater than zero. 
</p>
</details> 

Of course, by extension, this example also fails with `--assumeInjectivityOnInhale` even without the changes from my PR.

Since I still wanted to speed up my case study I tried a few more options:
- Generating triggers for this precondition quantifier with `quantifierSupporter.autoTrigger`
- Simplifying the precondition quantifier by using only one set of quantified variables (because it was based on the injectivity check it had two sets of the quantified variables)
- Simplifying the precondition quantifier and generating triggers for it

## Results
I ran my file 10 times to get an idea of the performance difference between the different options. Note that the user/system times only count Silicon's execution time and not its child processes, i.e., Z3.

### Normal without triggers
This is the baseline measurement
``` 
  Time (mean ± σ):     21.274 s ±  0.851 s    [User: 50.287 s, System: 4.702 s]
  Range (min … max):   20.205 s … 22.824 s    10 runs
```

### With push/pop
This was the fastest for this example but as I said above there were some examples where this is less complete
``` 
  Time (mean ± σ):     17.693 s ±  0.421 s    [User: 41.324 s, System: 4.049 s]
  Range (min … max):   16.998 s … 18.239 s    10 runs
``` 

### Normal with triggers
This did not succeed in verifying the example, I assume the triggers are either too restrictive or at least worse in some way compared to the one generated by Z3 itself. 

### Simplified without triggers
This made a pretty decent difference,  I suppose it's mostly about introducing fewer terms through the instantiation of the quantifier. There is one VerCors example that runs out of memory in Z3 with this option but that is likely just because that example is overly complicated / needs improvement.
``` 
  Time (mean ± σ):     18.127 s ±  0.672 s    [User: 43.937 s, System: 4.371 s]
  Range (min … max):   16.991 s … 19.503 s    10 runs
``` 

### Simplified with triggers
Interestingly generating triggers again performs worse than letting Z3 choose the triggers. For the overly complicated VerCors example mentioned previously here silicon runs out of memory while generating a trigger since it finds 120 candidate expressions that attempt to form triggers with for 6 variables. (I guess that's somewhere between 2^120 and 6^120 possible trigger sets to explore since the candidate expressions generally only contain one or two quantified variables) But again I don't think that is a significant problem because the example is just overly complicated, although maybe Silicon should have some sort of maximum iteration count.
``` 
  Time (mean ± σ):     20.523 s ±  1.343 s    [User: 49.857 s, System: 4.572 s]
  Range (min … max):   18.897 s … 22.150 s    10 runs
``` 

## Summary
This PR currently has the simplified quantifier without triggers approach that I would be happy to see merged since it shows a marginal improvement on my case studies. I don't think the issue I presented here is in general related to what makes QPs slow, but it is some low-hanging fruit that was easy to tackle. However, I am also curious to hear the Viper developers' opinion on this change, the other options I discussed, and slow verification with quantified permissions in general.  In particular, I am wondering if there is more low-hanging fruit like this and whether there are plans to improve things like the chunk ordering heuristics in the future. 