### PR TITLE
Simplify unfolds by reusing results of predicate verification

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -193,6 +193,13 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
+  val disableSimplifiedUnfolds: ScallopOption[Boolean] = opt[Boolean]("disableSimplifiedUnfolds",
+    descr = (  "Disable an optimization that reuses the results of verifying a predicate to simplify the process "
+             + "of unfolding it (via an unfold statement or an unfolding expression)."),
+    default = Some(false),
+    noshort = true
+  )
+
   val logLevel: ScallopOption[String] = opt[String]("logLevel",
     descr = "One of the log levels ALL, TRACE, DEBUG, INFO, WARN, ERROR, OFF",
     default = None,

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -193,8 +193,8 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
-  val disableSimplifiedUnfolds: ScallopOption[Boolean] = opt[Boolean]("disableSimplifiedUnfolds",
-    descr = (  "Disable an optimization that reuses the results of verifying a predicate to simplify the process "
+  val enableSimplifiedUnfolds: ScallopOption[Boolean] = opt[Boolean]("enableSimplifiedUnfolds",
+    descr = (  "Enable an optimization that reuses the results of verifying a predicate to simplify the process "
              + "of unfolding it (via an unfold statement or an unfolding expression)."),
     default = Some(false),
     noshort = true

--- a/src/main/scala/interfaces/Preamble.scala
+++ b/src/main/scala/interfaces/Preamble.scala
@@ -29,10 +29,8 @@ trait PreambleContributor[+SO, +SY, +AX] extends StatefulComponent {
   def sortsAfterAnalysis: Iterable[SO]
   def declareSortsAfterAnalysis(sink: ProverLike): Unit
 
-  def symbolsAfterAnalysis: Iterable[SY]
   def declareSymbolsAfterAnalysis(sink: ProverLike): Unit
 
-  def axiomsAfterAnalysis: Iterable[AX]
   def emitAxiomsAfterAnalysis(sink: ProverLike): Unit
 }
 

--- a/src/main/scala/interfaces/state/Chunks.scala
+++ b/src/main/scala/interfaces/state/Chunks.scala
@@ -24,7 +24,7 @@ trait GeneralChunk extends Chunk {
   def permMinus(perm: Term, permExp: Option[ast.Exp]): GeneralChunk
   def permPlus(perm: Term, permExp: Option[ast.Exp]): GeneralChunk
 
-  def permScale(perm: Term): GeneralChunk
+  def permScale(perm: Term, permExp: Option[ast.Exp]): GeneralChunk
 
   val permExp: Option[ast.Exp]
 }

--- a/src/main/scala/interfaces/state/Chunks.scala
+++ b/src/main/scala/interfaces/state/Chunks.scala
@@ -24,6 +24,8 @@ trait GeneralChunk extends Chunk {
   def permMinus(perm: Term, permExp: Option[ast.Exp]): GeneralChunk
   def permPlus(perm: Term, permExp: Option[ast.Exp]): GeneralChunk
 
+  def permScale(perm: Term): GeneralChunk
+
   val permExp: Option[ast.Exp]
 }
 

--- a/src/main/scala/interfaces/state/Chunks.scala
+++ b/src/main/scala/interfaces/state/Chunks.scala
@@ -6,12 +6,14 @@
 
 package viper.silicon.interfaces.state
 
+import viper.silicon
 import viper.silicon.resources.ResourceID
 import viper.silicon.state.terms.{Term, Var}
 import viper.silver.ast
 
-trait Chunk
-
+trait Chunk {
+  def substitute(terms: silicon.Map[Term, Term]): Chunk
+}
 trait ChunkIdentifer
 
 trait GeneralChunk extends Chunk {

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -383,7 +383,7 @@ object consumer extends ConsumptionRules {
               val debugExp = Option.when(withExp)(DebugExp.createInstance(s"Field Trigger: ${eRcvrNew.get.toString}.${field.name}"))
               v2.decider.assume(FieldTrigger(field.name, smDef1.sm, tRcvr), debugExp)
               //            v2.decider.assume(PermAtMost(tPerm, FullPerm()))
-              s2.copy(smCache = smCache1)
+              s2.copy(smCache = smCache1, functionRecorder = s2.functionRecorder.recordFvfAndDomain(smDef1))
             } else {
               s2
             }
@@ -427,7 +427,7 @@ object consumer extends ConsumptionRules {
                   s2, predicate, s2.predicateFormalVarMap(predicate), relevantChunks, v2)
               val debugExp = Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${predicate.name}(${eArgsNew.mkString(", ")}))", isInternal_ = true))
               v2.decider.assume(PredicateTrigger(predicate.name, smDef1.sm, tArgs), debugExp)
-              s2.copy(smCache = smCache1)
+              s2.copy(smCache = smCache1, functionRecorder = s2.functionRecorder.recordFvfAndDomain(smDef1))
             } else {
               s2
             }
@@ -497,7 +497,7 @@ object consumer extends ConsumptionRules {
             val predName = MagicWandIdentifier(wand, s.program).toString
             val debugExp = Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger($predName($argsString))", isInternal_ = true))
             v1.decider.assume(PredicateTrigger(predName, smDef1.sm, tArgs), debugExp)
-            s1.copy(smCache = smCache1)
+            s1.copy(smCache = smCache1, functionRecorder = s1.functionRecorder.recordFvfAndDomain(smDef1))
           } else {
             s1
           }

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1030,7 +1030,7 @@ object evaluator extends EvaluationRules {
 
                       if (s7a.predicateData(predicate).unfoldTree.isDefined) {
                         val toReplace: silicon.Map[Term, Term] = silicon.Map.from(s7a.predicateData(predicate).params.get.zip(Seq(snap.get) ++ tArgs))
-                        predicateSupporter.doTree(s7a, s7a.predicateData(predicate).unfoldTree.get, toReplace, v4)((s8, v5) => {
+                        predicateSupporter.doTree(s7a, s7a.predicateData(predicate).unfoldTree.get, toReplace, v4, true)((s8, v5) => {
                           val s9 = s8.copy(g = s7.g,
                             functionRecorder = s8.functionRecorder.changeDepthBy(-1),
                             recordVisited = s3.recordVisited,

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -317,7 +317,7 @@ object evaluator extends EvaluationRules {
                     val smLookup = Lookup(fa.field.name, smDef1.sm, tRcvr)
                     val fr2 =
                       s2.functionRecorder.recordSnapshot(fa, v1.decider.pcs.branchConditions, smLookup)
-                        .recordFvfAndDomain(smDef1)
+                        .recordFvfAndDomain(smDef1).recordPermMap(pmDef1)
                     val s3 = s2.copy(functionRecorder = fr2)
                     Q(s3, smLookup, newFa, v1)
                 }
@@ -579,7 +579,8 @@ object evaluator extends EvaluationRules {
                       quantifiedChunkSupporter.summarisingPermissionMap(
                         s1, wand, formalVars, relevantChunks, null, v1)
 
-                    (s1.copy(pmCache = pmCache), pmDef)
+                    val newFr = s1.functionRecorder.recordPermMap(pmDef)
+                    (s1.copy(pmCache = pmCache, functionRecorder = newFr), pmDef)
                   }
                   (s2, PredicatePermLookup(identifier.toString, pmDef.pm, args))
 
@@ -595,8 +596,8 @@ object evaluator extends EvaluationRules {
                     val (pmDef, pmCache) =
                       quantifiedChunkSupporter.summarisingPermissionMap(
                         s1, field, Seq(`?r`), relevantChunks, null, v1)
-
-                    (s1.copy(pmCache = pmCache), pmDef)
+                    val newFr = s1.functionRecorder.recordPermMap(pmDef)
+                    (s1.copy(pmCache = pmCache, functionRecorder = newFr), pmDef)
                   }
                   val currentPermAmount = PermLookup(field.name, pmDef.pm, args.head)
                   v1.decider.prover.comment(s"perm($resacc)  ~~>  assume upper permission bound")

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -6,6 +6,7 @@
 
 package viper.silicon.rules
 
+import viper.silicon
 import viper.silicon.debugger.DebugExp
 import viper.silicon.Config.JoinMode
 import viper.silver.ast
@@ -1021,16 +1022,33 @@ object evaluator extends EvaluationRules {
                       val argsPairs: List[(Term, Option[ast.Exp])] = if (withExp) tArgs zip eArgsNew.get.map(Some(_)) else tArgs zip Seq.fill(tArgs.size)(None)
                       val insg = s7.g + Store(predicate.formalArgs map (_.localVar) zip argsPairs)
                       val s7a = s7.copy(g = insg).setConstrainable(s7.constrainableARPs, false)
-                      produce(s7a, toSf(snap.get), body, pve, v4)((s8, v5) => {
-                        val s9 = s8.copy(g = s7.g,
-                                         functionRecorder = s8.functionRecorder.changeDepthBy(-1),
-                                         recordVisited = s3.recordVisited,
-                                         permissionScalingFactor = s6.permissionScalingFactor,
-                                         permissionScalingFactorExp = s6.permissionScalingFactorExp,
-                                         constrainableARPs = s1.constrainableARPs)
-                                   .decCycleCounter(predicate)
-                        val s10 = v5.stateConsolidator(s9).consolidateOptionally(s9, v5)
-                        eval(s10, eIn, pve, v5)((s9, t9, e9, v9) => QB(s9, (t9, e9), v9))})})
+
+                      if (s7a.predicateData(predicate).unfoldTree.isDefined) {
+                        val toReplace: silicon.Map[Term, Term] = silicon.Map.from(s7a.predicateData(predicate).params.get.zip(Seq(snap.get) ++ tArgs))
+                        predicateSupporter.doTree(s7a, s7a.predicateData(predicate).unfoldTree.get, toReplace, v4)((s8, v5) => {
+                          val s9 = s8.copy(g = s7.g,
+                            functionRecorder = s8.functionRecorder.changeDepthBy(-1),
+                            recordVisited = s3.recordVisited,
+                            permissionScalingFactor = s6.permissionScalingFactor,
+                            permissionScalingFactorExp = s6.permissionScalingFactorExp,
+                            constrainableARPs = s1.constrainableARPs)
+                            .decCycleCounter(predicate)
+                          val s10 = v5.stateConsolidator(s9).consolidateOptionally(s9, v5)
+                          eval(s10, eIn, pve, v5)((s9, t9, e9, v9) => QB(s9, (t9, e9), v9))
+                        })
+                      } else {
+                        produce(s7a, toSf(snap.get), body, pve, v4)((s8, v5) => {
+                          val s9 = s8.copy(g = s7.g,
+                                           functionRecorder = s8.functionRecorder.changeDepthBy(-1),
+                                           recordVisited = s3.recordVisited,
+                                           permissionScalingFactor = s6.permissionScalingFactor,
+                                           permissionScalingFactorExp = s6.permissionScalingFactorExp,
+                                           constrainableARPs = s1.constrainableARPs)
+                                     .decCycleCounter(predicate)
+                          val s10 = v5.stateConsolidator(s9).consolidateOptionally(s9, v5)
+                          eval(s10, eIn, pve, v5)((s9, t9, e9, v9) => QB(s9, (t9, e9), v9))})
+                      }
+                    })
                   })(join(eIn.typ, "joined_unfolding", s2.relevantQuantifiedVariables.map(_._1),
                     Option.when(withExp)(s2.relevantQuantifiedVariables.map(_._2.get)), v2))((s12, r12, v7)
                     => {
@@ -1041,7 +1059,8 @@ object evaluator extends EvaluationRules {
                   createFailure(pve dueTo NonPositivePermission(ePerm.get), v2, s2, IsPositive(tPerm), ePermNew.map(p => ast.PermGtCmp(p, ast.NoPerm()())(p.pos, p.info, p.errT)))}))
         } else {
           val unknownValue = v.decider.appliedFresh("recunf", v.symbolConverter.toSort(eIn.typ), s.relevantQuantifiedVariables.map(_._1))
-          Q(s, unknownValue, Option.when(withExp)(ast.LocalVarWithVersion("unknownValue", eIn.typ)(eIn.pos, eIn.info, eIn.errT)), v)
+          val newFuncRec = s.functionRecorder.recordFreshSnapshot(unknownValue.applicable.asInstanceOf[Function])
+          Q(s.copy(functionRecorder = newFuncRec), unknownValue, Option.when(withExp)(ast.LocalVarWithVersion("unknownValue", eIn.typ)(eIn.pos, eIn.info, eIn.errT)), v)
         }
 
       case ast.Applying(wand, eIn) =>

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -256,22 +256,30 @@ object evaluator extends EvaluationRules {
                   val triggerExp = Option.when(withExp)(DebugExp.createInstance(s"FieldTrigger(${eRcvr.toString()}.${fa.field.name})"))
                   v1.decider.assume(trigger, triggerExp)
                 }
-                val (permCheck, permCheckExp) =
+                val (permCheck, permCheckExp, s1a) =
                   if (s1.triggerExp) {
-                    (True, Option.when(withExp)(TrueLit()()))
+                    (True, Option.when(withExp)(TrueLit()()), s1)
                   } else {
+                    val (s1a, lhs) = tRcvr match {
+                      case _: Literal | _: Var => (s1, True)
+                      case _ =>
+                        // Make sure the receiver exists on the SMT level and is thus able to trigger any relevant quantifiers.
+                        val rcvrVar = v1.decider.appliedFresh("rcvr", tRcvr.sort, s1.relevantQuantifiedVariables.map(_._1))
+                        val newFuncRec = s1.functionRecorder.recordFreshSnapshot(rcvrVar.applicable.asInstanceOf[Function])
+                        (s1.copy(functionRecorder = newFuncRec), BuiltinEquals(rcvrVar, tRcvr))
+                    }
                     val permVal = relevantChunks.head.perm
                     val totalPermissions = permVal.replace(relevantChunks.head.quantifiedVars, Seq(tRcvr))
-                    (IsPositive(totalPermissions), Option.when(withExp)(ast.PermGtCmp(ast.CurrentPerm(fa)(fa.pos, fa.info, fa.errT), ast.NoPerm()())(fa.pos, fa.info, fa.errT)))
+                    (Implies(lhs, IsPositive(totalPermissions)), Option.when(withExp)(ast.PermGtCmp(ast.CurrentPerm(fa)(fa.pos, fa.info, fa.errT), ast.NoPerm()())(fa.pos, fa.info, fa.errT)), s1a)
                   }
                 v1.decider.assert(permCheck) {
                   case false =>
-                    createFailure(pve dueTo InsufficientPermission(fa), v1, s1, permCheck, permCheckExp)
+                    createFailure(pve dueTo InsufficientPermission(fa), v1, s1a, permCheck, permCheckExp)
                   case true =>
                     val smLookup = Lookup(fa.field.name, relevantChunks.head.fvf, tRcvr)
                     val fr2 =
-                      s1.functionRecorder.recordSnapshot(fa, v1.decider.pcs.branchConditions, smLookup)
-                    val s2 = s1.copy(functionRecorder = fr2)
+                      s1a.functionRecorder.recordSnapshot(fa, v1.decider.pcs.branchConditions, smLookup)
+                    val s2 = s1a.copy(functionRecorder = fr2)
                     Q(s2, smLookup, newFa, v1)
                 }
               } else {

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -169,7 +169,13 @@ object predicateSupporter extends PredicateSupportRules {
           }
         })
         val substHeap = Heap(substChunksOptQps)
-        val s1 = s.copy(h = s.h + substHeap, functionRecorder = newFr)
+        val s1 = if (true) {  // merge or just append?
+          val (fr1, h1) = v.stateConsolidator(s).merge(newFr, s, s.h, substHeap, v)
+          s.copy(h = h1, functionRecorder = fr1)
+        } else {
+          s.copy(h = s.h + substHeap, functionRecorder = newFr)
+        }
+
         Q(s1, v)
       case PredBranchNode(cond, left, right) =>
         val substCond = cond.replace(toReplace)

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -134,7 +134,7 @@ object predicateSupporter extends PredicateSupportRules {
     tree match {
       case PredLeafNode(h, assumptions) =>
         v.decider.assume(assumptions.map(_.replace(toReplace)).toSeq, None)
-        val substChunks = h.values.map(_.substitute(toReplace).asInstanceOf[GeneralChunk])
+        val substChunks = h.values.map(_.substitute(toReplace).asInstanceOf[GeneralChunk].permScale(s.permissionScalingFactor))
 
         val quantifiedResourceIdentifiers: Set[ChunkIdentifer] = s.qpPredicates.map(p => BasicChunkIdentifier(p.name)) ++ s.qpFields.map(f => BasicChunkIdentifier(f.name)) ++ s.qpMagicWands
 

--- a/src/main/scala/rules/PredicateSupporter.scala
+++ b/src/main/scala/rules/PredicateSupporter.scala
@@ -6,12 +6,16 @@
 
 package viper.silicon.rules
 
+import viper.silicon
 import viper.silicon.debugger.DebugExp
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.interfaces.VerificationResult
-import viper.silicon.resources.PredicateID
+import viper.silicon.interfaces.state.{ChunkIdentifer, GeneralChunk, NonQuantifiedChunk}
+import viper.silicon.resources.{FieldID, PredicateID}
 import viper.silicon.state._
 import viper.silicon.state.terms._
+import viper.silicon.state.terms.predef.`?r`
+import viper.silicon.supporters.{PredBranchNode, PredLeafNode, PredTree}
 import viper.silicon.utils.toSf
 import viper.silicon.verifier.Verifier
 import viper.silver.ast
@@ -124,6 +128,62 @@ object predicateSupporter extends PredicateSupportRules {
     })
   }
 
+  def doTree(s: State, tree: PredTree, toReplace: silicon.Map[Term, Term], v: Verifier)
+            (Q: (State, Verifier) => VerificationResult)
+            : VerificationResult = {
+    tree match {
+      case PredLeafNode(h, assumptions) =>
+        v.decider.assume(assumptions.map(_.replace(toReplace)).toSeq, None)
+        val substChunks = h.values.map(_.substitute(toReplace).asInstanceOf[GeneralChunk])
+
+        val quantifiedResourceIdentifiers: Set[ChunkIdentifer] = s.qpPredicates.map(p => BasicChunkIdentifier(p.name)) ++ s.qpFields.map(f => BasicChunkIdentifier(f.name)) ++ s.qpMagicWands
+
+        var newFr = s.functionRecorder
+        val substChunksOptQps = substChunks.map(c => {
+          if (quantifiedResourceIdentifiers.contains(c.id) && c.isInstanceOf[NonQuantifiedChunk]) {
+            c match {
+              case bc: BasicChunk =>
+                val resource = bc.resourceID match {
+                  case FieldID => s.program.findField(bc.id.name)
+                  case _ => s.program.findPredicate(bc.id.name)
+                }
+                val (sm, smValueDef) = quantifiedChunkSupporter.singletonSnapshotMap(s, resource, bc.args, bc.snap, v)
+                v.decider.assumeDefinition(smValueDef, None)
+                val codQvars = bc.resourceID match {
+                  case FieldID => Seq(`?r`)
+                  case _ => s.predicateFormalVarMap(resource.asInstanceOf[ast.Predicate])
+                }
+                newFr = newFr.recordFvfAndDomain(SnapshotMapDefinition(resource, sm, Seq(smValueDef), Seq()))
+                quantifiedChunkSupporter.createSingletonQuantifiedChunk(codQvars, None, resource, bc.args, None, bc.perm, None, sm, s.program)
+              case mwc: MagicWandChunk =>
+                val wand = mwc.id.ghostFreeWand
+                val bodyVars = wand.subexpressionsToEvaluate(s.program)
+                val codQvars = bodyVars.indices.toList.map(i => Var(Identifier(s"x$i"), v.symbolConverter.toSort(bodyVars(i).typ), false))
+                val (sm, smValueDef) = quantifiedChunkSupporter.singletonSnapshotMap(s, wand, mwc.args, mwc.snap, v)
+                v.decider.assumeDefinition(smValueDef, None)
+                newFr = newFr.recordFvfAndDomain(SnapshotMapDefinition(wand, sm, Seq(smValueDef), Seq()))
+                quantifiedChunkSupporter.createSingletonQuantifiedChunk(codQvars, None, wand, mwc.args, None, mwc.perm, None, sm, s.program)
+            }
+          } else {
+            c
+          }
+        })
+        val substHeap = Heap(substChunksOptQps)
+        val s1 = s.copy(h = s.h + substHeap, functionRecorder = newFr)
+        Q(s1, v)
+      case PredBranchNode(cond, left, right) =>
+        val substCond = cond.replace(toReplace)
+        brancher.branch(s, substCond, (ast.TrueLit()(), None), v)(
+          (s1, v1) => {
+            doTree(s1, left, toReplace, v1)(Q)
+          },
+          (s2, v2) => {
+            doTree(s2, right, toReplace, v2)(Q)
+          }
+        )
+    }
+  }
+
   def unfold(s: State,
              predicate: ast.Predicate,
              tArgs: List[Term],
@@ -163,19 +223,42 @@ object predicateSupporter extends PredicateSupportRules {
       )((s2, h2, snap, v1) => {
         val s3 = s2.copy(g = gIns, h = h2)
                    .setConstrainable(constrainableWildcards, false)
-        produce(s3, toSf(snap.get), body, pve, v1)((s4, v2) => {
-          v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
-          if (!Verifier.config.disableFunctionUnfoldTrigger()) {
-            val predicateTrigger =
-              App(s4.predicateData(predicate).triggerFunction,
-                snap.get.convert(terms.sorts.Snap) +: tArgs)
-            val eargs = eArgs.mkString(", ")
-            v2.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${predicate.name}($eargs))")))
-          }
-          Q(s4.copy(g = s.g,
-                    permissionScalingFactor = s.permissionScalingFactor,
-                    permissionScalingFactorExp = s.permissionScalingFactorExp),
-            v2)})
+        if (s3.predicateData(predicate).unfoldTree.isDefined) {
+          // emit all symbols - NO! do that once and forall!
+          // walk though branches, always substituting
+          // assume and add to heap, substituting args, perms, snaps, making basic chunks singleton chunks if needed.
+          val toReplace: silicon.Map[Term, Term] = silicon.Map.from(s3.predicateData(predicate).params.get.zip(Seq(snap.get) ++ tArgs))
+          doTree(s3, s3.predicateData(predicate).unfoldTree.get, toReplace, v1)((s4, v4) => {
+            v4.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
+            if (!Verifier.config.disableFunctionUnfoldTrigger()) {
+              val predicateTrigger =
+                App(s4.predicateData(predicate).triggerFunction,
+                  snap.get.convert(terms.sorts.Snap) +: tArgs)
+              val eargs = eArgs.mkString(", ")
+              v4.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${predicate.name}($eargs))")))
+            }
+            Q(s4.copy(g = s.g,
+              permissionScalingFactor = s.permissionScalingFactor,
+              permissionScalingFactorExp = s.permissionScalingFactorExp),
+              v4)
+          })
+        } else {
+          produce(s3, toSf(snap.get), body, pve, v1)((s4, v2) => {
+            v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
+            if (!Verifier.config.disableFunctionUnfoldTrigger()) {
+              val predicateTrigger =
+                App(s4.predicateData(predicate).triggerFunction,
+                  snap.get.convert(terms.sorts.Snap) +: tArgs)
+              val eargs = eArgs.mkString(", ")
+              v2.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${predicate.name}($eargs))")))
+            }
+            Q(s4.copy(g = s.g,
+              permissionScalingFactor = s.permissionScalingFactor,
+              permissionScalingFactorExp = s.permissionScalingFactorExp),
+              v2)
+          })
+        }
+
       })
     } else {
       val ve = pve dueTo InsufficientPermission(pa)
@@ -183,18 +266,38 @@ object predicateSupporter extends PredicateSupportRules {
       chunkSupporter.consume(s1, s1.h, predicate, tArgs, eArgs, s1.permissionScalingFactor, s1.permissionScalingFactorExp, true, ve, v, description)((s2, h1, snap, v1) => {
         val s3 = s2.copy(g = gIns, h = h1)
                    .setConstrainable(constrainableWildcards, false)
-        produce(s3, toSf(snap.get), body, pve, v1)((s4, v2) => {
-          v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
-          if (!Verifier.config.disableFunctionUnfoldTrigger()) {
-            val predicateTrigger =
-              App(s4.predicateData(predicate).triggerFunction, snap.get +: tArgs)
-            val eargs = eArgs.mkString(", ")
-            v2.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${pa.predicateName}($eargs))")))
-          }
-          val s5 = s4.copy(g = s.g,
-                           permissionScalingFactor = s.permissionScalingFactor,
-                           permissionScalingFactorExp = s.permissionScalingFactorExp)
-          Q(s5, v2)})})
+        if (s3.predicateData(predicate).unfoldTree.isDefined) {
+          // emit all symbols - NO! do that once and forall!
+          // walk though branches, always substituting
+          // assume and add to heap, substituting args, perms, snaps, making basic chunks singleton chunks if needed.
+          val toReplace: silicon.Map[Term, Term] = silicon.Map.from(s3.predicateData(predicate).params.get.zip(Seq(snap.get) ++ tArgs))
+          doTree(s3, s3.predicateData(predicate).unfoldTree.get, toReplace, v1)((s4, v4) => {
+            v4.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
+            if (!Verifier.config.disableFunctionUnfoldTrigger()) {
+              val predicateTrigger =
+                App(s4.predicateData(predicate).triggerFunction, snap.get +: tArgs)
+              val eargs = eArgs.mkString(", ")
+              v4.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${pa.predicateName}($eargs))")))
+            }
+            val s5 = s4.copy(g = s.g,
+              permissionScalingFactor = s.permissionScalingFactor,
+              permissionScalingFactorExp = s.permissionScalingFactorExp)
+            Q(s5, v4)
+          })
+        } else {
+          produce(s3, toSf(snap.get), body, pve, v1)((s4, v2) => {
+            v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterUnfold)
+            if (!Verifier.config.disableFunctionUnfoldTrigger()) {
+              val predicateTrigger =
+                App(s4.predicateData(predicate).triggerFunction, snap.get +: tArgs)
+              val eargs = eArgs.mkString(", ")
+              v2.decider.assume(predicateTrigger, Option.when(withExp)(DebugExp.createInstance(s"PredicateTrigger(${pa.predicateName}($eargs))")))
+            }
+            val s5 = s4.copy(g = s.g,
+                             permissionScalingFactor = s.permissionScalingFactor,
+                             permissionScalingFactorExp = s.permissionScalingFactorExp)
+            Q(s5, v2)})}
+      })
     }
   }
 

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -2030,11 +2030,15 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
   override def findChunk(chunks: Iterable[Chunk], chunk: QuantifiedChunk, v: Verifier): Option[QuantifiedChunk] = {
     val lr = chunk match {
       case qfc: QuantifiedFieldChunk if qfc.invs.isDefined =>
-        Left(qfc.invs.get.invertibles, qfc.quantifiedVars, qfc.condition)
+        val qvarsAndInverses = qfc.invs.get.qvarsToInverses.map(qvi => (qvi._1, App(qvi._2, qfc.invs.get.additionalArguments.toSeq ++ qfc.quantifiedVars)))
+        val invertiblesReplaced = qfc.invs.get.invertibles.map(_.replace(qvarsAndInverses))
+        Left(invertiblesReplaced, qfc.quantifiedVars, qfc.condition)
       case qfc: QuantifiedFieldChunk if qfc.singletonArguments.isDefined =>
         Right(qfc.singletonArguments.get, qfc.condition)
       case qpc: QuantifiedPredicateChunk if qpc.invs.isDefined =>
-        Left(qpc.invs.get.invertibles, qpc.quantifiedVars, qpc.condition)
+        val qvarsAndInverses = qpc.invs.get.qvarsToInverses.map(qvi => (qvi._1, App(qvi._2, qpc.invs.get.additionalArguments.toSeq ++ qpc.quantifiedVars)))
+        val invertiblesReplaced = qpc.invs.get.invertibles.map(_.replace(qvarsAndInverses))
+        Left(invertiblesReplaced, qpc.quantifiedVars, qpc.condition)
       case qpc: QuantifiedPredicateChunk if qpc.singletonArguments.isDefined =>
         Right(qpc.singletonArguments.get, qpc.condition)
       case _ => return None
@@ -2078,9 +2082,13 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     relevantChunks.find { ch =>
       val chunkInfo = ch match {
         case qfc: QuantifiedFieldChunk if qfc.invs.isDefined =>
-          Some(qfc.invs.get.invertibles, qfc.quantifiedVars, qfc.condition)
+          val qvarsAndInverses = qfc.invs.get.qvarsToInverses.map(qvi => (qvi._1, App(qvi._2, qfc.invs.get.additionalArguments.toSeq ++ qfc.quantifiedVars)))
+          val invertiblesReplaced = qfc.invs.get.invertibles.map(_.replace(qvarsAndInverses))
+          Some(invertiblesReplaced, qfc.quantifiedVars, qfc.condition)
         case qpc: QuantifiedPredicateChunk if qpc.invs.isDefined =>
-          Some(qpc.invs.get.invertibles, qpc.quantifiedVars, qpc.condition)
+          val qvarsAndInverses = qpc.invs.get.qvarsToInverses.map(qvi => (qvi._1, App(qvi._2, qpc.invs.get.additionalArguments.toSeq ++ qpc.quantifiedVars)))
+          val invertiblesReplaced = qpc.invs.get.invertibles.map(_.replace(qvarsAndInverses))
+          Some(invertiblesReplaced, qpc.quantifiedVars, qpc.condition)
         case _ => None
       }
       chunkInfo match {

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -783,7 +783,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       quantifiedChunkSupporter.summarisingPermissionMap(
         s1, resource, codomainQVars, relevantChunks, smDef, v)
 
-    val s2 = s1.copy(pmCache = pmCache)
+    val s2 = s1.copy(pmCache = pmCache, functionRecorder = s1.functionRecorder.recordFvfAndDomain(smDef).recordPermMap(pmDef))
 
     (s2, smDef, pmDef)
   }
@@ -1335,8 +1335,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                       else None
                     val (smDef2, smCache2) = quantifiedChunkSupporter.summarisingSnapshotMap(
                       s2, resource, formalQVars, relevantChunks, v, optSmDomainDefinitionCondition2)
-                    val fr3 = s2.functionRecorder.recordFvfAndDomain(smDef2)
+                    var fr3 = s2.functionRecorder.recordFvfAndDomain(smDef2)
                       .recordFieldInv(inverseFunctions)
+                    fr3 = smDef1 match {
+                      case None => fr3
+                      case Some(smDef) => fr3.recordFvfAndDomain(smDef)
+                    }
                     val s3 = s2.copy(functionRecorder = fr3,
                       partiallyConsumedHeap = Some(h3),
                       constrainableARPs = s.constrainableARPs,

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -646,12 +646,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
   }
 
   def summarisingPermissionMap(s: State,
-                             resource: ast.Resource,
-                             formalQVars: Seq[Var],
-                             relevantChunks: Seq[QuantifiedBasicChunk],
-                             smDef: SnapshotMapDefinition,
-                             v: Verifier)
-                            : (PermMapDefinition, PmCache) = {
+                               resource: ast.Resource,
+                               formalQVars: Seq[Var],
+                               relevantChunks: Seq[QuantifiedBasicChunk],
+                               smDef: SnapshotMapDefinition,
+                               v: Verifier)
+                              : (PermMapDefinition, PmCache) = {
 
     Verifier.config.mapCache(s.pmCache.get(resource, relevantChunks)) match {
       case Some(pmDef) =>

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -998,9 +998,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           }
         val comment = "Check receiver injectivity"
         v.decider.prover.comment(comment)
-        v.decider.assume(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program),
-          Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
-        v.decider.assert(receiverInjectivityCheck) {
+        val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program),
+          receiverInjectivityCheck)
+        v.decider.assert(completeReceiverInjectivityCheck) {
           case true =>
             val ax = inverseFunctions.axiomInversesOfInvertibles
             val inv = inverseFunctions.copy(axiomInversesOfInvertibles = Forall(ax.vars, ax.body, effectiveTriggers))
@@ -1072,8 +1072,10 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
                      conservedPcs = conservedPcs,
                      smCache = smCache1)
             Q(s1, v)
-          case false =>
-            createFailure(pve dueTo notInjectiveReason, v, s, receiverInjectivityCheck, "QP receiver is injective")}
+          case false => {
+            createFailure(pve dueTo notInjectiveReason, v, s, receiverInjectivityCheck, "QP receiver is injective")
+          }
+        }
       case false =>
         createFailure(pve dueTo negativePermissionReason, v, s, nonNegImplication, nonNegImplicationExp)}
   }
@@ -1252,8 +1254,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             qidPrefix = qid,
             program = s.program)
         v.decider.prover.comment("Check receiver injectivity")
-        v.decider.assume(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), Option.when(withExp)(DebugExp.createInstance(comment, isInternal_ = true)))
-        v.decider.assert(receiverInjectivityCheck) {
+        val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), receiverInjectivityCheck)
+        v.decider.assert(completeReceiverInjectivityCheck) {
           case true =>
             val qvarsToInvOfLoc = inverseFunctions.qvarsToInversesOf(formalQVars)
             val condOfInvOfLoc = tCond.replace(qvarsToInvOfLoc)

--- a/src/main/scala/state/Chunks.scala
+++ b/src/main/scala/state/Chunks.scala
@@ -52,8 +52,8 @@ case class BasicChunk(resourceID: BaseID,
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(perm, newPerm), newPermExp.map(npe => ast.PermAdd(permExp.get, npe)()))
 
-  override def permScale(newPerm: Term) =
-    withPerm(PermTimes(perm, newPerm), permExp)
+  override def permScale(newPerm: Term, newPermExp: Option[ast.Exp]) =
+    withPerm(PermTimes(perm, newPerm), permExp.map(pe => ast.PermMul(pe, newPermExp.get)()))
   override def withPerm(newPerm: Term, newPermExp: Option[ast.Exp]) = BasicChunk(resourceID, id, args, argsExp, snap, snapExp, newPerm, newPermExp)
   override def withSnap(newSnap: Term, newSnapExp: Option[ast.Exp]) = BasicChunk(resourceID, id, args, argsExp, newSnap, newSnapExp, perm, permExp)
 
@@ -127,8 +127,8 @@ case class QuantifiedFieldChunk(id: BasicChunkIdentifier,
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(permValue, newPerm), newPermExp.map(npe => ast.PermAdd(permValueExp.get, npe)()))
 
-  override def permScale(newPerm: Term) =
-    withPerm(PermTimes(perm, newPerm), permExp)
+  override def permScale(newPerm: Term, newPermExp: Option[ast.Exp]) =
+    withPerm(PermTimes(perm, newPerm), permExp.map(pe => ast.PermMul(pe, newPermExp.get)()))
   override def withSnapshotMap(newFvf: Term) =
     QuantifiedFieldChunk(id, newFvf, condition, conditionExp, permValue, permValueExp, invs, singletonRcvr, singletonRcvrExp, hints)
 
@@ -175,8 +175,8 @@ case class QuantifiedPredicateChunk(id: BasicChunkIdentifier,
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(permValue, newPerm), newPermExp.map(npe => ast.PermAdd(permValueExp.get, npe)()))
 
-  override def permScale(newPerm: Term) =
-    withPerm(PermTimes(perm, newPerm), permExp)
+  override def permScale(newPerm: Term, newPermExp: Option[ast.Exp]) =
+    withPerm(PermTimes(perm, newPerm), permExp.map(pe => ast.PermMul(pe, newPermExp.get)()))
   override def withSnapshotMap(newPsf: Term) =
     QuantifiedPredicateChunk(id, quantifiedVars, quantifiedVarExps, newPsf, condition, conditionExp, permValue, permValueExp, invs, singletonArgs, singletonArgExps, hints)
 
@@ -217,8 +217,8 @@ case class QuantifiedMagicWandChunk(id: MagicWandIdentifier,
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(perm, newPerm), newPermExp.map(npe => ast.PermAdd(permExp.get, npe)()))
 
-  override def permScale(newPerm: Term) =
-    withPerm(PermTimes(perm, newPerm), permExp)
+  override def permScale(newPerm: Term, newPermExp: Option[ast.Exp]) =
+    withPerm(PermTimes(perm, newPerm), permExp.map(pe => ast.PermMul(pe, newPermExp.get)()))
   def withPerm(newPerm: Term, newPermExp: Option[ast.Exp]) =
     QuantifiedMagicWandChunk(id, quantifiedVars, quantifiedVarExps, wsf, newPerm, newPermExp, invs, singletonArgs, singletonArgExps, hints)
   override def withSnapshotMap(newWsf: Term) =
@@ -268,8 +268,8 @@ case class MagicWandChunk(id: MagicWandIdentifier,
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(perm, newPerm), newPermExp.map(npe => ast.PermAdd(permExp.get, npe)()))
 
-  override def permScale(newPerm: Term) =
-    withPerm(PermTimes(perm, newPerm), permExp)
+  override def permScale(newPerm: Term, newPermExp: Option[ast.Exp]) =
+    withPerm(PermTimes(perm, newPerm), permExp.map(pe => ast.PermMul(pe, newPermExp.get)()))
   override def withPerm(newPerm: Term, newPermExp: Option[ast.Exp]) = MagicWandChunk(id, bindings, args, argsExp, snap, newPerm, newPermExp)
 
   override def withSnap(newSnap: Term, newSnapExp: Option[ast.Exp]) = {

--- a/src/main/scala/state/Chunks.scala
+++ b/src/main/scala/state/Chunks.scala
@@ -6,6 +6,7 @@
 
 package viper.silicon.state
 
+import viper.silicon
 import viper.silver.ast
 import viper.silicon.interfaces.state._
 import viper.silicon.resources._
@@ -56,6 +57,10 @@ case class BasicChunk(resourceID: BaseID,
   override lazy val toString = resourceID match {
     case FieldID => s"${args.head}.$id -> $snap # $perm"
     case PredicateID => s"$id($snap; ${args.mkString(",")}) # $perm"
+  }
+
+  override def substitute(terms: silicon.Map[Term, Term]) = {
+    copy(args = args.map(_.replace(terms)), snap = snap.replace(terms), perm = perm.replace(terms))
   }
 }
 
@@ -122,6 +127,10 @@ case class QuantifiedFieldChunk(id: BasicChunkIdentifier,
     QuantifiedFieldChunk(id, newFvf, condition, conditionExp, permValue, permValueExp, invs, singletonRcvr, singletonRcvrExp, hints)
 
   override lazy val toString = s"${terms.Forall} ${`?r`} :: ${`?r`}.$id -> $fvf # $perm"
+
+  override def substitute(terms: silicon.Map[Term, Term]): Chunk =
+    copy(fvf = fvf.replace(terms), condition = condition.replace(terms), permValue = permValue.replace(terms),
+      singletonRcvr = singletonRcvr.map(_.replace(terms)), hints = hints.map(_.replace(terms)), invs = invs.map(_.substitute(terms)))
 }
 
 case class QuantifiedPredicateChunk(id: BasicChunkIdentifier,
@@ -163,6 +172,10 @@ case class QuantifiedPredicateChunk(id: BasicChunkIdentifier,
     QuantifiedPredicateChunk(id, quantifiedVars, quantifiedVarExps, newPsf, condition, conditionExp, permValue, permValueExp, invs, singletonArgs, singletonArgExps, hints)
 
   override lazy val toString = s"${terms.Forall} ${quantifiedVars.mkString(",")} :: $id(${quantifiedVars.mkString(",")}) -> $psf # $perm"
+
+  override def substitute(terms: silicon.Map[Term, Term]): Chunk =
+    copy(psf = psf.replace(terms), condition = condition.replace(terms), permValue = permValue.replace(terms),
+      singletonArgs = singletonArgs.map(_.map(_.replace(terms))), hints = hints.map(_.replace(terms)), invs = invs.map(_.substitute(terms)))
 }
 
 case class QuantifiedMagicWandChunk(id: MagicWandIdentifier,
@@ -200,6 +213,10 @@ case class QuantifiedMagicWandChunk(id: MagicWandIdentifier,
     QuantifiedMagicWandChunk(id, quantifiedVars, quantifiedVarExps, newWsf, perm, permExp, invs, singletonArgs, singletonArgExps, hints)
 
   override lazy val toString = s"${terms.Forall} ${quantifiedVars.mkString(",")} :: $id(${quantifiedVars.mkString(",")}) -> $wsf # $perm"
+
+  override def substitute(terms: silicon.Map[Term, Term]): Chunk =
+    copy(wsf = wsf.replace(terms), perm = perm.replace(terms), singletonArgs = singletonArgs.map(_.map(_.replace(terms))),
+      hints = hints.map(_.replace(terms)), invs = invs.map(_.substitute(terms)))
 }
 
 case class MagicWandIdentifier(ghostFreeWand: ast.MagicWand)(override val hashCode: Int) extends ChunkIdentifer {
@@ -254,5 +271,9 @@ case class MagicWandChunk(id: MagicWandIdentifier,
       case other => other.toString
     }
     s"wand@$pos[$snap; ${args.mkString(", ")}]"
+  }
+
+  override def substitute(terms: silicon.Map[Term, Term]) = {
+    copy(args = args.map(_.replace(terms)), snap = snap.replace(terms).asInstanceOf[MagicWandSnapshot], perm = perm.replace(terms))
   }
 }

--- a/src/main/scala/state/Chunks.scala
+++ b/src/main/scala/state/Chunks.scala
@@ -51,6 +51,9 @@ case class BasicChunk(resourceID: BaseID,
     withPerm(PermMinus(perm, newPerm), newPermExp.map(npe => ast.PermSub(permExp.get, npe)()))
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(perm, newPerm), newPermExp.map(npe => ast.PermAdd(permExp.get, npe)()))
+
+  override def permScale(newPerm: Term) =
+    withPerm(PermTimes(perm, newPerm), permExp)
   override def withPerm(newPerm: Term, newPermExp: Option[ast.Exp]) = BasicChunk(resourceID, id, args, argsExp, snap, snapExp, newPerm, newPermExp)
   override def withSnap(newSnap: Term, newSnapExp: Option[ast.Exp]) = BasicChunk(resourceID, id, args, argsExp, newSnap, newSnapExp, perm, permExp)
 
@@ -123,6 +126,9 @@ case class QuantifiedFieldChunk(id: BasicChunkIdentifier,
     withPerm(PermMinus(permValue, newPerm), newPermExp.map(npe => ast.PermSub(permValueExp.get, npe)()))
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(permValue, newPerm), newPermExp.map(npe => ast.PermAdd(permValueExp.get, npe)()))
+
+  override def permScale(newPerm: Term) =
+    withPerm(PermTimes(perm, newPerm), permExp)
   override def withSnapshotMap(newFvf: Term) =
     QuantifiedFieldChunk(id, newFvf, condition, conditionExp, permValue, permValueExp, invs, singletonRcvr, singletonRcvrExp, hints)
 
@@ -168,6 +174,9 @@ case class QuantifiedPredicateChunk(id: BasicChunkIdentifier,
     withPerm(PermMinus(permValue, newPerm), newPermExp.map(npe => ast.PermSub(permValueExp.get, npe)()))
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(permValue, newPerm), newPermExp.map(npe => ast.PermAdd(permValueExp.get, npe)()))
+
+  override def permScale(newPerm: Term) =
+    withPerm(PermTimes(perm, newPerm), permExp)
   override def withSnapshotMap(newPsf: Term) =
     QuantifiedPredicateChunk(id, quantifiedVars, quantifiedVarExps, newPsf, condition, conditionExp, permValue, permValueExp, invs, singletonArgs, singletonArgExps, hints)
 
@@ -207,6 +216,9 @@ case class QuantifiedMagicWandChunk(id: MagicWandIdentifier,
     withPerm(PermMinus(perm, newPerm), newPermExp.map(npe => ast.PermSub(permExp.get, npe)()))
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(perm, newPerm), newPermExp.map(npe => ast.PermAdd(permExp.get, npe)()))
+
+  override def permScale(newPerm: Term) =
+    withPerm(PermTimes(perm, newPerm), permExp)
   def withPerm(newPerm: Term, newPermExp: Option[ast.Exp]) =
     QuantifiedMagicWandChunk(id, quantifiedVars, quantifiedVarExps, wsf, newPerm, newPermExp, invs, singletonArgs, singletonArgExps, hints)
   override def withSnapshotMap(newWsf: Term) =
@@ -255,6 +267,9 @@ case class MagicWandChunk(id: MagicWandIdentifier,
     withPerm(PermMinus(perm, newPerm), newPermExp.map(npe => ast.PermSub(permExp.get, npe)()))
   override def permPlus(newPerm: Term, newPermExp: Option[ast.Exp]) =
     withPerm(PermPlus(perm, newPerm), newPermExp.map(npe => ast.PermAdd(permExp.get, npe)()))
+
+  override def permScale(newPerm: Term) =
+    withPerm(PermTimes(perm, newPerm), permExp)
   override def withPerm(newPerm: Term, newPermExp: Option[ast.Exp]) = MagicWandChunk(id, bindings, args, argsExp, snap, newPerm, newPermExp)
 
   override def withSnap(newSnap: Term, newSnapExp: Option[ast.Exp]) = {

--- a/src/main/scala/state/State.scala
+++ b/src/main/scala/state/State.scala
@@ -130,7 +130,7 @@ final case class State(g: Store = Store(),
     State.preserveAfterLocalEvaluation(this, post)
 
   def functionRecorderQuantifiedVariables(): Seq[(Var, Option[ast.AbstractLocalVar])] =
-    functionRecorder.data.fold(Seq.empty[(Var, Option[ast.AbstractLocalVar])])(d => d.arguments.zip(d.argumentExps))
+    functionRecorder.arguments.fold(Seq.empty[(Var, Option[ast.AbstractLocalVar])])(d => d)
 
   def relevantQuantifiedVariables(filterPredicate: Var => Boolean): Seq[(Var, Option[ast.AbstractLocalVar])] = (
        functionRecorderQuantifiedVariables()

--- a/src/main/scala/state/Utils.scala
+++ b/src/main/scala/state/Utils.scala
@@ -146,7 +146,7 @@ package object utils {
     def goTriggers(trigger: Trigger) = Trigger(trigger.p map go)
 
     def recurse(term: Term): Term = term match {
-      case _: Var | _: Function | _: Literal | _: MagicWandChunkTerm | _: Distinct => term
+      case _: Var | _: Function | _: Literal | _: MagicWandChunkTerm | _: Distinct | _: AppHint => term
 
       case Quantification(quantifier, variables, body, triggers, name, isGlobal, weight) =>
         Quantification(quantifier, variables map go, go(body), triggers map goTriggers, name, isGlobal, weight)

--- a/src/main/scala/supporters/MagicWandSnapFunctionsContributor.scala
+++ b/src/main/scala/supporters/MagicWandSnapFunctionsContributor.scala
@@ -54,16 +54,9 @@ class MagicWandSnapFunctionsContributor(preambleReader: PreambleReader[String, S
     sortsAfterAnalysis foreach (s => sink.declare(SortDecl(s)))
   }
 
-  /** Symbols to add to the preamble of the SMT proof script. */
-  override def symbolsAfterAnalysis: Iterable[String] =
-    extractPreambleLines(collectedFunctionDecls)
-
   /** Add all symbols needed to the preamble using `sink`. */
   override def declareSymbolsAfterAnalysis(sink: ProverLike): Unit =
     emitPreambleLines(sink, collectedFunctionDecls)
-
-  /** Axioms to add to the preamble of the SMT proof script. Currently, there are none. */
-  override def axiomsAfterAnalysis: Iterable[String] = Seq.empty
 
   /** Add all axioms needed to the preamble using `sink`. Currently, there are none. */
   override def emitAxiomsAfterAnalysis(sink: ProverLike): Unit = {}

--- a/src/main/scala/supporters/PredicateVerificationUnit.scala
+++ b/src/main/scala/supporters/PredicateVerificationUnit.scala
@@ -101,7 +101,7 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
       val ins = predicate.formalArgs.map(_.localVar)
       val snap = freshSnap(sorts.Snap, v)
       val argVars = ins.map(x => (x, decider.fresh(x)))
-      var funcRecorder: FunctionRecorder = if (Verifier.config.disableSimplifiedUnfolds()) {
+      var funcRecorder: FunctionRecorder = if (!Verifier.config.enableSimplifiedUnfolds()) {
         NoopFunctionRecorder
       } else {
         ActualFunctionRecorder(Right((predicate, Seq(snap) ++ argVars.map(_._2._1))))
@@ -135,7 +135,7 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
                   })})
       }
 
-      val overallResult = if (predicate.body.isDefined && !result.isFatal && !Verifier.config.disableSimplifiedUnfolds())
+      val overallResult = if (predicate.body.isDefined && !result.isFatal && Verifier.config.enableSimplifiedUnfolds())
         Some(makePredTree(branchResults)) else None
 
       this.predicateData(predicate).predContents = overallResult

--- a/src/main/scala/supporters/PredicateVerificationUnit.scala
+++ b/src/main/scala/supporters/PredicateVerificationUnit.scala
@@ -7,6 +7,7 @@
 package viper.silicon.supporters
 
 import com.typesafe.scalalogging.Logger
+import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silver.ast
 import viper.silver.ast.Program
 import viper.silver.components.StatefulComponent
@@ -19,24 +20,43 @@ import viper.silicon.state.State.OldHeaps
 import viper.silicon.state.terms._
 import viper.silicon.interfaces._
 import viper.silicon.rules.executionFlowController
+import viper.silicon.supporters.functions.{ActualFunctionRecorder, FunctionRecorder, FunctionRecorderHandler}
 import viper.silicon.verifier.{Verifier, VerifierComponent}
-import viper.silicon.utils.freshSnap
+import viper.silicon.utils.{freshSnap, toSf}
 
 class PredicateData(predicate: ast.Predicate)
                    /* Note: Holding a reference to a fixed symbol converter (instead of going
                     *       through a verifier) is only safe if the converter is effectively
                     *       independent of the verifiers.
                     */
-                   (private val symbolConvert: SymbolConverter) {
+                   (private val symbolConvert: SymbolConverter) extends FunctionRecorderHandler {
+
+  var unfoldTree: Option[PredTree] = None
+  var params: Option[Seq[Var]] = None
 
   val argumentSorts = predicate.formalArgs map (fm => symbolConvert.toSort(fm.typ))
 
   val triggerFunction =
     Fun(Identifier(s"${predicate.name}%trigger"), sorts.Snap +: argumentSorts, sorts.Bool)
+
+  def getAxioms(): Seq[Term] = {
+    val nested = (
+      freshFieldInvs.flatMap(_.definitionalAxioms)
+        ++ freshFvfsAndDomains.flatMap(fvfDef => fvfDef.domainDefinitions ++ fvfDef.valueDefinitions)
+        ++ freshConstrainedVars.map(_._2)
+        ++ freshConstraints)
+    Seq()
+  }
 }
 
+trait PredTree
+
+case class PredBranchNode(cond: Term, left: PredTree, right: PredTree) extends PredTree
+
+case class PredLeafNode(heap: Heap, assumptions: InsertionOrderedSet[Term]) extends PredTree
+
 trait PredicateVerificationUnit
-    extends VerifyingPreambleContributor[Sort, Fun, Term, ast.Predicate] {
+    extends VerifyingPreambleContributor[Sort, Decl, Term, ast.Predicate] {
 
   def data: Map[ast.Predicate, PredicateData]
 }
@@ -87,10 +107,18 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
       openSymbExLogger(predicate)
 
       val ins = predicate.formalArgs.map(_.localVar)
-      val s = sInit.copy(g = Store(ins.map(x => (x, decider.fresh(x)))),
+      val snap = freshSnap(sorts.Snap, v)
+      val argVars = ins.map(x => (x, decider.fresh(x)))
+      var funcRecorder = ActualFunctionRecorder(Right((predicate, Seq(snap) ++ argVars.map(_._2._1))))
+      val s = sInit.copy(g = Store(argVars),
                          h = Heap(),
-                         oldHeaps = OldHeaps())
+                         oldHeaps = OldHeaps(),
+                         functionRecorder = funcRecorder)
+
       val err = PredicateNotWellformed(predicate)
+
+      var branchResults: Seq[(Seq[Term], Heap, InsertionOrderedSet[Term])] = Seq()
+
 
       val result = predicate.body match {
         case None =>
@@ -99,25 +127,79 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
           /*    locallyXXX {
                 magicWandSupporter.checkWandsAreSelfFraming(σ.γ, σ.h, predicate, c)}
           &&*/  executionFlowController.locally(s, v)((s1, _) => {
-                  produce(s1, freshSnap, body, err, v)((_, _) =>
-                    Success())})
+                  produce(s1, toSf(snap), body, err, v)((s2, v2) => {
+                    val branchConds = v2.decider.pcs.branchConditions.reverse
+                    val heap = s2.h
+                    val assumptions = v2.decider.pcs.assumptions
+                    branchResults = branchResults :+
+                      (branchConds, heap, assumptions)
+                    funcRecorder = funcRecorder.merge(s2.functionRecorder)
+                    Success()
+                  })})
       }
+
+      val overallResult = if (predicate.body.isDefined && !result.isFatal) Some(makePredTree(branchResults)) else None
+
+      this.predicateData(predicate).unfoldTree = overallResult
+      this.predicateData(predicate).params = Some(Seq(snap) ++ argVars.map(_._2._1))
+      this.predicateData(predicate).addRecorders(Seq(funcRecorder))
 
       symbExLog.closeMemberScope()
       Seq(result)
+    }
+
+    def makePredTree(branches: Seq[(Seq[Term], Heap, InsertionOrderedSet[Term])]): PredTree = {
+      if (branches.head._1.isEmpty) {
+        assert(branches.length == 1)
+        PredLeafNode(branches.head._2, branches.head._3)
+      } else {
+        val branchCond = branches.head._1.head
+        val (trueBranches, falseBranches) = branches.partition(_._1.head == branchCond)
+        if (trueBranches.nonEmpty && falseBranches.nonEmpty) {
+          val trueTree = makePredTree(trueBranches.map(brnchs => (brnchs._1.tail, brnchs._2, brnchs._3)))
+          val falseTree = makePredTree(falseBranches.map(brnchs => (brnchs._1.tail, brnchs._2, brnchs._3)))
+          PredBranchNode(branchCond, trueTree, falseTree)
+        } else if (trueBranches.nonEmpty) {
+          makePredTree(trueBranches.map(brnchs => (brnchs._1.tail, brnchs._2, brnchs._3)))
+        } else {
+          assert(falseBranches.nonEmpty)
+          makePredTree(falseBranches.map(brnchs => (brnchs._1.tail, brnchs._2, brnchs._3)))
+        }
+      }
     }
 
     /* Predicate supporter generates no sorts */
     val sortsAfterVerification: Iterable[Sort] = Seq.empty
     def declareSortsAfterVerification(sink: ProverLike): Unit = ()
 
-    /* Predicate supporter does not generate additional symbols during verification */
-    val symbolsAfterVerification: Iterable[Fun] = Seq.empty
-    def declareSymbolsAfterVerification(sink: ProverLike): Unit = ()
+    val symbolsAfterVerification: Iterable[Decl] =
+      generateFunctionSymbolsAfterVerification collect { case Right(f) => f }
+
+    def declareSymbolsAfterVerification(sink: ProverLike): Unit = {
+      generateFunctionSymbolsAfterVerification foreach {
+        case Left(comment) => sink.comment(comment)
+        case Right(decl) => sink.declare(decl)
+      }
+    }
+
+    private def generateFunctionSymbolsAfterVerification: Iterable[Either[String, Decl]] = {
+      // TODO: It can currently happen that a pTaken macro (see QuantifiedChunkSupporter, def removePermissions)
+      //       is recorded as a fresh macro before a snapshot map that is used in the macro definition (body)
+      //       is recorded, which will yield a Z3 syntax error (undeclared symbol). To work around this,
+      //       macros are declared last. This work-around shouldn't be necessary, though.
+      val (macroDecls, otherDecls) =
+      predicateData.values.flatMap(_.getFreshSymbolsAcrossAllPhases).partition(_.isInstanceOf[MacroDecl])
+
+      Seq(Left("Declaring symbols related to program functions (from verification)")) ++
+        otherDecls.map(Right(_)) ++
+        macroDecls.map(Right(_))
+    }
 
     /* Predicate supporter generates no axioms */
     val axiomsAfterVerification: Iterable[Term] = Seq.empty
-    def emitAxiomsAfterVerification(sink: ProverLike): Unit = ()
+    def emitAxiomsAfterVerification(sink: ProverLike): Unit = {
+      predicateData.values.map(_.getAxioms) foreach (ax => sink.assumeAxioms(InsertionOrderedSet(ax), ""))
+    }
 
     /* Lifetime */
 

--- a/src/main/scala/supporters/functions/FunctionData.scala
+++ b/src/main/scala/supporters/functions/FunctionData.scala
@@ -25,11 +25,58 @@ import viper.silver.ast.LocalVarWithVersion
 import viper.silver.parser.PUnknown
 import viper.silver.reporter.Reporter
 
-/* TODO: Refactor FunctionData!
- *       Separate computations from "storing" the final results and sharing
- *       them with other components. Computations should probably be moved to the
- *       FunctionVerificationUnit.
- */
+trait FunctionRecorderHandler {
+
+  protected[functions] var locToSnap: Map[ast.LocationAccess, Term] = Map.empty
+  protected[functions] var fappToSnap: Map[ast.FuncApp, Term] = Map.empty
+  protected[this] var freshFvfsAndDomains: InsertionOrderedSet[SnapshotMapDefinition] = InsertionOrderedSet.empty
+  protected[this] var freshFieldInvs: InsertionOrderedSet[InverseFunctions] = InsertionOrderedSet.empty
+  protected[this] var freshConstrainedVars: InsertionOrderedSet[(Var, Term)] = InsertionOrderedSet.empty
+  protected[this] var freshConstraints: InsertionOrderedSet[Term] = InsertionOrderedSet.empty
+  protected[this] var freshSnapshots: InsertionOrderedSet[Function] = InsertionOrderedSet.empty
+  protected[this] var freshPathSymbols: InsertionOrderedSet[Function] = InsertionOrderedSet.empty
+  protected[this] var freshMacros: InsertionOrderedSet[MacroDecl] = InsertionOrderedSet.empty
+  protected[this] var freshSymbolsAcrossAllPhases: InsertionOrderedSet[Decl] = InsertionOrderedSet.empty
+
+  private[functions] def getFreshFieldInvs: InsertionOrderedSet[InverseFunctions] = freshFieldInvs
+
+  private[functions] def getFreshConstrainedVars: InsertionOrderedSet[Var] = freshConstrainedVars.map(_._1)
+
+  def getFreshSymbolsAcrossAllPhases: InsertionOrderedSet[Decl] = freshSymbolsAcrossAllPhases
+
+  def addRecorders(recorders: Seq[FunctionRecorder]): Unit = {
+    val mergedFunctionRecorder: FunctionRecorder =
+      if (recorders.isEmpty)
+        NoopFunctionRecorder
+      else
+        recorders.tail.foldLeft(recorders.head)((summaryRec, nextRec) => summaryRec.merge(nextRec))
+
+    locToSnap = mergedFunctionRecorder.locToSnap
+    fappToSnap = mergedFunctionRecorder.fappToSnap
+    freshFvfsAndDomains = mergedFunctionRecorder.freshFvfsAndDomains
+    freshFieldInvs = mergedFunctionRecorder.freshFieldInvs
+    freshConstrainedVars = mergedFunctionRecorder.freshConstrainedVars
+    freshConstraints = mergedFunctionRecorder.freshConstraints
+    freshSnapshots = mergedFunctionRecorder.freshSnapshots
+    freshPathSymbols = mergedFunctionRecorder.freshPathSymbols
+    freshMacros = mergedFunctionRecorder.freshMacros
+
+    freshSymbolsAcrossAllPhases ++= freshPathSymbols map FunctionDecl
+    freshSymbolsAcrossAllPhases ++= freshConstrainedVars.map(pair => FunctionDecl(pair._1))
+    freshSymbolsAcrossAllPhases ++= freshSnapshots map FunctionDecl
+    freshSymbolsAcrossAllPhases ++= freshFieldInvs.flatMap(i => (i.inverses ++ i.images) map FunctionDecl)
+    freshSymbolsAcrossAllPhases ++= freshMacros
+
+    freshSymbolsAcrossAllPhases ++= freshFvfsAndDomains map (fvfDef =>
+      fvfDef.sm match {
+        case x: Var => ConstDecl(x)
+        case App(f: Function, _) => FunctionDecl(f)
+        case other => sys.error(s"Unexpected SM $other of type ${other.getClass.getSimpleName}")
+      })
+  }
+
+}
+
 class FunctionData(val programFunction: ast.Function,
                    val height: Int,
                    val quantifiedFields: InsertionOrderedSet[ast.Field],
@@ -45,9 +92,7 @@ class FunctionData(val programFunction: ast.Function,
                    predicateData: ast.Predicate => PredicateData,
                    @unused config: Config,
                    @unused reporter: Reporter)
-    extends LazyLogging {
-
-  private[this] var phase = 0
+    extends LazyLogging with FunctionRecorderHandler {
 
   /*
    * Properties computed from the constructor arguments
@@ -100,55 +145,16 @@ class FunctionData(val programFunction: ast.Function,
    */
 
   private[functions] var verificationFailures: Seq[FatalResult] = Vector.empty
-  private[functions] var locToSnap: Map[ast.LocationAccess, Term] = Map.empty
-  private[functions] var fappToSnap: Map[ast.FuncApp, Term] = Map.empty
-  private[this] var freshFvfsAndDomains: InsertionOrderedSet[SnapshotMapDefinition] = InsertionOrderedSet.empty
-  private[this] var freshFieldInvs: InsertionOrderedSet[InverseFunctions] = InsertionOrderedSet.empty
-  private[this] var freshConstrainedVars: InsertionOrderedSet[(Var, Term)] = InsertionOrderedSet.empty
-  private[this] var freshConstraints: InsertionOrderedSet[Term] = InsertionOrderedSet.empty
-  private[this] var freshSnapshots: InsertionOrderedSet[Function] = InsertionOrderedSet.empty
-  private[this] var freshPathSymbols: InsertionOrderedSet[Function] = InsertionOrderedSet.empty
-  private[this] var freshMacros: InsertionOrderedSet[MacroDecl] = InsertionOrderedSet.empty
-  private[this] var freshSymbolsAcrossAllPhases: InsertionOrderedSet[Decl] = InsertionOrderedSet.empty
 
-  private[functions] def getFreshFieldInvs: InsertionOrderedSet[InverseFunctions] = freshFieldInvs
-  private[functions] def getFreshConstrainedVars: InsertionOrderedSet[Var] = freshConstrainedVars.map(_._1)
-  private[functions] def getFreshSymbolsAcrossAllPhases: InsertionOrderedSet[Decl] = freshSymbolsAcrossAllPhases
+  private[this] var phase = 0
 
   private[functions] def advancePhase(recorders: Seq[FunctionRecorder]): Unit = {
     assert(0 <= phase && phase <= 1, s"Cannot advance from phase $phase")
 
-    val mergedFunctionRecorder: FunctionRecorder =
-      if (recorders.isEmpty)
-        NoopFunctionRecorder
-      else
-        recorders.tail.foldLeft(recorders.head)((summaryRec, nextRec) => summaryRec.merge(nextRec))
-
-    locToSnap = mergedFunctionRecorder.locToSnap
-    fappToSnap = mergedFunctionRecorder.fappToSnap
-    freshFvfsAndDomains = mergedFunctionRecorder.freshFvfsAndDomains
-    freshFieldInvs = mergedFunctionRecorder.freshFieldInvs
-    freshConstrainedVars = mergedFunctionRecorder.freshConstrainedVars
-    freshConstraints = mergedFunctionRecorder.freshConstraints
-    freshSnapshots = mergedFunctionRecorder.freshSnapshots
-    freshPathSymbols = mergedFunctionRecorder.freshPathSymbols
-    freshMacros = mergedFunctionRecorder.freshMacros
-
-    freshSymbolsAcrossAllPhases ++= freshPathSymbols map FunctionDecl
-    freshSymbolsAcrossAllPhases ++= freshConstrainedVars.map(pair => FunctionDecl(pair._1))
-    freshSymbolsAcrossAllPhases ++= freshSnapshots map FunctionDecl
-    freshSymbolsAcrossAllPhases ++= freshFieldInvs.flatMap(i => (i.inverses ++ i.images) map FunctionDecl)
-    freshSymbolsAcrossAllPhases ++= freshMacros
-
-    freshSymbolsAcrossAllPhases ++= freshFvfsAndDomains map (fvfDef =>
-      fvfDef.sm match {
-        case x: Var => ConstDecl(x)
-        case App(f: Function, _) => FunctionDecl(f)
-        case other => sys.error(s"Unexpected SM $other of type ${other.getClass.getSimpleName}")
-      })
-
+    addRecorders(recorders)
     phase += 1
   }
+
 
   private def generateNestedDefinitionalAxioms: InsertionOrderedSet[Term] = {
     val freshSymbols: Set[Identifier] = freshSymbolsAcrossAllPhases.map(_.id)

--- a/src/main/scala/supporters/functions/FunctionRecorder.scala
+++ b/src/main/scala/supporters/functions/FunctionRecorder.scala
@@ -202,7 +202,7 @@ case class ActualFunctionRecorder(private val _data: Either[FunctionData, (ast.P
     else this
 
   def recordFreshSnapshot(snap: Function): ActualFunctionRecorder =
-    if (depth <= 2) copy(freshSnapshots = freshSnapshots + snap)
+    if (depth <= 3) copy(freshSnapshots = freshSnapshots + snap)
     else this
 
   def recordPathSymbol(symbol: Function): ActualFunctionRecorder =

--- a/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
+++ b/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
@@ -163,7 +163,7 @@ trait DefaultFunctionVerificationUnitProvider extends VerifierComponent { v: Ver
 
     private def handleFunction(sInit: State, function: ast.Function): VerificationResult = {
       val data = functionData(function)
-      val s = sInit.copy(functionRecorder = ActualFunctionRecorder(data),
+      val s = sInit.copy(functionRecorder = ActualFunctionRecorder(Left(data)),
         conservingSnapshotGeneration = true,
         assertReadAccessOnly = !Verifier.config.respectFunctionPrePermAmounts())
 

--- a/src/test/resources/symbExLogTests/symbLogTest_ImpureBranching.vpr.elog
+++ b/src/test/resources/symbExLogTests/symbLogTest_ImpureBranching.vpr.elog
@@ -1,7 +1,7 @@
 predicate P
-  Branch b@0@00:
+  Branch b@1@00:
     comment: Reachable
-  Branch !(b@0@00):
+  Branch !(b@1@00):
     comment: Reachable
 
 method test1

--- a/src/test/resources/symbExLogTests/symbLogTest_linkedListMinimal.vpr.elog
+++ b/src/test/resources/symbExLogTests/symbLogTest_linkedListMinimal.vpr.elog
@@ -1,37 +1,37 @@
 predicate lseg
-  Branch this@0@00 != end@1@00:
+  Branch this@1@00 != end@2@00:
     comment: Reachable
     Join
-      Branch First:(Second:($t@2@00)) != end@1@00:
+      Branch First:(Second:($t@0@00)) != end@2@00:
         comment: Reachable
         Join
-          Branch First:(Second:(First:(Second:(Second:($t@2@00))))) != end@1@00:
+          Branch First:(Second:(First:(Second:(Second:($t@0@00))))) != end@2@00:
             comment: Reachable
             Join
-              Branch First:(Second:(First:(Second:(Second:($t@2@00))))) != end@1@00:
+              Branch First:(Second:(First:(Second:(Second:($t@0@00))))) != end@2@00:
                 comment: Reachable
-              Branch First:(Second:(First:(Second:(Second:($t@2@00))))) == end@1@00:
+              Branch First:(Second:(First:(Second:(Second:($t@0@00))))) == end@2@00:
                 comment: Unreachable
-          Branch First:(Second:(First:(Second:(Second:($t@2@00))))) == end@1@00:
+          Branch First:(Second:(First:(Second:(Second:($t@0@00))))) == end@2@00:
             comment: Reachable
             Join
-              Branch First:(Second:(First:(Second:(Second:($t@2@00))))) != end@1@00:
+              Branch First:(Second:(First:(Second:(Second:($t@0@00))))) != end@2@00:
                 comment: Unreachable
-              Branch First:(Second:(First:(Second:(Second:($t@2@00))))) == end@1@00:
+              Branch First:(Second:(First:(Second:(Second:($t@0@00))))) == end@2@00:
                 comment: Reachable
         Join
-          Branch First:(Second:($t@2@00)) != end@1@00:
+          Branch First:(Second:($t@0@00)) != end@2@00:
             comment: Reachable
-          Branch First:(Second:($t@2@00)) == end@1@00:
+          Branch First:(Second:($t@0@00)) == end@2@00:
             comment: Unreachable
-      Branch First:(Second:($t@2@00)) == end@1@00:
+      Branch First:(Second:($t@0@00)) == end@2@00:
         comment: Reachable
         Join
-          Branch First:(Second:($t@2@00)) != end@1@00:
+          Branch First:(Second:($t@0@00)) != end@2@00:
             comment: Unreachable
-          Branch First:(Second:($t@2@00)) == end@1@00:
+          Branch First:(Second:($t@0@00)) == end@2@00:
             comment: Reachable
-  Branch this@0@00 == end@1@00:
+  Branch this@1@00 == end@2@00:
     comment: Reachable
 
 predicate List
@@ -43,58 +43,6 @@ method insert
   execute unfold acc(lseg(this.head, null), write)
     Branch First:($t@6@01) != Null:
       comment: Reachable
-      Join
-        Branch First:(Second:(Second:($t@6@01))) != Null:
-          comment: Reachable
-          Join
-            Branch First:(Second:(First:(Second:(Second:(Second:($t@6@01)))))) != Null:
-              comment: Reachable
-              Join
-                Branch First:(Second:(First:(Second:(Second:(Second:($t@6@01)))))) != Null:
-                  comment: Reachable
-                Branch First:(Second:(First:(Second:(Second:(Second:($t@6@01)))))) == Null:
-                  comment: Unreachable
-            Branch First:(Second:(First:(Second:(Second:(Second:($t@6@01)))))) == Null:
-              comment: Reachable
-              Join
-                Branch First:(Second:(First:(Second:(Second:(Second:($t@6@01)))))) != Null:
-                  comment: Unreachable
-                Branch First:(Second:(First:(Second:(Second:(Second:($t@6@01)))))) == Null:
-                  comment: Reachable
-          Join
-            Branch First:(Second:(Second:($t@6@01))) != Null:
-              comment: Reachable
-            Branch First:(Second:(Second:($t@6@01))) == Null:
-              comment: Unreachable
-        Branch First:(Second:(Second:($t@6@01))) == Null:
-          comment: Reachable
-          Join
-            Branch First:(Second:(Second:($t@6@01))) != Null:
-              comment: Unreachable
-            Branch First:(Second:(Second:($t@6@01))) == Null:
-              comment: Reachable
-      Branch 1:
-        comment: Reachable
-        Join
-          Branch First:($t@6@01) == Null:
-            comment: Reachable
-          Branch First:($t@6@01) != Null:
-            comment: Reachable
-        Branch !(First:($t@6@01) == Null || elem@4@01 <= First:(Second:($t@6@01))):
-          comment: Reachable
-        Branch First:($t@6@01) == Null || elem@4@01 <= First:(Second:($t@6@01)):
-          comment: Reachable
-      Branch 2:
-        comment: Reachable
-        Join
-          Branch First:($t@6@01) == Null:
-            comment: Reachable
-          Branch First:($t@6@01) != Null:
-            comment: Reachable
-        Branch First:($t@6@01) == Null || elem@4@01 <= First:(Second:($t@6@01)):
-          comment: Reachable
-        Branch !(First:($t@6@01) == Null || elem@4@01 <= First:(Second:($t@6@01))):
-          comment: Reachable
     Branch First:($t@6@01) == Null:
       comment: Reachable
       Branch 1:

--- a/src/test/resources/symbExLogTests/symbLogTest_minimal.vpr.elog
+++ b/src/test/resources/symbExLogTests/symbLogTest_minimal.vpr.elog
@@ -1,7 +1,7 @@
 predicate P4
-  Branch b@0@00:
+  Branch b@1@00:
     comment: Reachable
-  Branch !(b@0@00):
+  Branch !(b@1@00):
     comment: Reachable
 
 method topOfStackInIgnoredSepSetCheck

--- a/src/test/scala/SiliconTestsSimplifiedUnfold.scala
+++ b/src/test/scala/SiliconTestsSimplifiedUnfold.scala
@@ -1,0 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2025 ETH Zurich.
+
+package viper.silicon.tests
+
+class SiliconTestsSimplifiedUnfold extends SiliconTests {
+  override val testDirectories: Seq[String] = Seq("all/predicates")
+
+  override val commandLineArguments: Seq[String] = Seq(
+    "--timeout", "300" /* seconds */,
+    "--enableSimplifiedUnfolds"
+  )
+}


### PR DESCRIPTION
Simplify executing ``unfold``s and evaluating ``unfolding``s by removing the need to fully produce the predicate body.
The idea (thanks @JonasAlaif!) is to reuse the result of verifying the predicate body's well-definedness: After doing so, we know the potential branches and the potential heaps we get from a predicate unfold. Thus, we can remember these heaps, the assumptions that came with them, as well as the declarations we made in the process, and simply declare them, assume them, and add them to our current heap when we are asked to unfold the predicate. 

For now, this optimization is disabled by default, and can be turned on by using the new flag ``--enableSimplifiedUnfolds``.

This requires: 
- Using the FunctionRecorder also while verifying a predicate, to collect all relevant declarations. This in turn required moving some code around between FunctionRecorder, FunctionData, and FunctionVerificationUnit, since the FunctionRecorder is now no longer only used for functions.
- Storing a tree structure containing all heaps etc. under the respective branch conditions resulting from inhaling a predicate body after verifying the predicate
- Adjusting the assumptions and heap chunks when doing the unfold (e.g., scaling permission amounts, replacing the snapshots with the actual snapshot of the unfolded predicate, and turning ordinary chunks into QP chunks)
- Recording some additional information in the FunctionRecorder that was not previously required, like apparently permission maps.
