### PR TITLE
Fixing variable counterexamples and adding tests

### DIFF
--- a/src/main/scala/interfaces/Verification.scala
+++ b/src/main/scala/interfaces/Verification.scala
@@ -10,7 +10,7 @@ import viper.silicon.debugger.{DebugAxiom, DebugExp, DebugExpPrintConfiguration}
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.interfaces.state.Chunk
 import viper.silicon.reporting._
-import viper.silicon.state.terms.{FunctionDecl, MacroDecl, Term}
+import viper.silicon.state.terms.{BooleanLiteral, FunctionDecl, IntLiteral, MacroDecl, Term, Var}
 import viper.silicon.state.{State, Store}
 import viper.silicon.verifier.Verifier
 import viper.silver.ast
@@ -166,11 +166,22 @@ case class SiliconNativeCounterexample(internalStore: Store, heap: Iterable[Chun
 
 case class SiliconVariableCounterexample(internalStore: Store, nativeModel: Model) extends SiliconCounterexample {
   override val model: Model = {
-    Model(internalStore.values.filter{
-      case (_,v) => nativeModel.entries.contains(v.toString)
-    }.map{
-      case (k, v) => k.name -> nativeModel.entries(v.toString)
-    })
+    val variableValues = internalStore.values.filter {
+      case (_, (v: Var, _)) => nativeModel.entries.contains(v.toString)
+      case _ => false
+    }.map {
+      case (k, (v, _)) => k.name -> nativeModel.entries(v.toString)
+    }
+    val constantValues = internalStore.values.filter {
+      case (_, (_: IntLiteral, _)) => true
+      case (_, (_: BooleanLiteral, _)) => true
+      case _ => false
+    }.map {
+      case (k, (i: IntLiteral, _)) => k.name -> ConstantEntry(i.toString)
+      case (k, (b: BooleanLiteral, _)) => k.name -> ConstantEntry(b.toString)
+    }
+
+    Model(variableValues ++ constantValues)
   }
 
   override def withStore(s: Store): SiliconCounterexample = {

--- a/src/test/scala/CounterexampleTests.scala
+++ b/src/test/scala/CounterexampleTests.scala
@@ -7,11 +7,10 @@
 package viper.silicon.tests
 
 import viper.silicon.Silicon
-import viper.silver.testing.{AbstractOutput, CustomAnnotation, DefaultAnnotatedTestInput, DefaultTestInput, OutputAnnotationId, SilOutput, TestAnnotation, TestAnnotationParser, TestCustomError, TestError, TestInput}
+import viper.silver.testing.{AbstractOutput, CounterexampleParser, CustomAnnotation, DefaultAnnotatedTestInput, DefaultTestInput, ExpectedCounterexample, OutputAnnotationId, SilOutput, TestAnnotation, TestAnnotationParser, TestCustomError, TestError, TestInput}
 import fastparse._
 import viper.silicon.interfaces.SiliconMappedCounterexample
 import viper.silicon.reporting.{ExtractedModel, ExtractedModelEntry, LitIntEntry, LitPermEntry, NullRefEntry, RecursiveRefEntry, RefEntry, SeqEntry}
-import viper.silver.parser.FastParserCompanion.whitespace
 import viper.silver.parser.{FastParser, PAccPred, PBinExp, PExp, PFieldAccess, PIdnUseExp, PIntLit, PLookup, PSymOp, PUnExp}
 import viper.silver.utility.Common.Rational
 import viper.silver.verifier.{FailureContext, VerificationError}
@@ -166,25 +165,4 @@ case class ExpectedCounterexampleAnnotation(id: OutputAnnotationId, file: Path, 
   override def notFoundError: TestError = TestCustomError(s"Expected the following counterexample on line $forLineNr: $expectedCounterexample")
 
   override def withForLineNr(line: Int = forLineNr): ExpectedCounterexampleAnnotation = ExpectedCounterexampleAnnotation(id, file, line, expectedCounterexample)
-}
-
-/**
-  * Simple input language to describe an expected counterexample with corresponding parser.
-  * Currently, a counterexample is expressed by a comma separated list of access predicates and equalities (using the
-  * same syntax as in Viper)
-  */
-class CounterexampleParser(fp: FastParser) {
-  import fp.{accessPred, eqExp}
-
-  def expectedCounterexample[_: P]: P[ExpectedCounterexample] =
-    (Start ~ "(" ~ (accessPred | eqExp).rep(0, ",") ~ ")" ~ End)
-      .map(ExpectedCounterexample)
-}
-
-case class ExpectedCounterexample(exprs: Seq[PExp]) {
-  assert(exprs.forall {
-    case _: PAccPred => true
-    case PBinExp(_, r, _) if r.rs == PSymOp.EqEq => true
-    case _ => false
-  })
 }

--- a/src/test/scala/SiliconCounterexampleVariablesTests.scala
+++ b/src/test/scala/SiliconCounterexampleVariablesTests.scala
@@ -1,0 +1,81 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2025 ETH Zurich.
+
+package viper.silicon.tests
+
+import viper.silicon.Silicon
+import viper.silver.testing.{AbstractOutput, CounterexampleVariablesTests, CustomAnnotation, ExpectedCounterexample, OutputAnnotationId, SilOutput, TestCustomError, TestError}
+import viper.silicon.interfaces.SiliconVariableCounterexample
+import viper.silver.parser.{PBinExp, PBoolLit, PExp, PIdnUseExp, PIntLit, PSymOp, PUnExp}
+import viper.silver.verifier.{ConstantEntry, FailureContext, Model, ModelEntry, VerificationError}
+
+import java.nio.file.Path
+
+class SiliconCounterexampleVariablesTests extends SiliconTests with CounterexampleVariablesTests {
+
+  override def configureVerifiersFromConfigMap(configMap: Map[String, Any]): Unit = {
+    val args = Silicon.optionsFromScalaTestConfigMap(prefixSpecificConfigMap(configMap).getOrElse("silicon", Map()))
+    val additionalArgs = Seq("--counterexample=variables", "--exhaleMode=1")
+
+    silicon.parseCommandLine(args ++ additionalArgs :+ Silicon.dummyInputFilename)
+  }
+
+  override def createExpectedValuesCounterexampleAnnotation(id: OutputAnnotationId, file: Path, forLineNr: Int, expectedCounterexample: ExpectedCounterexample): CustomAnnotation =
+    ExpectedValuesCounterexampleAnnotation(id, file, forLineNr, expectedCounterexample)
+}
+
+/** represents an expected output (identified by `id`) with an associated (possibly partial) counterexample model */
+case class ExpectedValuesCounterexampleAnnotation(id: OutputAnnotationId, file: Path, forLineNr: Int, expectedCounterexample: ExpectedCounterexample) extends CustomAnnotation {
+  override def matches(actual: AbstractOutput): Boolean =
+    id.matches(actual.fullId) && actual.isSameLine(file, forLineNr) && containsModel(actual)
+
+  /** returns true if the expected model (i.e. class parameter) is a subset of a model given in a failure context */
+  def containsModel(is: AbstractOutput): Boolean = is match {
+    case SilOutput(err) => err match {
+      case vErr: VerificationError => vErr.failureContexts.toVector.exists(containsExpectedCounterexample)
+      case _ => false
+    }
+    case _ => false
+  }
+
+  def containsExpectedCounterexample(failureContext: FailureContext): Boolean =
+    failureContext.counterExample match {
+      case Some(silCounterexample: SiliconVariableCounterexample) => meetsExpectations(expectedCounterexample, silCounterexample.model)
+      case _ => false
+    }
+
+  /** returns true if model2 contains at least the content expressed by model1 */
+  def meetsExpectations(model1: ExpectedCounterexample, model2: Model): Boolean = {
+    model1.exprs.forall {
+      case PBinExp(lhs, r, rhs) if r.rs == PSymOp.EqEq => containsEquality(lhs, rhs, model2)
+    }
+  }
+
+  def containsEquality(lhs: PExp, rhs: PExp, model: Model): Boolean =
+    resolve(Vector(lhs, rhs), model).exists { case Vector(resolvedLhs, resolvedRhs) =>
+      areEqualEntries(resolvedLhs, resolvedRhs) }
+
+  /** resolves `expr` to a model entry in the given model. In case it's a field access, the corresponding permissions are returned as well */
+  def resolve(expr: PExp, model: Model): Option[ModelEntry] = expr match {
+    case PIntLit(value) => Some(ConstantEntry(value.toString()))
+    case PBoolLit(value) => Some(ConstantEntry(value.rs.keyword))
+    case PUnExp(r, PIntLit(value)) if r.rs == PSymOp.Neg => Some(ConstantEntry((-value).toString()))
+    case idnuse: PIdnUseExp => model.entries.get(idnuse.name)
+  }
+
+  def resolve(exprs: Vector[PExp], model: Model): Option[Vector[ModelEntry]] = {
+    val entries = exprs.map(expr => resolve(expr, model)).collect{ case Some(entry) => entry }
+    if (exprs.size == entries.size) Some(entries) else None
+  }
+
+  def areEqualEntries(entry1: ModelEntry, entry2: ModelEntry): Boolean = (entry1, entry2) match {
+    case (ConstantEntry(value1), ConstantEntry(value2)) => value1 == value2
+  }
+
+  override def notFoundError: TestError = TestCustomError(s"Expected the following counterexample on line $forLineNr: $expectedCounterexample")
+
+  override def withForLineNr(line: Int = forLineNr): ExpectedValuesCounterexampleAnnotation = ExpectedValuesCounterexampleAnnotation(id, file, line, expectedCounterexample)
+}


### PR DESCRIPTION
Fixes ``--counterexample=variables``, which has apparently been broken since the debugger was added. Also adding a test for it (whose code is mostly in silver) and moving some code for general counterexample tests to silver.