### PR TITLE
Pruning and verification flags for VSC Extension

### DIFF
--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -753,10 +753,21 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
 
   val pruneExportFileName: ScallopOption[String] = opt[String]("pruneExportFileName",
     descr = "Export file name for the pruned program (used with --pruneLines)",
-    default = Some("pruned"),
+    default = Some("prunedExport.vpr"),
+    noshort = true
+  )
+  
+  val computeVerificationProgress: ScallopOption[Boolean] = opt[Boolean]("computeVerificationProgress",
+    descr = "Computes verification progress of the program",
+    default = Some(false),
     noshort = true
   )
 
+  val computeVerificationProgressFileName: ScallopOption[String] = opt[String]("computeVerificationProgressFileName",
+    descr = "Export file name for the verification progress output (used with --computeVerificationProgress)",
+    default = Some("progressExport.vpr"),
+    noshort = true
+  )
 
   /* Option validation (trailing file argument is validated by parent class) */
 
@@ -840,6 +851,13 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     case (Some(_), Some(true)) => Right(())
     case (Some(_), _) =>
       Left(s"Option ${pruneLines.name} requires option ${enableDependencyAnalysis.name}")
+  }
+
+  validateOpt(computeVerificationProgress, enableDependencyAnalysis) {
+    case (Some(false), _) => Right(())
+    case (_, Some(true)) => Right(())
+    case (_, _) =>
+      Left(s"Option ${computeVerificationProgress.name} requires option ${enableDependencyAnalysis.name}")
   }
 
   validateOpt(startDebuggerAutomatically, enableDebugging) {

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -745,6 +745,19 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
+  val pruneLines: ScallopOption[List[Int]] = opt[List[Int]]("pruneLines",
+    descr = "Line numbers to prune the program with respect to. Part of the dependency analysis tool.",
+    default = None,
+    noshort = true
+  )
+
+  val pruneExportFileName: ScallopOption[String] = opt[String]("pruneExportFileName",
+    descr = "Export file name for the pruned program (used with --pruneLines)",
+    default = Some("pruned"),
+    noshort = true
+  )
+
+
   /* Option validation (trailing file argument is validated by parent class) */
 
   validateOpt(prover) {
@@ -820,6 +833,13 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     case (_, Some(true)) => Right(())
     case (_, _) =>
       Left(s"Option ${startDependencyAnalysisTool.name} requires option ${enableDependencyAnalysis.name}")
+  }
+
+  validateOpt(pruneLines, enableDependencyAnalysis) {
+    case (None, _) => Right(())
+    case (Some(_), Some(true)) => Right(())
+    case (Some(_), _) =>
+      Left(s"Option ${pruneLines.name} requires option ${enableDependencyAnalysis.name}")
   }
 
   validateOpt(startDebuggerAutomatically, enableDebugging) {

--- a/src/main/scala/dependencyAnalysis/DependencyAnalysisUserTool.scala
+++ b/src/main/scala/dependencyAnalysis/DependencyAnalysisUserTool.scala
@@ -162,13 +162,19 @@ class DependencyAnalysisUserTool(fullGraphInterpreter: DependencyGraphInterprete
     println("Done.")
   }
 
-  private def handleVerificationProgressQuery(): Unit = {
+  def handleVerificationProgressQuery(exportFileNameOpt: Option[String] = None): Unit = {
 
     val ((optProgressPeter, optProgressLea, optInfo), optTime) = measureTime(fullGraphInterpreter.computeVerificationProgress())
     //    println(s"Overall verification progress: $progress")
-    println(s"$optInfo")
-    println(s"Peter: $optProgressPeter; Lea: $optProgressLea")
-    println(s"Finished in ${optTime}ms")
+    
+    val output = s"$optInfo\nPeter: $optProgressPeter; Lea: $optProgressLea\nFinished in ${optTime}ms"
+    println(output)
+
+    if (exportFileNameOpt.isDefined) {
+      val writer = new PrintWriter(exportFileNameOpt.get)
+      writer.println(output)
+      writer.close()
+    }
   }
 
   private def handleVerificationProgressDEBUGQuery(): Unit = {

--- a/src/main/scala/dependencyAnalysis/DependencyAnalysisUserTool.scala
+++ b/src/main/scala/dependencyAnalysis/DependencyAnalysisUserTool.scala
@@ -413,9 +413,11 @@ class DependencyAnalysisUserTool(fullGraphInterpreter: DependencyGraphInterprete
     (res, durationMs)
   }
 
-  private def handlePruningRequest(inputs: Seq[String]): Unit = {
-    println("exportFileName: ")
-    val exportFileName = readLine()
+  def handlePruningRequest(inputs: Seq[String], exportFileNameOpt: Option[String] = None): Unit = {
+    val exportFileName = exportFileNameOpt.getOrElse {
+      println("exportFileName: ")
+      readLine()
+    }
 
     val queriedNodes = getQueriedNodesFromInput(inputs.toSet)
     val dependencies = fullGraphInterpreter.getAllNonInternalDependencies(queriedNodes.map(_.id))

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -676,6 +676,14 @@ class DefaultMainVerifier(config: Config,
 
     DependencyAnalyzer.stopTimeMeasurementAndAddToTotal(postProcessingStartTime, DependencyAnalyzer.timeOfPostprocessing)
 
+    if (Verifier.config.pruneLines.isDefined) {
+      val commandLineTool = new DependencyAnalysisUserTool(result.getFullDependencyGraphInterpreter, dependencyGraphInterpreters, program, verificationErrors)
+      val lineInputs = Verifier.config.pruneLines().map(_.toString)
+      val exportFileName = Verifier.config.pruneExportFileName()
+      commandLineTool.handlePruningRequest(lineInputs, Some(exportFileName))
+    }
+
+
     if (Verifier.config.startDependencyAnalysisTool()) {
       val commandLineTool = new DependencyAnalysisUserTool(result.getFullDependencyGraphInterpreter, dependencyGraphInterpreters, program, verificationErrors)
       commandLineTool.run()

--- a/src/main/scala/verifier/DefaultMainVerifier.scala
+++ b/src/main/scala/verifier/DefaultMainVerifier.scala
@@ -683,6 +683,11 @@ class DefaultMainVerifier(config: Config,
       commandLineTool.handlePruningRequest(lineInputs, Some(exportFileName))
     }
 
+    if (Verifier.config.computeVerificationProgress()) {
+      val commandLineTool = new DependencyAnalysisUserTool(result.getFullDependencyGraphInterpreter, dependencyGraphInterpreters, program, verificationErrors)
+      val exportFileName = Verifier.config.computeVerificationProgressFileName()
+      commandLineTool.handleVerificationProgressQuery(Some(exportFileName))
+    }
 
     if (Verifier.config.startDependencyAnalysisTool()) {
       val commandLineTool = new DependencyAnalysisUserTool(result.getFullDependencyGraphInterpreter, dependencyGraphInterpreters, program, verificationErrors)


### PR DESCRIPTION
This pull request adds pruning flags (--pruneLines, --pruneExportFileName), and verification progress flags (--computeVerificationProgress, --computeVerificationProgressFileName), that are necessary for pruning and progress functionality implementation in viper-ide Visual Studio Code extension.

Viper-ide extension would add these feature flags to the Silicon invocation when requested by the user, and Silicon would use the respective features.