### PR TITLE
Fix --useOldAxiomatization option and add tests for it

### DIFF
--- a/src/main/resources/dafny_axioms/sequences_old.vpr
+++ b/src/main/resources/dafny_axioms/sequences_old.vpr
@@ -277,20 +277,20 @@ domain $Seq[E] {
 
   function Seq_range(min: Int, max: Int): $Seq[Int]
 
-  axiom ranged_seq_length {
+  axiom Seq_range_length {
     forall min: Int, max: Int :: {Seq_length(Seq_range(min, max))}
       min < max
         ? Seq_length(Seq_range(min, max)) == max - min
         : Seq_length(Seq_range(min, max)) == 0
   }
 
-  axiom ranged_seq_index {
+  axiom Seq_range_index {
     forall min: Int, max: Int, i: Int :: {Seq_index(Seq_range(min, max), i)}
       0 <= i && i < max - min ==>
         Seq_index(Seq_range(min, max), i) == min + i
   }
 
-  axiom ranged_seq_contains {
+  axiom Seq_range_contains {
     forall min: Int, max: Int, e: Int :: {Seq_contains(Seq_range(min, max), e)}
       Seq_contains(Seq_range(min, max), e)
         <==> // Two implications in the Dafny version

--- a/src/test/resources/oldaxiomatization/example1.vpr
+++ b/src/test/resources/oldaxiomatization/example1.vpr
@@ -1,0 +1,75 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+method test1()
+{
+  var m : Map[Int, Bool] := Map()
+  assert |Map[Int, Bool]()| == 0
+  assert |m| == 0
+  
+  var d : Set[Int] := domain(m)
+  assert d == Set()
+  
+  var r : Set[Bool] := range(m)
+  assert |range(m)| == 0
+}
+
+method test2()
+{
+  var m : Map[Int, Bool] := Map()
+  m := m[2 := true]
+  
+  assert m[2]
+  assert domain(m) == Set(2)
+  assert range(m) == Set(true)
+}
+
+method test3()
+{
+  var m : Map[Int, Int] := Map(2 := 12, 3 := 24, 4 := 36)
+  
+  assert |m| == 3
+  assert m[2] == 12 && m[3] == 24 && m[4] == 36
+  assert domain(m) == Set(4, 2, 3)
+  assert range(m) == Set(24, 12, 36)
+  assert 3 in m
+  assert !(1 in m)
+}
+
+method test4()
+{
+  var m1 : Map[Int, Bool] := Map(2 := false, 4 := true, 6 := false)
+  var m2 : Map[Int, Bool] := Map(6 := false, 2 := false)
+  
+  assert !(4 in m2)
+  assert m1 != m2
+  assert m2[4 := true][4]
+  assert m1 == m1[4 := true]
+  assert m1 == m2[4 := true]
+}
+
+method test5(m : Map[Int, Map[Int, Bool]])
+  requires forall i : Int :: { i in m } (0 <= i && i < 4 <==> i in m)
+  requires forall i : Int, j : Int :: { j in m[i] } i in m ==> (0 <= j && j < 4 <==> j in m[i])
+  requires forall i : Int, j : Int :: { m[i][j] } i in m && j in m ==> (m[i][j] <==> i == j)
+{
+  assert m[2][2]
+  assert !m[1][2]
+  assert domain(m) == Set(0, 1, 2, 3)
+  assert domain(m[0]) == Set(0, 1, 2, 3)
+  assert m[2] == Map(0 := false, 1 := false, 2 := true, 3 := false)
+  assert Map(0 := false, 1 := false, 2 := true, 3 := false) in range(m)
+}
+
+field val : Int
+
+method test6(m : Map[Int, Ref], x : Int)
+  requires forall i: Int, j: Int :: { i in m, j in m } i in m && j in m && i != j ==> m[i] != m[j]
+  requires forall k : Int :: { k in m } k in m ==> acc(m[k].val)
+{
+  if (x in m)
+  {
+    m[x].val := m[x].val + x
+  }
+}
+

--- a/src/test/resources/oldaxiomatization/lesscomplete.vpr
+++ b/src/test/resources/oldaxiomatization/lesscomplete.vpr
@@ -1,0 +1,8 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+method test_seq_semiequal()
+{
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert Seq(true, false) != Seq(true, true)
+}

--- a/src/test/resources/oldaxiomatization/range_axiom_issue.vpr
+++ b/src/test/resources/oldaxiomatization/range_axiom_issue.vpr
@@ -1,0 +1,9 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+method refSeq()
+{
+  var tmp: Seq[Ref]
+  // make sure we don't get errors if we use only seq types other than int
+  // (since there are special range axioms only for int seqs that can lead to errors if int seqs are not defined)
+}

--- a/src/test/resources/oldaxiomatization/sequences.vpr
+++ b/src/test/resources/oldaxiomatization/sequences.vpr
@@ -1,0 +1,100 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+method t1(x: Int, xs: Seq[Int]) {
+    var n: Seq[Int] := Seq[Int]()
+    assert |n| == 0
+    assert n != Seq(x)
+    assert |Seq(1)| == 1
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert |Seq(0)| == 0
+}
+
+method t2() {
+    assert 1 in Seq(1,2,3)
+    assert |[-1..10)| == 11
+    assert Seq(1) ++ Seq(2) == Seq(1,2)
+
+    var a: Seq[Int] := Seq(0,1,-11,22)
+    assert a[2] == -11
+
+    assert a[..1] == Seq(0)
+    assert a[1..] == Seq(1,-11,22)
+    assert a[1..2] == Seq(1)
+
+    assert a[1 := 22] == (a[1 := -1][1 := 22])
+    assert a[1 := 22] == Seq(0,22,-11,22)
+    assert |a[1 := 22]| == 4
+    assert a[1 := 22][1] == 22
+    assert a[1 := 22][2] == -11
+    //:: ExpectedOutput(assert.failed:assertion.false)
+    assert a[1 := 22][0] == 22
+}
+
+method test3() {
+  var xs: Seq[Int] := Seq(0, 1, 2, 3, 4, 5, 6, 7)
+  var bs: Seq[Bool] := Seq(true, true, false, true) ++ Seq(false, true)
+
+  assert |xs[1..][..6]| == |bs|
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert |xs[1..]| == |xs|
+}
+
+method test4(s:Seq[Int], i : Int, j:Int) 
+  requires 0 <= i
+  requires i <= j
+{
+  assert s == s[..i] ++ s[i..]
+  assert s == s[..i] ++ s[i..j] ++ s[j..]
+  assert (s[..i] ++ s[i..j]) ++ s[j..] == s[..i] ++ (s[i..j] ++ s[j..])
+  //:: ExpectedOutput(assert.failed:assertion.false)
+  assert |s[j..]| == |s| - j
+}
+
+method test5(s:Seq[Int], i : Int, j:Int) 
+{
+  assert s == s[..i] ++ s[i..]
+}
+
+method test6() {
+  assert Seq(3,4,5,6)[0] == 3
+  assert Seq(3,4,5,6)[1] == 4
+  assert Seq(3,4,5,6)[2] == 5
+  assert Seq(3,4,5,6)[3] == 6
+    //:: ExpectedOutput(assert.failed:assertion.false)
+  assert Seq(3,4,5,6)[3] == 5
+}
+
+function trivial(i:Int) : Bool { true }
+
+method test_index_definedness_small(i : Int) 
+  requires i < 4
+{
+  //:: ExpectedOutput(assert.failed:seq.index.negative)  
+  assert trivial(Seq(3,4,5,6)[i])
+}
+
+method test_index_definedness_large(i : Int) 
+  requires i >= 0
+{ 
+  //:: ExpectedOutput(assert.failed:seq.index.length)  
+  assert trivial(Seq(3,4,5,6)[i])
+}
+
+method test_build_index_definedness_small(i : Int) 
+  requires i < 4
+{
+  //:: ExpectedOutput(assert.failed:seq.index.negative)
+  //:: MissingOutput(assert.failed:seq.index.negative, /carbon/issue/232/)
+  assert trivial(Seq(3,4,5,6)[i := 3][0])
+}
+
+method test_build_index_definedness_large(i : Int) 
+  requires i >= 0
+{    
+  //:: ExpectedOutput(assignment.failed:seq.index.length)
+  //:: MissingOutput(assignment.failed:seq.index.length, /carbon/issue/232/)
+  var s : Seq[Int] := Seq(3,4,5,6)[i := 3]
+  assert trivial(s[0])
+}
+

--- a/src/test/resources/oldaxiomatization/sets.vpr
+++ b/src/test/resources/oldaxiomatization/sets.vpr
@@ -1,0 +1,20 @@
+// Any copyright is dedicated to the Public Domain.
+// http://creativecommons.org/publicdomain/zero/1.0/
+
+
+method t1(x: Int, xs: Set[Int]) {
+    var n: Set[Int] := Set[Int]()
+    assert |n| == 0
+    assert n != Set(x)
+    assert |Set(1)| == 1
+}
+
+method t2() {
+    assert 1 in Set(1,2,3)
+    var a: Set[Int] := Set(1)
+    var b: Set[Int] := Set(2)
+    assert (a union b) == Set(1,2)
+    assert ((Set(1)) union (Set(1))) == Set(1)
+
+    assert 1 in ((Set(1,2)) intersection (Set(100,1)))
+}

--- a/src/test/scala/SiliconTestsOldAxiomatization.scala
+++ b/src/test/scala/SiliconTestsOldAxiomatization.scala
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2025 ETH Zurich.
+
+package viper.silicon.tests
+
+class SiliconTestsOldAxiomatization extends SiliconTests {
+  override val testDirectories: Seq[String] = Seq("oldaxiomatization")
+
+ override val commandLineArguments: Seq[String] = Seq(
+    "--timeout", "300" /* seconds */,
+    "--useOldAxiomatization")
+}


### PR DESCRIPTION
Fixing the command line option ``--useOldAxiomatization``, which was broken by https://github.com/viperproject/silicon/pull/927, and adding tests for it so this doesn't go unnoticed again.