### PR TITLE
Avoid defining let-bound variables on SMT level 

### DIFF
--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -640,7 +640,7 @@ object executor extends ExecutionRules {
 
    private def ssaifyRhs(rhs: Term, rhsExp: ast.Exp, rhsExpNew: Option[ast.Exp], name: String, typ: ast.Type, v: Verifier, s : State): (Term, Option[ast.Exp]) = {
      rhs match {
-       case _: Var | _: Literal =>
+       case t if t.isKnownNonTriggering =>
          (rhs, rhsExpNew)
 
        case _  =>


### PR DESCRIPTION
When evaluating an expression ``let x == (e1) in e2``, Silicon emits an ``(assert (= x e1))`` for a fresh variable ``x`` on the SMT level to make sure that ``e1`` is available as a triggering term even when does not occur in ``e2``; this is done to fix https://github.com/viperproject/silver/issues/688.

However, these additional variables and equalities can slow down verification significantly (see attached file [floats.txt](https://github.com/user-attachments/files/23504589/floats.txt)).
This PR implements a compromise and emits these definitions only when ``e1`` might be triggering and only during function and predicate verification, since in those, let-bound function calls and similar expressions are commonly used e.g. to call lemmas or trigger quantifiers (as in the original issue).
As a helper, it also adds a new method ``isKnownNonTriggering`` on terms that allows us to make some case distinctions more precise.