### PR TITLE
Fix name clash between class and object

### DIFF
--- a/src/main/scala/rules/HeapSupporter.scala
+++ b/src/main/scala/rules/HeapSupporter.scala
@@ -163,7 +163,7 @@ trait HeapSupportRules extends SymbolicExecutionRules {
 
 }
 
-class DefaultHeapSupporter extends HeapSupportRules {
+class DefaultHeapSupportRules extends HeapSupportRules {
   def isPossibleTrigger(s: State, fa: ast.FieldAccess): Boolean = {
     s.qpFields.contains(fa.field)
   }
@@ -847,4 +847,4 @@ class DefaultHeapSupporter extends HeapSupportRules {
   }
 }
 
-object defaultHeapSupporter extends DefaultHeapSupporter
+object defaultHeapSupporter extends DefaultHeapSupportRules


### PR DESCRIPTION
Fixing the name clash between the class ``DefaultHeapSupporter`` and the object ``defaultHeapSupporter``that is apparently the cause of the ``NoClassDefFoundError`` in issue https://github.com/viperproject/silicon/issues/941 by renaming the class to ``DefaultHeapSupportRules``.