### PR TITLE
Making assumption of function preconditions for injectivity check local

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -260,12 +260,16 @@ object evaluator extends EvaluationRules {
                   if (s1.triggerExp) {
                     (True, Option.when(withExp)(TrueLit()()), s1)
                   } else {
-                    // Make sure the receiver exists on the SMT level and is thus able to trigger any relevant quantifiers.
-                    val rcvrVar = v1.decider.appliedFresh("rcvr", tRcvr.sort, s1.relevantQuantifiedVariables.map(_._1))
-                    val debugExp = Option.when(withExp)(DebugExp.createInstance("temp var for field access receiver"))
-                    v1.decider.assumeDefinition(BuiltinEquals(rcvrVar, tRcvr), debugExp)
-                    val newFuncRec = s1.functionRecorder.recordFreshSnapshot(rcvrVar.applicable.asInstanceOf[Function])
-                    val s1a = s1.copy(functionRecorder = newFuncRec)
+                    val s1a = tRcvr match {
+                      case _: Literal | _: Var => s1
+                      case _ =>
+                        // Make sure the receiver exists on the SMT level and is thus able to trigger any relevant quantifiers.
+                        val rcvrVar = v1.decider.appliedFresh("rcvr", tRcvr.sort, s1.relevantQuantifiedVariables.map(_._1))
+                        val debugExp = Option.when(withExp)(DebugExp.createInstance("temp var for field access receiver"))
+                        v1.decider.assumeDefinition(BuiltinEquals(rcvrVar, tRcvr), debugExp)
+                        val newFuncRec = s1.functionRecorder.recordFreshSnapshot(rcvrVar.applicable.asInstanceOf[Function])
+                        s1.copy(functionRecorder = newFuncRec)
+                    }
                     val permVal = relevantChunks.head.perm
                     val totalPermissions = permVal.replace(relevantChunks.head.quantifiedVars, Seq(tRcvr))
                     (IsPositive(totalPermissions), Option.when(withExp)(ast.PermGtCmp(ast.CurrentPerm(fa)(fa.pos, fa.info, fa.errT), ast.NoPerm()())(fa.pos, fa.info, fa.errT)), s1a)

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1254,8 +1254,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             qidPrefix = qid,
             program = s.program)
         v.decider.prover.comment("Check receiver injectivity")
-        v.decider.assume(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
-        v.decider.assert(receiverInjectivityCheck) {
+        val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), receiverInjectivityCheck)
+        v.decider.assert(completeReceiverInjectivityCheck) {
           case true =>
             val qvarsToInvOfLoc = inverseFunctions.qvarsToInversesOf(formalQVars)
             val condOfInvOfLoc = tCond.replace(qvarsToInvOfLoc)

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -998,9 +998,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           }
         val comment = "Check receiver injectivity"
         v.decider.prover.comment(comment)
-        v.decider.assume(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program),
-          Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
-        v.decider.assert(receiverInjectivityCheck) {
+        val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program),
+          receiverInjectivityCheck)
+        v.decider.assert(completeReceiverInjectivityCheck) {
           case true =>
             val ax = inverseFunctions.axiomInversesOfInvertibles
             val inv = inverseFunctions.copy(axiomInversesOfInvertibles = Forall(ax.vars, ax.body, effectiveTriggers))
@@ -1072,8 +1072,10 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                      conservedPcs = conservedPcs,
                      smCache = smCache1)
             Q(s1, v)
-          case false =>
-            createFailure(pve dueTo notInjectiveReason, v, s, receiverInjectivityCheck, "QP receiver is injective")}
+          case false => {
+            createFailure(pve dueTo notInjectiveReason, v, s, receiverInjectivityCheck, "QP receiver is injective")
+          }
+        }
       case false =>
         createFailure(pve dueTo negativePermissionReason, v, s, nonNegImplication, nonNegImplicationExp)}
   }


### PR DESCRIPTION
…and fixing a resulting incompleteness.

This is an attempt to do what @superaxander did in PR #914 but 
- without the push/pop calls, since we never really manually call them virtually anywhere in Silicon; I think just asserting the implication should achieve the same effect
- also fixing an incompleteness that he found that can appear in this context (a receiver term that was needed to trigger a QP did not always make it to the SMT level) 

@superaxander: This version works for the example you included; could you check if it results in any other incompletenesses?