### PR TITLE
Record metadata for each SMT-query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ viper_tutorial_examples
 .bsp/
 .bloop/
 .metals/
+.vscode

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -691,6 +691,18 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
+  val recordProofQueries: ScallopOption[Boolean] = opt[Boolean]("recordProofQueries",
+    descr = "Record SMT query statistics (kind, member, source position, duration) per query in ProofQueryCollector",
+    default = Some(false),
+    noshort = true
+  )
+
+  val proofQueryCsvFile: ScallopOption[String] = opt[String]("proofQueryCsvFile",
+    descr = "Path to a CSV file to which proof query records are written at the end of verification (requires --recordProofQueries)",
+    default = None,
+    noshort = true
+  )
+
   /* Option validation (trailing file argument is validated by parent class) */
 
   validateOpt(prover) {

--- a/src/main/scala/Config.scala
+++ b/src/main/scala/Config.scala
@@ -691,14 +691,8 @@ class Config(args: Seq[String]) extends SilFrontendConfig(args, "Silicon") {
     noshort = true
   )
 
-  val recordProofQueries: ScallopOption[Boolean] = opt[Boolean]("recordProofQueries",
-    descr = "Record SMT query statistics (kind, member, source position, duration) per query in ProofQueryCollector",
-    default = Some(false),
-    noshort = true
-  )
-
-  val proofQueryCsvFile: ScallopOption[String] = opt[String]("proofQueryCsvFile",
-    descr = "Path to a CSV file to which proof query records are written at the end of verification (requires --recordProofQueries)",
+  val recordProofQueries: ScallopOption[String] = opt[String]("recordProofQueries",
+    descr = "Path to a CSV file to which SMT query statistics (kind, member, source position, duration) are written at the end of verification",
     default = None,
     noshort = true
   )

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -237,7 +237,7 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
 
       /* Write proof-query CSV if requested */
       config.recordProofQueries.toOption.foreach { path =>
-        val header = "isAssert,member,file,line,column,kind,durationMs,succeeded"
+        val header = "isAssert,member,file,line,column,kind,durationMs,succeeded,description"
         val rows = ProofQueryCollector.records.map { r =>
           val (file, line, col) = r.pos match {
             case sp: viper.silver.ast.AbstractSourcePosition =>
@@ -245,7 +245,8 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
             case _ => ("?", "?", "?")
           }
           Seq(r.isAssert, r.member.getOrElse("?"), file, line, col,
-              r.kind, "%.3f".format(r.durationMs), r.succeeded).mkString(",")
+              r.kind, "%.3f".format(r.durationMs), r.succeeded,
+              r.description.getOrElse("")).mkString(",")
         }
         java.nio.file.Files.write(
           java.nio.file.Paths.get(path),

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -236,23 +236,21 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
       assert(result.nonEmpty, "The result of the verification run wasn't stored appropriately")
 
       /* Write proof-query CSV if requested */
-      if (config.recordProofQueries()) {
-        config.proofQueryCsvFile.toOption.foreach { path =>
-          val header = "isAssert,member,file,line,column,kind,durationMs,succeeded"
-          val rows = ProofQueryCollector.records.map { r =>
-            val (file, line, col) = r.pos match {
-              case sp: viper.silver.ast.AbstractSourcePosition =>
-                (sp.file.toString, sp.line.toString, sp.column.toString)
-              case _ => ("?", "?", "?")
-            }
-            Seq(r.isAssert, r.member.getOrElse("?"), file, line, col,
-                r.kind, r.durationMs, r.succeeded).mkString(",")
+      config.recordProofQueries.toOption.foreach { path =>
+        val header = "isAssert,member,file,line,column,kind,durationMs,succeeded"
+        val rows = ProofQueryCollector.records.map { r =>
+          val (file, line, col) = r.pos match {
+            case sp: viper.silver.ast.AbstractSourcePosition =>
+              (sp.file.toString, sp.line.toString, sp.column.toString)
+            case _ => ("?", "?", "?")
           }
-          java.nio.file.Files.write(
-            java.nio.file.Paths.get(path),
-            (header +: rows).mkString("\n").getBytes(java.nio.charset.StandardCharsets.UTF_8)
-          )
+          Seq(r.isAssert, r.member.getOrElse("?"), file, line, col,
+              r.kind, "%.3f".format(r.durationMs), r.succeeded).mkString(",")
         }
+        java.nio.file.Files.write(
+          java.nio.file.Paths.get(path),
+          (header +: rows).mkString("\n").getBytes(java.nio.charset.StandardCharsets.UTF_8)
+        )
         ProofQueryCollector.clear()
       }
 

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -19,7 +19,7 @@ import viper.silver.reporter._
 import viper.silver.verifier.{AbstractVerificationError => SilAbstractVerificationError, Failure => SilFailure, Success => SilSuccess, TimeoutOccurred => SilTimeoutOccurred, VerificationResult => SilVerificationResult, Verifier => SilVerifier}
 import viper.silicon.interfaces.Failure
 import viper.silicon.logger.{MemberSymbExLogger, SymbExLogger}
-import viper.silicon.reporting.{MultiRunRecorders, condenseToViperResult}
+import viper.silicon.reporting.{MultiRunRecorders, ProofQueryCollector, condenseToViperResult}
 import viper.silicon.verifier.DefaultMainVerifier
 import viper.silicon.decider.{Cvc5ProverStdIO, Z3ProverStdIO}
 import viper.silver.cfg.silver.SilverCfg
@@ -234,6 +234,28 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
       }
 
       assert(result.nonEmpty, "The result of the verification run wasn't stored appropriately")
+
+      /* Write proof-query CSV if requested */
+      if (config.recordProofQueries()) {
+        config.proofQueryCsvFile.toOption.foreach { path =>
+          val header = "isAssert,member,file,line,column,kind,durationMs,succeeded"
+          val rows = ProofQueryCollector.records.map { r =>
+            val (file, line, col) = r.pos match {
+              case sp: viper.silver.ast.AbstractSourcePosition =>
+                (sp.file.toString, sp.line.toString, sp.column.toString)
+              case _ => ("?", "?", "?")
+            }
+            Seq(r.isAssert, r.member.getOrElse("?"), file, line, col,
+                r.kind, r.durationMs, r.succeeded).mkString(",")
+          }
+          java.nio.file.Files.write(
+            java.nio.file.Paths.get(path),
+            (header +: rows).mkString("\n").getBytes(java.nio.charset.StandardCharsets.UTF_8)
+          )
+        }
+        ProofQueryCollector.clear()
+      }
+
       result.get
     }
   }

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -237,15 +237,15 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
 
       /* Write proof-query CSV if requested */
       config.recordProofQueries.toOption.foreach { path =>
-        val header = "isAssert,member,file,line,column,kind,durationMs,succeeded,description"
+        val header = "kind,member,file,line,column,category,durationMs,succeeded,description"
         val rows = ProofQueryCollector.records.map { r =>
           val (file, line, col) = r.pos match {
             case sp: viper.silver.ast.AbstractSourcePosition =>
               (sp.file.toString, sp.line.toString, sp.column.toString)
             case _ => ("?", "?", "?")
           }
-          Seq(r.isAssert, r.member.getOrElse("?"), file, line, col,
-              r.kind, "%.3f".format(r.durationMs), r.succeeded,
+          Seq(r.kind, r.member.getOrElse("?"), file, line, col,
+              r.category, "%.3f".format(r.durationMs), r.succeeded,
               r.description.getOrElse("")).mkString(",")
         }
         java.nio.file.Files.write(

--- a/src/main/scala/Silicon.scala
+++ b/src/main/scala/Silicon.scala
@@ -238,6 +238,12 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
       /* Write proof-query CSV if requested */
       config.recordProofQueries.toOption.foreach { path =>
         val header = "kind,member,file,line,column,category,durationMs,succeeded,description"
+        /* File names, member names and descriptions are not guaranteed to be comma-free. */
+        def escape(field: Any): String = {
+          val s = field.toString
+          if (s.exists(c => c == ',' || c == '"' || c == '\n')) "\"" + s.replace("\"", "\"\"") + "\""
+          else s
+        }
         val rows = ProofQueryCollector.records.map { r =>
           val (file, line, col) = r.pos match {
             case sp: viper.silver.ast.AbstractSourcePosition =>
@@ -246,7 +252,7 @@ class Silicon(val reporter: Reporter, private var debugInfo: Seq[(String, Any)] 
           }
           Seq(r.kind, r.member.getOrElse("?"), file, line, col,
               r.category, "%.3f".format(r.durationMs), r.succeeded,
-              r.description.getOrElse("")).mkString(",")
+              r.description.getOrElse("")).map(escape).mkString(",")
         }
         java.nio.file.Files.write(
           java.nio.file.Paths.get(path),

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -379,7 +379,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       val t0  = System.nanoTime()
       val res = prover.check(timeout) == Unsat
       val dur = (System.nanoTime() - t0) / 1e6
-      if (Verifier.config.recordProofQueries())
+      if (Verifier.config.recordProofQueries.isDefined)
         ProofQueryCollector.record(ProofQueryRecord(
           isAssert   = false,
           member     = member,
@@ -430,7 +430,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       val result = alreadyKnown || proverAssert(t, timeout)
       val durMs  = (System.nanoTime() - t0) / 1e6
 
-      if (Verifier.config.recordProofQueries())
+      if (Verifier.config.recordProofQueries.isDefined)
         ProofQueryCollector.record(ProofQueryRecord(
           isAssert   = isAssert,
           member     = member,

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -52,7 +52,8 @@ trait Decider {
 
   def checkSmoke(isAssert: Boolean = false,
                  pos: ast.Position = ast.NoPosition,
-                 member: Option[String] = None): Boolean
+                 member: Option[String] = None,
+                 description: Option[String] = None): Boolean
 
   def setCurrentBranchCondition(t: Term, te: (ast.Exp, Option[ast.Exp])): Unit
   def setPathConditionMark(): Mark
@@ -73,7 +74,8 @@ trait Decider {
   def check(t: Term, timeout: Int,
             kind: ProofQueryKind = ProofQueryKind.Consistency,
             pos: ast.Position = ast.NoPosition,
-            member: Option[String] = None): Boolean
+            member: Option[String] = None,
+            description: Option[String] = None): Boolean
 
   /* TODO: Consider changing assert such that
    *         1. It passes State and Operations to the continuation
@@ -83,7 +85,8 @@ trait Decider {
              timeout: Option[Int] = None,
              kind: ProofQueryKind = ProofQueryKind.Consistency,
              pos: ast.Position = ast.NoPosition,
-             member: Option[String] = None
+             member: Option[String] = None,
+             description: Option[String] = None
             )(Q: Boolean => VerificationResult): VerificationResult
 
   def fresh(id: String, sort: Sort, ptype: Option[PType]): Var
@@ -374,36 +377,40 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
     def checkSmoke(isAssert: Boolean = false,
                    pos: ast.Position = ast.NoPosition,
-                   member: Option[String] = None): Boolean = {
+                   member: Option[String] = None,
+                   description: Option[String] = None): Boolean = {
       val timeout = if (isAssert) Verifier.config.assertTimeout.toOption else Verifier.config.checkTimeout.toOption
       val t0  = System.nanoTime()
       val res = prover.check(timeout) == Unsat
       val dur = (System.nanoTime() - t0) / 1e6
       if (Verifier.config.recordProofQueries.isDefined)
         ProofQueryCollector.record(ProofQueryRecord(
-          isAssert   = false,
-          member     = member,
-          pos        = pos,
-          kind       = ProofQueryKind.PathInfeasibility,
-          durationMs = dur,
-          succeeded  = res))
+          isAssert    = false,
+          member      = member,
+          pos         = pos,
+          kind        = ProofQueryKind.PathInfeasibility,
+          durationMs  = dur,
+          succeeded   = res,
+          description = description))
       res
     }
 
     def check(t: Term, timeout: Int,
               kind: ProofQueryKind = ProofQueryKind.Consistency,
               pos: ast.Position = ast.NoPosition,
-              member: Option[String] = None): Boolean =
-      deciderAssert(t, Some(timeout), kind, pos, member, isAssert = false)
+              member: Option[String] = None,
+              description: Option[String] = None): Boolean =
+      deciderAssert(t, Some(timeout), kind, pos, member, description, isAssert = false)
 
     def assert(t: Term,
                timeout: Option[Int] = Verifier.config.assertTimeout.toOption,
                kind: ProofQueryKind = ProofQueryKind.Consistency,
                pos: ast.Position = ast.NoPosition,
-               member: Option[String] = None
+               member: Option[String] = None,
+               description: Option[String] = None
               )(Q: Boolean => VerificationResult): VerificationResult = {
 
-      val success = deciderAssert(t, timeout, kind, pos, member, isAssert = true)
+      val success = deciderAssert(t, timeout, kind, pos, member, description, isAssert = true)
 
       // If the SMT query was not successful, store it (possibly "overwriting"
       // any previously saved query), otherwise discard any query we had saved
@@ -421,6 +428,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
                                kind: ProofQueryKind = ProofQueryKind.Consistency,
                                pos: ast.Position = ast.NoPosition,
                                member: Option[String] = None,
+                               description: Option[String] = None,
                                isAssert: Boolean = true) = {
       val assertRecord = new DeciderAssertRecord(t, timeout)
       val sepIdentifier = symbExLog.openScope(assertRecord)
@@ -432,12 +440,13 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
       if (Verifier.config.recordProofQueries.isDefined)
         ProofQueryCollector.record(ProofQueryRecord(
-          isAssert   = isAssert,
-          member     = member,
-          pos        = pos,
-          kind       = kind,
-          durationMs = durMs,
-          succeeded  = result))
+          isAssert    = isAssert,
+          member      = member,
+          pos         = pos,
+          kind        = kind,
+          durationMs  = durMs,
+          succeeded   = result,
+          description = description))
 
       symbExLog.closeScope(sepIdentifier)
       result

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -72,7 +72,7 @@ trait Decider {
   def assume(terms: Iterable[Term], debugExp: Option[DebugExp], enforceAssumption: Boolean): Unit
 
   def check(t: Term, timeout: Int,
-            kind: ProofQueryKind = ProofQueryKind.Consistency,
+            kind: ProofQueryKind,
             pos: ast.Position = ast.NoPosition,
             member: Option[String] = None,
             description: Option[String] = None): Boolean
@@ -82,8 +82,8 @@ trait Decider {
    *         2. The implementation reacts to a failing assertion by e.g. a state consolidation
    */
   def assert(t: Term,
+             kind: ProofQueryKind,
              timeout: Option[Int] = None,
-             kind: ProofQueryKind = ProofQueryKind.Consistency,
              pos: ast.Position = ast.NoPosition,
              member: Option[String] = None,
              description: Option[String] = None
@@ -396,15 +396,15 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     }
 
     def check(t: Term, timeout: Int,
-              kind: ProofQueryKind = ProofQueryKind.Consistency,
+              kind: ProofQueryKind,
               pos: ast.Position = ast.NoPosition,
               member: Option[String] = None,
               description: Option[String] = None): Boolean =
       deciderAssert(t, Some(timeout), kind, pos, member, description, isAssert = false)
 
     def assert(t: Term,
+               kind: ProofQueryKind,
                timeout: Option[Int] = Verifier.config.assertTimeout.toOption,
-               kind: ProofQueryKind = ProofQueryKind.Consistency,
                pos: ast.Position = ast.NoPosition,
                member: Option[String] = None,
                description: Option[String] = None
@@ -425,7 +425,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     }
 
     private def deciderAssert(t: Term, timeout: Option[Int],
-                               kind: ProofQueryKind = ProofQueryKind.Consistency,
+                               kind: ProofQueryKind,
                                pos: ast.Position = ast.NoPosition,
                                member: Option[String] = None,
                                description: Option[String] = None,

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -13,6 +13,7 @@ import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.interfaces._
 import viper.silicon.interfaces.decider._
 import viper.silicon.logger.records.data.{DeciderAssertRecord, DeciderAssumeRecord, ProverAssertRecord}
+import viper.silicon.reporting.{ProofQueryCollector, ProofQueryRecord}
 import viper.silicon.state._
 import viper.silicon.state.terms.{Term, _}
 import viper.silicon.utils.ast.{extractPTypeFromExp, simplifyVariableName}
@@ -49,7 +50,9 @@ trait Decider {
   def pushScope(): Unit
   def popScope(): Unit
 
-  def checkSmoke(isAssert: Boolean = false): Boolean
+  def checkSmoke(isAssert: Boolean = false,
+                 pos: ast.Position = ast.NoPosition,
+                 member: Option[String] = None): Boolean
 
   def setCurrentBranchCondition(t: Term, te: (ast.Exp, Option[ast.Exp])): Unit
   def setPathConditionMark(): Mark
@@ -67,13 +70,21 @@ trait Decider {
   def assume(assumptions: InsertionOrderedSet[(Term, Option[DebugExp])], enforceAssumption: Boolean = false, isDefinition: Boolean = false): Unit
   def assume(terms: Iterable[Term], debugExp: Option[DebugExp], enforceAssumption: Boolean): Unit
 
-  def check(t: Term, timeout: Int): Boolean
+  def check(t: Term, timeout: Int,
+            kind: ProofQueryKind = ProofQueryKind.Consistency,
+            pos: ast.Position = ast.NoPosition,
+            member: Option[String] = None): Boolean
 
   /* TODO: Consider changing assert such that
    *         1. It passes State and Operations to the continuation
    *         2. The implementation reacts to a failing assertion by e.g. a state consolidation
    */
-  def assert(t: Term, timeout: Option[Int] = None)(Q:  Boolean => VerificationResult): VerificationResult
+  def assert(t: Term,
+             timeout: Option[Int] = None,
+             kind: ProofQueryKind = ProofQueryKind.Consistency,
+             pos: ast.Position = ast.NoPosition,
+             member: Option[String] = None
+            )(Q: Boolean => VerificationResult): VerificationResult
 
   def fresh(id: String, sort: Sort, ptype: Option[PType]): Var
   def fresh(id: String, argSorts: Seq[Sort], resultSort: Sort): Function
@@ -361,18 +372,38 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
     /* Asserting facts */
 
-    def checkSmoke(isAssert: Boolean = false): Boolean = {
+    def checkSmoke(isAssert: Boolean = false,
+                   pos: ast.Position = ast.NoPosition,
+                   member: Option[String] = None): Boolean = {
       val timeout = if (isAssert) Verifier.config.assertTimeout.toOption else Verifier.config.checkTimeout.toOption
-      prover.check(timeout) == Unsat
+      val t0  = System.nanoTime()
+      val res = prover.check(timeout) == Unsat
+      val dur = (System.nanoTime() - t0) / 1e6
+      if (Verifier.config.recordProofQueries())
+        ProofQueryCollector.record(ProofQueryRecord(
+          isAssert   = false,
+          member     = member,
+          pos        = pos,
+          kind       = ProofQueryKind.PathInfeasibility,
+          durationMs = dur,
+          succeeded  = res))
+      res
     }
 
-    def check(t: Term, timeout: Int): Boolean = deciderAssert(t, Some(timeout))
+    def check(t: Term, timeout: Int,
+              kind: ProofQueryKind = ProofQueryKind.Consistency,
+              pos: ast.Position = ast.NoPosition,
+              member: Option[String] = None): Boolean =
+      deciderAssert(t, Some(timeout), kind, pos, member, isAssert = false)
 
-    def assert(t: Term, timeout: Option[Int] = Verifier.config.assertTimeout.toOption)
-              (Q: Boolean => VerificationResult)
-              : VerificationResult = {
+    def assert(t: Term,
+               timeout: Option[Int] = Verifier.config.assertTimeout.toOption,
+               kind: ProofQueryKind = ProofQueryKind.Consistency,
+               pos: ast.Position = ast.NoPosition,
+               member: Option[String] = None
+              )(Q: Boolean => VerificationResult): VerificationResult = {
 
-      val success = deciderAssert(t, timeout)
+      val success = deciderAssert(t, timeout, kind, pos, member, isAssert = true)
 
       // If the SMT query was not successful, store it (possibly "overwriting"
       // any previously saved query), otherwise discard any query we had saved
@@ -386,12 +417,27 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       Q(success)
     }
 
-    private def deciderAssert(t: Term, timeout: Option[Int]) = {
+    private def deciderAssert(t: Term, timeout: Option[Int],
+                               kind: ProofQueryKind = ProofQueryKind.Consistency,
+                               pos: ast.Position = ast.NoPosition,
+                               member: Option[String] = None,
+                               isAssert: Boolean = true) = {
       val assertRecord = new DeciderAssertRecord(t, timeout)
       val sepIdentifier = symbExLog.openScope(assertRecord)
 
-      val asserted = isKnownToBeTrue(t)
-      val result = asserted || proverAssert(t, timeout)
+      val alreadyKnown = isKnownToBeTrue(t)
+      val t0     = System.nanoTime()
+      val result = alreadyKnown || proverAssert(t, timeout)
+      val durMs  = (System.nanoTime() - t0) / 1e6
+
+      if (Verifier.config.recordProofQueries())
+        ProofQueryCollector.record(ProofQueryRecord(
+          isAssert   = isAssert,
+          member     = member,
+          pos        = pos,
+          kind       = kind,
+          durationMs = durMs,
+          succeeded  = result))
 
       symbExLog.closeScope(sepIdentifier)
       result

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -438,7 +438,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       val result = alreadyKnown || proverAssert(t, timeout)
       val durMs  = (System.nanoTime() - t0) / 1e6
 
-      if (Verifier.config.recordProofQueries.isDefined)
+      if (Verifier.config.recordProofQueries.isDefined && !alreadyKnown)
         ProofQueryCollector.record(ProofQueryRecord(
           isAssert    = isAssert,
           member      = member,

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -47,8 +47,8 @@ trait Decider {
 
   def debugVariableTypes: Map[String, PType]
 
-  def pushScope(): Unit
-  def popScope(): Unit
+  def pushScope(member: Option[String] = None, description: Option[String] = None): Unit
+  def popScope(member: Option[String] = None, description: Option[String] = None): Unit
 
   def checkSmoke(isAssert: Boolean = false,
                  pos: ast.Position = ast.NoPosition,
@@ -247,19 +247,41 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
     /* Assumption scope handling */
 
-    def pushScope(): Unit = {
+    def pushScope(member: Option[String] = None, description: Option[String] = None): Unit = {
       //val commentRecord = new CommentRecord("push", null, null)
       //val sepIdentifier = symbExLog.openScope(commentRecord)
       pathConditions.pushScope()
+      val t0 = System.nanoTime()
       _prover.push(timeout = Verifier.config.pushTimeout.toOption)
+      val durMs = (System.nanoTime() - t0) / 1e6
+      if (Verifier.config.recordProofQueries.isDefined)
+        ProofQueryCollector.record(ProofQueryRecord(
+          kind        = QueryKind.Push,
+          member      = member,
+          pos         = ast.NoPosition,
+          category    = ProofQueryKind.ScopeManagement,
+          durationMs  = durMs,
+          succeeded   = true,
+          description = description))
       //symbExLog.closeScope(sepIdentifier)
     }
 
-    def popScope(): Unit = {
+    def popScope(member: Option[String] = None, description: Option[String] = None): Unit = {
       //val commentRecord = new CommentRecord("pop", null, null)
       //val sepIdentifier = symbExLog.openScope(commentRecord)
+      val t0 = System.nanoTime()
       _prover.pop()
+      val durMs = (System.nanoTime() - t0) / 1e6
       pathConditions.popScope()
+      if (Verifier.config.recordProofQueries.isDefined)
+        ProofQueryCollector.record(ProofQueryRecord(
+          kind        = QueryKind.Pop,
+          member      = member,
+          pos         = ast.NoPosition,
+          category    = ProofQueryKind.ScopeManagement,
+          durationMs  = durMs,
+          succeeded   = true,
+          description = description))
       //symbExLog.closeScope(sepIdentifier)
     }
 
@@ -385,10 +407,10 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
       val dur = (System.nanoTime() - t0) / 1e6
       if (Verifier.config.recordProofQueries.isDefined)
         ProofQueryCollector.record(ProofQueryRecord(
-          isAssert    = false,
+          kind        = QueryKind.Check,
           member      = member,
           pos         = pos,
-          kind        = ProofQueryKind.PathInfeasibility,
+          category    = ProofQueryKind.PathInfeasibility,
           durationMs  = dur,
           succeeded   = res,
           description = description))
@@ -400,7 +422,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
               pos: ast.Position = ast.NoPosition,
               member: Option[String] = None,
               description: Option[String] = None): Boolean =
-      deciderAssert(t, Some(timeout), kind, pos, member, description, isAssert = false)
+      deciderAssert(t, Some(timeout), kind, pos, member, description, queryKind = QueryKind.Check)
 
     def assert(t: Term,
                kind: ProofQueryKind,
@@ -410,7 +432,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
                description: Option[String] = None
               )(Q: Boolean => VerificationResult): VerificationResult = {
 
-      val success = deciderAssert(t, timeout, kind, pos, member, description, isAssert = true)
+      val success = deciderAssert(t, timeout, kind, pos, member, description, queryKind = QueryKind.Assert)
 
       // If the SMT query was not successful, store it (possibly "overwriting"
       // any previously saved query), otherwise discard any query we had saved
@@ -429,7 +451,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
                                pos: ast.Position = ast.NoPosition,
                                member: Option[String] = None,
                                description: Option[String] = None,
-                               isAssert: Boolean = true) = {
+                               queryKind: QueryKind = QueryKind.Assert) = {
       val assertRecord = new DeciderAssertRecord(t, timeout)
       val sepIdentifier = symbExLog.openScope(assertRecord)
 
@@ -440,10 +462,10 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
 
       if (Verifier.config.recordProofQueries.isDefined && !alreadyKnown)
         ProofQueryCollector.record(ProofQueryRecord(
-          isAssert    = isAssert,
+          kind        = queryKind,
           member      = member,
           pos         = pos,
-          kind        = kind,
+          category    = kind,
           durationMs  = durMs,
           succeeded   = result,
           description = description))

--- a/src/main/scala/decider/Decider.scala
+++ b/src/main/scala/decider/Decider.scala
@@ -50,10 +50,14 @@ trait Decider {
   def pushScope(member: Option[String] = None, description: Option[String] = None): Unit
   def popScope(member: Option[String] = None, description: Option[String] = None): Unit
 
+  /** Checks whether the current path conditions are already contradictory. Most such checks serve
+    * to detect infeasible paths, hence the default category; call sites that use a smoke check for
+    * a different purpose should override `kind` accordingly. */
   def checkSmoke(isAssert: Boolean = false,
                  pos: ast.Position = ast.NoPosition,
                  member: Option[String] = None,
-                 description: Option[String] = None): Boolean
+                 description: Option[String] = None,
+                 kind: ProofQueryKind = ProofQueryKind.PathInfeasibility): Boolean
 
   def setCurrentBranchCondition(t: Term, te: (ast.Exp, Option[ast.Exp])): Unit
   def setPathConditionMark(): Mark
@@ -400,7 +404,8 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
     def checkSmoke(isAssert: Boolean = false,
                    pos: ast.Position = ast.NoPosition,
                    member: Option[String] = None,
-                   description: Option[String] = None): Boolean = {
+                   description: Option[String] = None,
+                   kind: ProofQueryKind = ProofQueryKind.PathInfeasibility): Boolean = {
       val timeout = if (isAssert) Verifier.config.assertTimeout.toOption else Verifier.config.checkTimeout.toOption
       val t0  = System.nanoTime()
       val res = prover.check(timeout) == Unsat
@@ -410,7 +415,7 @@ trait DefaultDeciderProvider extends VerifierComponent { this: Verifier =>
           kind        = QueryKind.Check,
           member      = member,
           pos         = pos,
-          category    = ProofQueryKind.PathInfeasibility,
+          category    = kind,
           durationMs  = dur,
           succeeded   = res,
           description = description))

--- a/src/main/scala/interfaces/decider/ProofQueryKind.scala
+++ b/src/main/scala/interfaces/decider/ProofQueryKind.scala
@@ -1,0 +1,32 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2019 ETH Zurich.
+
+package viper.silicon.interfaces.decider
+
+/** Categorises the purpose of an SMT query (assert or check) issued by the verifier. */
+sealed trait ProofQueryKind
+
+object ProofQueryKind {
+  /** (a) Consistency checks: non-negative/positive permission assertions, injectivity checks
+   *  in quantified permissions, and similar well-formedness obligations. */
+  case object Consistency extends ProofQueryKind
+
+  /** (b) Heap proof obligations: chunk-existence checks, permission-amount checks during
+   *  consume/produce operations, and related heap-access correctness queries. */
+  case object Heap extends ProofQueryKind
+
+  /** (c) Functional-correctness queries: pre/postcondition checks, assert-statement assertions,
+   *  array-index bounds, divisor non-zero, and similar user-visible proof obligations. */
+  case object FunctionalCorrectness extends ProofQueryKind
+
+  /** (d) Axiomatisation queries: consistency of function, domain, or predicate axioms
+   *  (rare – axioms are mostly assumed, not asserted). */
+  case object Axiomatization extends ProofQueryKind
+
+  /** (e) Path-infeasibility checks: smoke checks and branch-feasibility tests that determine
+   *  whether the current execution path is reachable at all. */
+  case object PathInfeasibility extends ProofQueryKind
+}

--- a/src/main/scala/interfaces/decider/ProofQueryKind.scala
+++ b/src/main/scala/interfaces/decider/ProofQueryKind.scala
@@ -29,4 +29,8 @@ object ProofQueryKind {
   /** (e) Path-infeasibility checks: smoke checks and branch-feasibility tests that determine
    *  whether the current execution path is reachable at all. */
   case object PathInfeasibility extends ProofQueryKind
+
+  /** (f) Unknown: used when the purpose of the query does not clearly fall into any of the
+   *  above categories, or has not yet been classified. */
+  case object Unknown extends ProofQueryKind
 }

--- a/src/main/scala/interfaces/decider/ProofQueryKind.scala
+++ b/src/main/scala/interfaces/decider/ProofQueryKind.scala
@@ -33,4 +33,8 @@ object ProofQueryKind {
   /** (f) Unknown: used when the purpose of the query does not clearly fall into any of the
    *  above categories, or has not yet been classified. */
   case object Unknown extends ProofQueryKind
+
+  /** (g) Scope-management operations: push and pop of the prover assertion stack
+   *  used to bound the scope of branch assumptions, contract checks, etc. */
+  case object ScopeManagement extends ProofQueryKind
 }

--- a/src/main/scala/interfaces/decider/ProofQueryKind.scala
+++ b/src/main/scala/interfaces/decider/ProofQueryKind.scala
@@ -10,31 +10,24 @@ package viper.silicon.interfaces.decider
 sealed trait ProofQueryKind
 
 object ProofQueryKind {
-  /** (a) Consistency checks: non-negative/positive permission assertions, injectivity checks
-   *  in quantified permissions, and similar well-formedness obligations. */
+  /** (a) Consistency checks: injectivity of quantified-permission receivers and similar
+   *  well-formedness obligations. */
   case object Consistency extends ProofQueryKind
 
-  /** (b) Heap proof obligations: chunk-existence checks, permission-amount checks during
-   *  consume/produce operations, and related heap-access correctness queries. */
+  /** (b) Heap proof obligations: chunk-existence checks, permission-amount checks (including
+   *  non-negativity and positivity of permission expressions) during consume/produce
+   *  operations, and related heap-access correctness queries. */
   case object Heap extends ProofQueryKind
 
   /** (c) Functional-correctness queries: pre/postcondition checks, assert-statement assertions,
    *  array-index bounds, divisor non-zero, and similar user-visible proof obligations. */
   case object FunctionalCorrectness extends ProofQueryKind
 
-  /** (d) Axiomatisation queries: consistency of function, domain, or predicate axioms
-   *  (rare – axioms are mostly assumed, not asserted). */
-  case object Axiomatization extends ProofQueryKind
-
-  /** (e) Path-infeasibility checks: smoke checks and branch-feasibility tests that determine
+  /** (d) Path-infeasibility checks: smoke checks and branch-feasibility tests that determine
    *  whether the current execution path is reachable at all. */
   case object PathInfeasibility extends ProofQueryKind
 
-  /** (f) Unknown: used when the purpose of the query does not clearly fall into any of the
-   *  above categories, or has not yet been classified. */
-  case object Unknown extends ProofQueryKind
-
-  /** (g) Scope-management operations: push and pop of the prover assertion stack
+  /** (e) Scope-management operations: push and pop of the prover assertion stack
    *  used to bound the scope of branch assumptions, contract checks, etc. */
   case object ScopeManagement extends ProofQueryKind
 }

--- a/src/main/scala/interfaces/decider/QueryKind.scala
+++ b/src/main/scala/interfaces/decider/QueryKind.scala
@@ -1,0 +1,17 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2019 ETH Zurich.
+
+package viper.silicon.interfaces.decider
+
+/** Identifies the kind of solver interaction recorded in a [[viper.silicon.reporting.ProofQueryRecord]]. */
+sealed trait QueryKind
+
+object QueryKind {
+  case object Assert extends QueryKind { override def toString = "assert" }
+  case object Check  extends QueryKind { override def toString = "check"  }
+  case object Push   extends QueryKind { override def toString = "push"   }
+  case object Pop    extends QueryKind { override def toString = "pop"    }
+}

--- a/src/main/scala/reporting/ProofQueryRecord.scala
+++ b/src/main/scala/reporting/ProofQueryRecord.scala
@@ -24,6 +24,8 @@ import scala.jdk.CollectionConverters._
  * @param durationMs Wall-clock duration in milliseconds (includes prover call only, not
  *                   path-condition trivial-check short-circuit).
  * @param succeeded  Whether the query returned true / Unsat.
+ * @param description Optional free-text description of the specific proof obligation,
+ *                    populated on demand at call sites where extra clarity is useful.
  */
 case class ProofQueryRecord(
   isAssert:    Boolean,
@@ -31,7 +33,8 @@ case class ProofQueryRecord(
   pos:         ast.Position,
   kind:        ProofQueryKind,
   durationMs:  Double,
-  succeeded:   Boolean
+  succeeded:   Boolean,
+  description: Option[String] = None
 )
 
 /**

--- a/src/main/scala/reporting/ProofQueryRecord.scala
+++ b/src/main/scala/reporting/ProofQueryRecord.scala
@@ -1,0 +1,51 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) 2011-2019 ETH Zurich.
+
+package viper.silicon.reporting
+
+import viper.silver.ast
+import viper.silicon.interfaces.decider.ProofQueryKind
+import java.util.concurrent.ConcurrentLinkedQueue
+import scala.jdk.CollectionConverters._
+
+/**
+ * One recorded SMT query (assert or check) with contextual information.
+ *
+ * @param isAssert   true  = emitted from [[viper.silicon.decider.Decider#assert]],
+ *                   false = emitted from [[viper.silicon.decider.Decider#check]] or
+ *                           [[viper.silicon.decider.Decider#checkSmoke]].
+ * @param member     Name of the program member (method/function/predicate/domain) whose
+ *                   verification triggered this query, if known.
+ * @param pos        Source position of the proof obligation.
+ * @param kind       Category of the query (see [[ProofQueryKind]]).
+ * @param durationMs Wall-clock duration in milliseconds (includes prover call only, not
+ *                   path-condition trivial-check short-circuit).
+ * @param succeeded  Whether the query returned true / Unsat.
+ */
+case class ProofQueryRecord(
+  isAssert:    Boolean,
+  member:      Option[String],
+  pos:         ast.Position,
+  kind:        ProofQueryKind,
+  durationMs:  Double,
+  succeeded:   Boolean
+)
+
+/**
+ * Thread-safe global collector for [[ProofQueryRecord]]s.
+ *
+ * Records are appended concurrently during parallel verification and can be
+ * retrieved at the end via [[records]]. Call [[clear]] between verification runs.
+ */
+object ProofQueryCollector {
+  private val _records = new ConcurrentLinkedQueue[ProofQueryRecord]()
+
+  def record(r: ProofQueryRecord): Unit = _records.add(r)
+
+  def records: Seq[ProofQueryRecord] = _records.iterator().asScala.toSeq
+
+  def clear(): Unit = _records.clear()
+}

--- a/src/main/scala/reporting/ProofQueryRecord.scala
+++ b/src/main/scala/reporting/ProofQueryRecord.scala
@@ -7,31 +7,35 @@
 package viper.silicon.reporting
 
 import viper.silver.ast
-import viper.silicon.interfaces.decider.ProofQueryKind
+import viper.silicon.interfaces.decider.{ProofQueryKind, QueryKind}
 import java.util.concurrent.ConcurrentLinkedQueue
 import scala.jdk.CollectionConverters._
 
 /**
- * One recorded SMT query (assert or check) with contextual information.
+ * One recorded solver interaction (assert, check, push, or pop) with contextual information.
  *
- * @param isAssert   true  = emitted from [[viper.silicon.decider.Decider#assert]],
- *                   false = emitted from [[viper.silicon.decider.Decider#check]] or
- *                           [[viper.silicon.decider.Decider#checkSmoke]].
+ * @param kind       Which solver interaction this is — assert, check, push, or pop. See [[QueryKind]].
+ *                   `assert` is emitted from [[viper.silicon.decider.Decider#assert]];
+ *                   `check` from [[viper.silicon.decider.Decider#check]] or
+ *                   [[viper.silicon.decider.Decider#checkSmoke]];
+ *                   `push`/`pop` from [[viper.silicon.decider.Decider#pushScope]] /
+ *                   [[viper.silicon.decider.Decider#popScope]].
  * @param member     Name of the program member (method/function/predicate/domain) whose
  *                   verification triggered this query, if known.
  * @param pos        Source position of the proof obligation.
- * @param kind       Category of the query (see [[ProofQueryKind]]).
+ * @param category   Category of the query (see [[ProofQueryKind]]) — e.g. PathInfeasibility for
+ *                   smoke checks, FunctionalCorrectness for user assertions, etc.
  * @param durationMs Wall-clock duration in milliseconds (includes prover call only, not
  *                   path-condition trivial-check short-circuit).
- * @param succeeded  Whether the query returned true / Unsat.
+ * @param succeeded  Whether the query returned true / Unsat. Always true for push/pop.
  * @param description Optional free-text description of the specific proof obligation,
  *                    populated on demand at call sites where extra clarity is useful.
  */
 case class ProofQueryRecord(
-  isAssert:    Boolean,
+  kind:        QueryKind,
   member:      Option[String],
   pos:         ast.Position,
-  kind:        ProofQueryKind,
+  category:    ProofQueryKind,
   durationMs:  Double,
   succeeded:   Boolean,
   description: Option[String] = None

--- a/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
+++ b/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
@@ -15,7 +15,8 @@ import viper.silicon.utils.ast.{BigAnd, replaceVarsInExp}
 import viper.silicon.verifier.Verifier
 import viper.silver.ast
 
-class NonQuantifiedPropertyInterpreter(heap: Iterable[Chunk], verifier: Verifier) extends PropertyInterpreter {
+class NonQuantifiedPropertyInterpreter(heap: Iterable[Chunk], verifier: Verifier,
+                                        member: Option[String] = None) extends PropertyInterpreter {
 
   protected case class Info(pm: Map[ChunkPlaceholder, GeneralChunk], resourceID: ResourceID) {
     def addMapping(cp: ChunkPlaceholder, ch: GeneralChunk) = Info(pm + (cp -> ch), resourceID)
@@ -122,7 +123,7 @@ class NonQuantifiedPropertyInterpreter(heap: Iterable[Chunk], verifier: Verifier
                                     info: Info): (Term, Option[ast.Exp]) = {
     val conditionTerm = buildPathCondition(condition, info)._1
     if (verifier.decider.check(conditionTerm, Verifier.config.checkTimeout(),
-                               kind = ProofQueryKind.Heap)) {
+                               kind = ProofQueryKind.Heap, member = member)) {
       buildPathCondition(thenDo, info)
     } else {
       buildPathCondition(otherwise, info)

--- a/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
+++ b/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
@@ -8,6 +8,7 @@ package viper.silicon.resources
 
 import viper.silicon.Map
 import viper.silicon.interfaces.state._
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.state.terms.Term
 import viper.silicon.state.{QuantifiedBasicChunk, terms}
 import viper.silicon.utils.ast.{BigAnd, replaceVarsInExp}
@@ -120,7 +121,8 @@ class NonQuantifiedPropertyInterpreter(heap: Iterable[Chunk], verifier: Verifier
                                     otherwise: PropertyExpression[K],
                                     info: Info): (Term, Option[ast.Exp]) = {
     val conditionTerm = buildPathCondition(condition, info)._1
-    if (verifier.decider.check(conditionTerm, Verifier.config.checkTimeout())) {
+    if (verifier.decider.check(conditionTerm, Verifier.config.checkTimeout(),
+                               kind = ProofQueryKind.Heap)) {
       buildPathCondition(thenDo, info)
     } else {
       buildPathCondition(otherwise, info)

--- a/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
+++ b/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
@@ -123,7 +123,8 @@ class NonQuantifiedPropertyInterpreter(heap: Iterable[Chunk], verifier: Verifier
                                     info: Info): (Term, Option[ast.Exp]) = {
     val conditionTerm = buildPathCondition(condition, info)._1
     if (verifier.decider.check(conditionTerm, Verifier.config.checkTimeout(),
-                               kind = ProofQueryKind.Heap, member = member)) {
+                               kind = ProofQueryKind.Heap, member = member,
+                               description = Some("chunk property condition"))) {
       buildPathCondition(thenDo, info)
     } else {
       buildPathCondition(otherwise, info)

--- a/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
+++ b/src/main/scala/resources/NonQuantifiedPropertyInterpreter.scala
@@ -122,9 +122,13 @@ class NonQuantifiedPropertyInterpreter(heap: Iterable[Chunk], verifier: Verifier
                                     otherwise: PropertyExpression[K],
                                     info: Info): (Term, Option[ast.Exp]) = {
     val conditionTerm = buildPathCondition(condition, info)._1
-    if (verifier.decider.check(conditionTerm, Verifier.config.checkTimeout(),
-                               kind = ProofQueryKind.Heap, member = member,
-                               description = Some("chunk property condition"))) {
+    /* The query is not a proof obligation: it decides which of the two branches of a conditional
+     * sub-property (e.g. the permission upper bound of `permUpperBoundDiseq`) has to be built. */
+    if (verifier.decider.check(conditionTerm,
+                               Verifier.config.checkTimeout(),
+                               kind = ProofQueryKind.Heap,
+                               member = member,
+                               description = Some("chunk property: select branch of conditional sub-property"))) {
       buildPathCondition(thenDo, info)
     } else {
       buildPathCondition(otherwise, info)

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -10,6 +10,7 @@ import java.util.concurrent._
 import viper.silicon.common.concurrency._
 import viper.silicon.decider.PathConditionStack
 import viper.silicon.interfaces.{Unreachable, VerificationResult}
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.reporting.condenseToViperResult
 import viper.silicon.state.State
 import viper.silicon.state.terms.{FunctionDecl, MacroDecl, Not, Term}
@@ -59,13 +60,19 @@ object brancher extends BranchingRules {
     /* True if the then-branch is to be explored */
     val executeThenBranch = (
          skipPathFeasibilityCheck
-      || !v.decider.check(negatedCondition, Verifier.config.checkTimeout()))
+      || !v.decider.check(negatedCondition, Verifier.config.checkTimeout(),
+                          kind = ProofQueryKind.PathInfeasibility,
+                          pos = conditionExp._1.pos,
+                          member = s.currentMember.map(_.name)))
 
     /* False if the then-branch is to be explored */
     val executeElseBranch = (
          !executeThenBranch /* Assumes that ast least one branch is feasible */
       || skipPathFeasibilityCheck
-      || !v.decider.check(condition, Verifier.config.checkTimeout()))
+      || !v.decider.check(condition, Verifier.config.checkTimeout(),
+                          kind = ProofQueryKind.PathInfeasibility,
+                          pos = conditionExp._1.pos,
+                          member = s.currentMember.map(_.name)))
 
     val parallelizeElseBranch = s.parallelizeBranches && executeThenBranch && executeElseBranch
 

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -63,7 +63,8 @@ object brancher extends BranchingRules {
       || !v.decider.check(negatedCondition, Verifier.config.checkTimeout(),
                           kind = ProofQueryKind.PathInfeasibility,
                           pos = conditionExp._1.pos,
-                          member = s.currentMember.map(_.name)))
+                          member = s.currentMember.map(_.name),
+                          description = Some("else-branch feasibility")))
 
     /* False if the then-branch is to be explored */
     val executeElseBranch = (
@@ -72,7 +73,8 @@ object brancher extends BranchingRules {
       || !v.decider.check(condition, Verifier.config.checkTimeout(),
                           kind = ProofQueryKind.PathInfeasibility,
                           pos = conditionExp._1.pos,
-                          member = s.currentMember.map(_.name)))
+                          member = s.currentMember.map(_.name),
+                          description = Some("then-branch feasibility")))
 
     val parallelizeElseBranch = s.parallelizeBranches && executeThenBranch && executeElseBranch
 

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -150,7 +150,7 @@ object brancher extends BranchingRules {
           }
           elseBranchVerifier = v0.uniqueId
 
-          executionFlowController.locally(s, v0)((s1, v1) => {
+          executionFlowController.locally(s, v0, description = Some("else-branch verification"))((s1, v1) => {
             v1.decider.prover.comment(s"[else-branch: $cnt | $negatedCondition]")
             v1.decider.setCurrentBranchCondition(negatedCondition, (negatedConditionExp, negatedConditionExpNew))
 
@@ -200,7 +200,7 @@ object brancher extends BranchingRules {
     val res = {
       val thenRes = if (executeThenBranch) {
           v.symbExLog.markReachable(uidBranchPoint)
-          executionFlowController.locally(s, v)((s1, v1) => {
+          executionFlowController.locally(s, v, description = Some("then-branch verification"))((s1, v1) => {
             v1.decider.prover.comment(s"[then-branch: $cnt | $condition]")
             v1.decider.setCurrentBranchCondition(condition, conditionExp)
 

--- a/src/main/scala/rules/Brancher.scala
+++ b/src/main/scala/rules/Brancher.scala
@@ -61,7 +61,8 @@ object brancher extends BranchingRules {
     /* True if the then-branch is to be explored */
     val executeThenBranch = (
          skipPathFeasibilityCheck
-      || !v.decider.check(negatedCondition, Verifier.config.checkTimeout(),
+      || !v.decider.check(negatedCondition,
+                          Verifier.config.checkTimeout(),
                           kind = ProofQueryKind.PathInfeasibility,
                           pos = conditionExp._1.pos,
                           member = s.currentMember.map(_.name),
@@ -71,7 +72,8 @@ object brancher extends BranchingRules {
     val executeElseBranch = (
          !executeThenBranch /* Assumes that ast least one branch is feasible */
       || skipPathFeasibilityCheck
-      || !v.decider.check(condition, Verifier.config.checkTimeout(),
+      || !v.decider.check(condition,
+                          Verifier.config.checkTimeout(),
                           kind = ProofQueryKind.PathInfeasibility,
                           pos = conditionExp._1.pos,
                           member = s.currentMember.map(_.name),

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -136,7 +136,8 @@ object chunkSupporter extends ChunkSupportRules {
                 case Some(ch) if returnSnap =>
                   if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout(),
                                        kind = ProofQueryKind.Heap,
-                                       member = s1.currentMember.map(_.name))) {
+                                       member = s1.currentMember.map(_.name),
+                                       description = Some("consumed positive permission"))) {
                     Some(ch.snap)
                   } else {
                     Some(Ite(IsPositive(perms), ch.snap.convert(sorts.Snap), Unit))
@@ -144,7 +145,8 @@ object chunkSupporter extends ChunkSupportRules {
                 case _ => None
               }
               QS(s2.copy(h = s.h), h2, snap, v1)
-            case _ if v1.decider.checkSmoke(true, member = s1.currentMember.map(_.name)) =>
+            case _ if v1.decider.checkSmoke(true, member = s1.currentMember.map(_.name),
+                                            description = Some("smoke check after consume")) =>
               Success() // TODO: Mark branch as dead?
             case _ =>
               createFailure(ve, v1, s1, "consuming chunk", true)
@@ -176,7 +178,8 @@ object chunkSupporter extends ChunkSupportRules {
       case Some(ch) =>
         if (s.assertReadAccessOnly) {
           if (v.decider.check(Implies(IsPositive(perms), IsPositive(ch.perm)), Verifier.config.assertTimeout.getOrElse(0),
-                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
+                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+                              description = Some("read-only: chunk has positive perm"))) {
             (Complete(), s, h, Some(ch))
           } else {
             (Incomplete(perms, permsExp), s, h, None)
@@ -189,7 +192,8 @@ object chunkSupporter extends ChunkSupportRules {
           val takenChunk = Some(ch.withPerm(toTake, toTakeExp))
           var newHeap = h - ch
           if (!v.decider.check(newChunk.perm === NoPerm, Verifier.config.checkTimeout(),
-                               kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
+                               kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+                               description = Some("chunk fully depleted"))) {
             newHeap = newHeap + newChunk
             assumeProperties(newChunk, newHeap)
           }
@@ -197,7 +201,8 @@ object chunkSupporter extends ChunkSupportRules {
           (ConsumptionResult(PermMinus(perms, toTake), remainingExp, Seq(), v, 0, s.currentMember.map(_.name)), s, newHeap, takenChunk)
         } else {
           if (v.decider.check(ch.perm !== NoPerm, Verifier.config.checkTimeout(),
-                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
+                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+                              description = Some("chunk has some permission"))) {
             val constraintExp = permsExp.map(pe => ast.PermLtCmp(pe, ch.permExp.get)(pe.pos, pe.info, pe.errT))
             v.decider.assume(PermLess(perms, ch.perm), Option.when(withExp)(DebugExp.createInstance(constraintExp, constraintExp)))
             val newPermExp = permsExp.map(pe => ast.PermSub(ch.permExp.get, pe)(pe.pos, pe.info, pe.errT))
@@ -212,7 +217,8 @@ object chunkSupporter extends ChunkSupportRules {
         }
       case None =>
         if (consumeExact && s.retrying && v.decider.check(perms === NoPerm, Verifier.config.checkTimeout(),
-                                                          kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
+                                                          kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+                                                          description = Some("retry: zero-permission consume"))) {
           (Complete(), s, h, None)
         } else {
           (Incomplete(perms, permsExp), s, h, None)
@@ -264,9 +270,11 @@ object chunkSupporter extends ChunkSupportRules {
     findRes match {
       case Some(ch) if v.decider.check(IsPositive(ch.perm), Verifier.config.assertTimeout.getOrElse(0),
                                        kind = ProofQueryKind.Heap, pos = resource.pos,
-                                       member = s.currentMember.map(_.name)) =>
+                                       member = s.currentMember.map(_.name),
+                                       description = Some("lookup: chunk has permission")) =>
         Q(s, ch.snap, v)
-      case _ if v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name)) =>
+      case _ if v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name),
+                                     description = Some("smoke check at lookup")) =>
         if (s.isInPackage) {
           val snap = v.decider.fresh(v.snapshotSupporter.optimalSnapshotSort(resource, s, v), Option.when(withExp)(PUnknown()))
           Q(s, snap, v)
@@ -330,6 +338,7 @@ object chunkSupporter extends ChunkSupportRules {
     chunks find (ch =>
       args.size == ch.args.size &&
       v.decider.check(And(ch.args zip args map (x => x._1 === x._2)), Verifier.config.checkTimeout(),
-                      kind = ProofQueryKind.Heap, member = member, pos = pos))
+                      kind = ProofQueryKind.Heap, member = member, pos = pos,
+                      description = Some("chunk alias via prover")))
   }
 }

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -55,7 +55,9 @@ trait ChunkSupportRules extends SymbolicExecutionRules {
                (chunks: Iterable[Chunk],
                 id: ChunkIdentifer,
                 args: Iterable[Term],
-                v: Verifier)
+                v: Verifier,
+                member: Option[String] = None,
+                pos: ast.Position = ast.NoPosition)
                : Option[CH]
 
   def findChunksWithID[CH <: NonQuantifiedChunk: ClassTag]
@@ -170,7 +172,7 @@ object chunkSupporter extends ChunkSupportRules {
       pathCond.foreach(p => v.decider.assume(p._1, Option.when(withExp)(DebugExp.createInstance(p._2, p._2))))
     }
 
-    findChunk[NonQuantifiedChunk](h.values, id, args, v) match {
+    findChunk[NonQuantifiedChunk](h.values, id, args, v, member = s.currentMember.map(_.name)) match {
       case Some(ch) =>
         if (s.assertReadAccessOnly) {
           if (v.decider.check(Implies(IsPositive(perms), IsPositive(ch.perm)), Verifier.config.assertTimeout.getOrElse(0),
@@ -258,7 +260,7 @@ object chunkSupporter extends ChunkSupportRules {
                           : VerificationResult = {
 
     val id = ChunkIdentifier(resource, s.program)
-    val findRes = findChunk[NonQuantifiedChunk](h.values, id, args, v)
+    val findRes = findChunk[NonQuantifiedChunk](h.values, id, args, v, member = s.currentMember.map(_.name), pos = resource.pos)
     findRes match {
       case Some(ch) if v.decider.check(IsPositive(ch.perm), Verifier.config.assertTimeout.getOrElse(0),
                                        kind = ProofQueryKind.Heap, pos = resource.pos,
@@ -280,10 +282,12 @@ object chunkSupporter extends ChunkSupportRules {
                (chunks: Iterable[Chunk],
                 id: ChunkIdentifer,
                 args: Iterable[Term],
-                v: Verifier)
+                v: Verifier,
+                member: Option[String] = None,
+                pos: ast.Position = ast.NoPosition)
                : Option[CH] = {
     val relevantChunks = findChunksWithID[CH](chunks, id)
-    findChunkLiterally(relevantChunks, args) orElse findChunkWithProver(relevantChunks, args, v)
+    findChunkLiterally(relevantChunks, args) orElse findChunkWithProver(relevantChunks, args, v, member, pos)
   }
 
   def findChunksWithID[CH <: NonQuantifiedChunk: ClassTag](chunks: Iterable[Chunk], id: ChunkIdentifer): Iterable[CH] = {
@@ -320,9 +324,12 @@ object chunkSupporter extends ChunkSupportRules {
     chunks find (ch => ch.args == args)
   }
 
-  private def findChunkWithProver[CH <: NonQuantifiedChunk](chunks: Iterable[CH], args: Iterable[Term], v: Verifier) = {
+  private def findChunkWithProver[CH <: NonQuantifiedChunk](chunks: Iterable[CH], args: Iterable[Term], v: Verifier,
+                                                            member: Option[String] = None,
+                                                            pos: ast.Position = ast.NoPosition) = {
     chunks find (ch =>
       args.size == ch.args.size &&
-      v.decider.check(And(ch.args zip args map (x => x._1 === x._2)), Verifier.config.checkTimeout()))
+      v.decider.check(And(ch.args zip args map (x => x._1 === x._2)), Verifier.config.checkTimeout(),
+                      kind = ProofQueryKind.Heap, member = member, pos = pos))
   }
 }

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -9,6 +9,7 @@ package viper.silicon.rules
 import viper.silicon.debugger.DebugExp
 import viper.silicon.interfaces.state._
 import viper.silicon.interfaces.{Success, VerificationResult}
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.resources.{NonQuantifiedPropertyInterpreter, Resources}
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -131,7 +132,9 @@ object chunkSupporter extends ChunkSupportRules {
             case (Complete(), s2, h2, optCh2) =>
               val snap = optCh2 match {
                 case Some(ch) if returnSnap =>
-                  if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout())) {
+                  if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout(),
+                                       kind = ProofQueryKind.Heap,
+                                       member = s1.currentMember.map(_.name))) {
                     Some(ch.snap)
                   } else {
                     Some(Ite(IsPositive(perms), ch.snap.convert(sorts.Snap), Unit))
@@ -139,7 +142,7 @@ object chunkSupporter extends ChunkSupportRules {
                 case _ => None
               }
               QS(s2.copy(h = s.h), h2, snap, v1)
-            case _ if v1.decider.checkSmoke(true) =>
+            case _ if v1.decider.checkSmoke(true, member = s1.currentMember.map(_.name)) =>
               Success() // TODO: Mark branch as dead?
             case _ =>
               createFailure(ve, v1, s1, "consuming chunk", true)
@@ -170,7 +173,8 @@ object chunkSupporter extends ChunkSupportRules {
     findChunk[NonQuantifiedChunk](h.values, id, args, v) match {
       case Some(ch) =>
         if (s.assertReadAccessOnly) {
-          if (v.decider.check(Implies(IsPositive(perms), IsPositive(ch.perm)), Verifier.config.assertTimeout.getOrElse(0))) {
+          if (v.decider.check(Implies(IsPositive(perms), IsPositive(ch.perm)), Verifier.config.assertTimeout.getOrElse(0),
+                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
             (Complete(), s, h, Some(ch))
           } else {
             (Incomplete(perms, permsExp), s, h, None)
@@ -182,14 +186,16 @@ object chunkSupporter extends ChunkSupportRules {
           val newChunk = ch.withPerm(PermMinus(ch.perm, toTake), newPermExp)
           val takenChunk = Some(ch.withPerm(toTake, toTakeExp))
           var newHeap = h - ch
-          if (!v.decider.check(newChunk.perm === NoPerm, Verifier.config.checkTimeout())) {
+          if (!v.decider.check(newChunk.perm === NoPerm, Verifier.config.checkTimeout(),
+                               kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
             newHeap = newHeap + newChunk
             assumeProperties(newChunk, newHeap)
           }
           val remainingExp = permsExp.map(pe => ast.PermSub(pe, toTakeExp.get)(pe.pos, pe.info, pe.errT))
           (ConsumptionResult(PermMinus(perms, toTake), remainingExp, Seq(), v, 0), s, newHeap, takenChunk)
         } else {
-          if (v.decider.check(ch.perm !== NoPerm, Verifier.config.checkTimeout())) {
+          if (v.decider.check(ch.perm !== NoPerm, Verifier.config.checkTimeout(),
+                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
             val constraintExp = permsExp.map(pe => ast.PermLtCmp(pe, ch.permExp.get)(pe.pos, pe.info, pe.errT))
             v.decider.assume(PermLess(perms, ch.perm), Option.when(withExp)(DebugExp.createInstance(constraintExp, constraintExp)))
             val newPermExp = permsExp.map(pe => ast.PermSub(ch.permExp.get, pe)(pe.pos, pe.info, pe.errT))
@@ -203,7 +209,8 @@ object chunkSupporter extends ChunkSupportRules {
           }
         }
       case None =>
-        if (consumeExact && s.retrying && v.decider.check(perms === NoPerm, Verifier.config.checkTimeout())) {
+        if (consumeExact && s.retrying && v.decider.check(perms === NoPerm, Verifier.config.checkTimeout(),
+                                                          kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {
           (Complete(), s, h, None)
         } else {
           (Incomplete(perms, permsExp), s, h, None)
@@ -253,9 +260,11 @@ object chunkSupporter extends ChunkSupportRules {
     val id = ChunkIdentifier(resource, s.program)
     val findRes = findChunk[NonQuantifiedChunk](h.values, id, args, v)
     findRes match {
-      case Some(ch) if v.decider.check(IsPositive(ch.perm), Verifier.config.assertTimeout.getOrElse(0)) =>
+      case Some(ch) if v.decider.check(IsPositive(ch.perm), Verifier.config.assertTimeout.getOrElse(0),
+                                       kind = ProofQueryKind.Heap, pos = resource.pos,
+                                       member = s.currentMember.map(_.name)) =>
         Q(s, ch.snap, v)
-      case _ if v.decider.checkSmoke(true) =>
+      case _ if v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name)) =>
         if (s.isInPackage) {
           val snap = v.decider.fresh(v.snapshotSupporter.optimalSnapshotSort(resource, s, v), Option.when(withExp)(PUnknown()))
           Q(s, snap, v)

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -164,7 +164,7 @@ object chunkSupporter extends ChunkSupportRules {
     val consumeExact = terms.utils.consumeExactRead(perms, s.constrainableARPs)
 
     def assumeProperties(chunk: NonQuantifiedChunk, heap: Heap): Unit = {
-      val interpreter = new NonQuantifiedPropertyInterpreter(heap.values, v)
+      val interpreter = new NonQuantifiedPropertyInterpreter(heap.values, v, s.currentMember.map(_.name))
       val resource = Resources.resourceDescriptions(chunk.resourceID)
       val pathCond = interpreter.buildPathConditionsForChunk(chunk, resource.instanceProperties(s.mayAssumeUpperBounds))
       pathCond.foreach(p => v.decider.assume(p._1, Option.when(withExp)(DebugExp.createInstance(p._2, p._2))))
@@ -192,7 +192,7 @@ object chunkSupporter extends ChunkSupportRules {
             assumeProperties(newChunk, newHeap)
           }
           val remainingExp = permsExp.map(pe => ast.PermSub(pe, toTakeExp.get)(pe.pos, pe.info, pe.errT))
-          (ConsumptionResult(PermMinus(perms, toTake), remainingExp, Seq(), v, 0), s, newHeap, takenChunk)
+          (ConsumptionResult(PermMinus(perms, toTake), remainingExp, Seq(), v, 0, s.currentMember.map(_.name)), s, newHeap, takenChunk)
         } else {
           if (v.decider.check(ch.perm !== NoPerm, Verifier.config.checkTimeout(),
                               kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name))) {

--- a/src/main/scala/rules/ChunkSupporter.scala
+++ b/src/main/scala/rules/ChunkSupporter.scala
@@ -134,7 +134,8 @@ object chunkSupporter extends ChunkSupportRules {
             case (Complete(), s2, h2, optCh2) =>
               val snap = optCh2 match {
                 case Some(ch) if returnSnap =>
-                  if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout(),
+                  if (v1.decider.check(IsPositive(perms),
+                                       Verifier.config.checkTimeout(),
                                        kind = ProofQueryKind.Heap,
                                        member = s1.currentMember.map(_.name),
                                        description = Some("consumed positive permission"))) {
@@ -145,7 +146,8 @@ object chunkSupporter extends ChunkSupportRules {
                 case _ => None
               }
               QS(s2.copy(h = s.h), h2, snap, v1)
-            case _ if v1.decider.checkSmoke(true, member = s1.currentMember.map(_.name),
+            case _ if v1.decider.checkSmoke(true,
+                                            member = s1.currentMember.map(_.name),
                                             description = Some("smoke check after consume")) =>
               Success() // TODO: Mark branch as dead?
             case _ =>
@@ -177,8 +179,10 @@ object chunkSupporter extends ChunkSupportRules {
     findChunk[NonQuantifiedChunk](h.values, id, args, v, member = s.currentMember.map(_.name)) match {
       case Some(ch) =>
         if (s.assertReadAccessOnly) {
-          if (v.decider.check(Implies(IsPositive(perms), IsPositive(ch.perm)), Verifier.config.assertTimeout.getOrElse(0),
-                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+          if (v.decider.check(Implies(IsPositive(perms), IsPositive(ch.perm)),
+                              Verifier.config.assertTimeout.getOrElse(0),
+                              kind = ProofQueryKind.Heap,
+                              member = s.currentMember.map(_.name),
                               description = Some("read-only: chunk has positive perm"))) {
             (Complete(), s, h, Some(ch))
           } else {
@@ -191,8 +195,10 @@ object chunkSupporter extends ChunkSupportRules {
           val newChunk = ch.withPerm(PermMinus(ch.perm, toTake), newPermExp)
           val takenChunk = Some(ch.withPerm(toTake, toTakeExp))
           var newHeap = h - ch
-          if (!v.decider.check(newChunk.perm === NoPerm, Verifier.config.checkTimeout(),
-                               kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+          if (!v.decider.check(newChunk.perm === NoPerm,
+                               Verifier.config.checkTimeout(),
+                               kind = ProofQueryKind.Heap,
+                               member = s.currentMember.map(_.name),
                                description = Some("chunk fully depleted"))) {
             newHeap = newHeap + newChunk
             assumeProperties(newChunk, newHeap)
@@ -200,8 +206,10 @@ object chunkSupporter extends ChunkSupportRules {
           val remainingExp = permsExp.map(pe => ast.PermSub(pe, toTakeExp.get)(pe.pos, pe.info, pe.errT))
           (ConsumptionResult(PermMinus(perms, toTake), remainingExp, Seq(), v, 0, s.currentMember.map(_.name)), s, newHeap, takenChunk)
         } else {
-          if (v.decider.check(ch.perm !== NoPerm, Verifier.config.checkTimeout(),
-                              kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+          if (v.decider.check(ch.perm !== NoPerm,
+                              Verifier.config.checkTimeout(),
+                              kind = ProofQueryKind.Heap,
+                              member = s.currentMember.map(_.name),
                               description = Some("chunk has some permission"))) {
             val constraintExp = permsExp.map(pe => ast.PermLtCmp(pe, ch.permExp.get)(pe.pos, pe.info, pe.errT))
             v.decider.assume(PermLess(perms, ch.perm), Option.when(withExp)(DebugExp.createInstance(constraintExp, constraintExp)))
@@ -216,8 +224,10 @@ object chunkSupporter extends ChunkSupportRules {
           }
         }
       case None =>
-        if (consumeExact && s.retrying && v.decider.check(perms === NoPerm, Verifier.config.checkTimeout(),
-                                                          kind = ProofQueryKind.Heap, member = s.currentMember.map(_.name),
+        if (consumeExact && s.retrying && v.decider.check(perms === NoPerm,
+                                                          Verifier.config.checkTimeout(),
+                                                          kind = ProofQueryKind.Heap,
+                                                          member = s.currentMember.map(_.name),
                                                           description = Some("retry: zero-permission consume"))) {
           (Complete(), s, h, None)
         } else {
@@ -266,14 +276,20 @@ object chunkSupporter extends ChunkSupportRules {
                           : VerificationResult = {
 
     val id = ChunkIdentifier(resource, s.program)
-    val findRes = findChunk[NonQuantifiedChunk](h.values, id, args, v, member = s.currentMember.map(_.name), pos = resource.pos)
+    val findRes = findChunk[NonQuantifiedChunk](h.values, id, args, v,
+                                                member = s.currentMember.map(_.name),
+                                                pos = resource.pos)
     findRes match {
-      case Some(ch) if v.decider.check(IsPositive(ch.perm), Verifier.config.assertTimeout.getOrElse(0),
-                                       kind = ProofQueryKind.Heap, pos = resource.pos,
+      case Some(ch) if v.decider.check(IsPositive(ch.perm),
+                                       Verifier.config.assertTimeout.getOrElse(0),
+                                       kind = ProofQueryKind.Heap,
+                                       pos = resource.pos,
                                        member = s.currentMember.map(_.name),
                                        description = Some("lookup: chunk has permission")) =>
         Q(s, ch.snap, v)
-      case _ if v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name),
+      case _ if v.decider.checkSmoke(true,
+                                     pos = resource.pos,
+                                     member = s.currentMember.map(_.name),
                                      description = Some("smoke check at lookup")) =>
         if (s.isInPackage) {
           val snap = v.decider.fresh(v.snapshotSupporter.optimalSnapshotSort(resource, s, v), Option.when(withExp)(PUnknown()))
@@ -337,8 +353,11 @@ object chunkSupporter extends ChunkSupportRules {
                                                             pos: ast.Position = ast.NoPosition) = {
     chunks find (ch =>
       args.size == ch.args.size &&
-      v.decider.check(And(ch.args zip args map (x => x._1 === x._2)), Verifier.config.checkTimeout(),
-                      kind = ProofQueryKind.Heap, member = member, pos = pos,
+      v.decider.check(And(ch.args zip args map (x => x._1 === x._2)),
+                      Verifier.config.checkTimeout(),
+                      kind = ProofQueryKind.Heap,
+                      member = member,
+                      pos = pos,
                       description = Some("chunk alias via prover")))
   }
 }

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -417,7 +417,8 @@ object consumer extends ConsumptionRules {
         v2.decider.assert(termToAssert,
                           kind = ProofQueryKind.FunctionalCorrectness,
                           pos = e.pos,
-                          member = s3.currentMember.map(_.name)) {
+                          member = s3.currentMember.map(_.name),
+                          description = Some("user assertion holds")) {
           case true =>
             v2.decider.assume(t, Option.when(withExp)(e), eNew)
             QS(s3, v2)

--- a/src/main/scala/rules/Consumer.scala
+++ b/src/main/scala/rules/Consumer.scala
@@ -14,6 +14,7 @@ import viper.silver.ast.utility.QuantifiedPermissions.QuantifiedPermissionAssert
 import viper.silver.verifier.PartialVerificationError
 import viper.silver.verifier.reasons._
 import viper.silicon.interfaces.VerificationResult
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.logger.records.data.{CondExpRecord, ConsumeRecord, ImpliesRecord}
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -413,7 +414,10 @@ object consumer extends ConsumptionRules {
             Quantification(q, vars, Implies(transformed, body), trgs, name, isGlob, weight)
           case _ => t
         }
-        v2.decider.assert(termToAssert) {
+        v2.decider.assert(termToAssert,
+                          kind = ProofQueryKind.FunctionalCorrectness,
+                          pos = e.pos,
+                          member = s3.currentMember.map(_.name)) {
           case true =>
             v2.decider.assume(t, Option.when(withExp)(e), eNew)
             QS(s3, v2)

--- a/src/main/scala/rules/ConsumptionResult.scala
+++ b/src/main/scala/rules/ConsumptionResult.scala
@@ -6,6 +6,7 @@
 
 package viper.silicon.rules
 
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.state.terms.{Forall, Term, Var}
 import viper.silicon.state.terms.perms.IsNonPositive
 import viper.silver.ast
@@ -33,7 +34,7 @@ object ConsumptionResult {
     } else {
       Forall(qvars, IsNonPositive(term), Seq())
     }
-    if (v.decider.check(toCheck, timeout))
+    if (v.decider.check(toCheck, timeout, kind = ProofQueryKind.Heap))
       Complete()
     else
       Incomplete(term, exp)

--- a/src/main/scala/rules/ConsumptionResult.scala
+++ b/src/main/scala/rules/ConsumptionResult.scala
@@ -36,7 +36,8 @@ object ConsumptionResult {
       Forall(qvars, IsNonPositive(term), Seq())
     }
     if (v.decider.check(toCheck, timeout, kind = ProofQueryKind.Heap, member = member,
-                        pos = exp.map(_.pos).getOrElse(ast.NoPosition)))
+                        pos = exp.map(_.pos).getOrElse(ast.NoPosition),
+                        description = Some("permission fully consumed")))
       Complete()
     else
       Incomplete(term, exp)

--- a/src/main/scala/rules/ConsumptionResult.scala
+++ b/src/main/scala/rules/ConsumptionResult.scala
@@ -35,7 +35,8 @@ object ConsumptionResult {
     } else {
       Forall(qvars, IsNonPositive(term), Seq())
     }
-    if (v.decider.check(toCheck, timeout, kind = ProofQueryKind.Heap, member = member))
+    if (v.decider.check(toCheck, timeout, kind = ProofQueryKind.Heap, member = member,
+                        pos = exp.map(_.pos).getOrElse(ast.NoPosition)))
       Complete()
     else
       Incomplete(term, exp)

--- a/src/main/scala/rules/ConsumptionResult.scala
+++ b/src/main/scala/rules/ConsumptionResult.scala
@@ -28,13 +28,14 @@ private case class Incomplete(permsNeeded: Term, permsNeededExp: Option[ast.Exp]
 }
 
 object ConsumptionResult {
-  def apply(term: Term, exp: Option[ast.Exp], qvars: Seq[Var],  v: Verifier, timeout: Int): ConsumptionResult = {
+  def apply(term: Term, exp: Option[ast.Exp], qvars: Seq[Var], v: Verifier, timeout: Int,
+            member: Option[String] = None): ConsumptionResult = {
     val toCheck = if (qvars.isEmpty) {
       IsNonPositive(term)
     } else {
       Forall(qvars, IsNonPositive(term), Seq())
     }
-    if (v.decider.check(toCheck, timeout, kind = ProofQueryKind.Heap))
+    if (v.decider.check(toCheck, timeout, kind = ProofQueryKind.Heap, member = member))
       Complete()
     else
       Incomplete(term, exp)

--- a/src/main/scala/rules/ConsumptionResult.scala
+++ b/src/main/scala/rules/ConsumptionResult.scala
@@ -35,7 +35,10 @@ object ConsumptionResult {
     } else {
       Forall(qvars, IsNonPositive(term), Seq())
     }
-    if (v.decider.check(toCheck, timeout, kind = ProofQueryKind.Heap, member = member,
+    if (v.decider.check(toCheck,
+                        timeout,
+                        kind = ProofQueryKind.Heap,
+                        member = member,
                         pos = exp.map(_.pos).getOrElse(ast.NoPosition),
                         description = Some("permission fully consumed")))
       Complete()

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -694,7 +694,7 @@ object evaluator extends EvaluationRules {
             eval(s1, ePerm.getOrElse(ast.FullPerm()()), pve, v1)((s2, tPerm, ePermNew, v2) =>
               v2.decider.assert(IsPositive(tPerm), // TODO: Replace with permissionSupporter.assertNotNegative
                                 kind = ProofQueryKind.Heap,
-                                pos = ePerm.pos,
+                                pos = ePerm.map(_.pos).getOrElse(ast.NoPosition),
                                 member = s2.currentMember.map(_.name)) {
                 case true =>
                   joiner.join[(Term, Option[ast.Exp]), (Term, Option[ast.Exp])](s2, v2)((s3, v3, QB) => {

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -15,6 +15,7 @@ import viper.silver.verifier.errors.{ErrorWrapperWithExampleTransformer, Precond
 import viper.silver.verifier.reasons._
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.interfaces._
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.interfaces.state.ChunkIdentifer
 import viper.silicon.logger.records.data.{CondExpRecord, EvaluateRecord, ImpliesRecord}
 import viper.silicon.state._
@@ -561,7 +562,7 @@ object evaluator extends EvaluationRules {
             Q(s2, tQuant, eQuantNew, v1)
           case (s1, _, _, _, _, None, v1) =>
             // This should not happen unless the current path is dead.
-            if (v1.decider.checkSmoke(true)) {
+            if (v1.decider.checkSmoke(true, pos = sourceQuant.pos, member = s1.currentMember.map(_.name))) {
               Unreachable()
             } else {
               createFailure(pve.dueTo(InternalReason(sourceQuant, "Quantifier evaluation failed.")), v1, s1, "quantifier could be evaluated")
@@ -691,7 +692,10 @@ object evaluator extends EvaluationRules {
           v.decider.startDebugSubExp()
           evals(s, eArgs, _ => pve, v)((s1, tArgs, eArgsNew, v1) =>
             eval(s1, ePerm.getOrElse(ast.FullPerm()()), pve, v1)((s2, tPerm, ePermNew, v2) =>
-              v2.decider.assert(IsPositive(tPerm)) { // TODO: Replace with permissionSupporter.assertNotNegative
+              v2.decider.assert(IsPositive(tPerm), // TODO: Replace with permissionSupporter.assertNotNegative
+                                kind = ProofQueryKind.Heap,
+                                pos = ePerm.pos,
+                                member = s2.currentMember.map(_.name)) {
                 case true =>
                   joiner.join[(Term, Option[ast.Exp]), (Term, Option[ast.Exp])](s2, v2)((s3, v3, QB) => {
                     val s4 = s3.incCycleCounter(predicate)
@@ -794,9 +798,13 @@ object evaluator extends EvaluationRules {
           if (s1.triggerExp) {
             Q(s1, SeqAt(t0, t1), eNew, v1)
           } else {
-            v1.decider.assert(AtLeast(t1, IntLiteral(0))) {
+            v1.decider.assert(AtLeast(t1, IntLiteral(0)),
+                              kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
+                              member = s1.currentMember.map(_.name)) {
               case true =>
-                v1.decider.assert(Less(t1, SeqLength(t0))) {
+                v1.decider.assert(Less(t1, SeqLength(t0)),
+                                  kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
+                                  member = s1.currentMember.map(_.name)) {
                   case true =>
                     Q(s1, SeqAt(t0, t1), eNew, v1)
                   case false =>
@@ -816,7 +824,9 @@ object evaluator extends EvaluationRules {
                   v1.decider.assume(AtLeast(t1, IntLiteral(0)), assertExp1, assertExp1New)
                   val assertExp2 = Option.when(withExp)(ast.LtCmp(e1, ast.SeqLength(e0)())(e1.pos, e1.info, e1.errT))
                   val assertExp2New = Option.when(withExp)(ast.LtCmp(esNew.get(1), ast.SeqLength(esNew.get(0))())(e1.pos, e1.info, e1.errT))
-                  v1.decider.assert(Less(t1, SeqLength(t0))) {
+                  v1.decider.assert(Less(t1, SeqLength(t0)),
+                                    kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
+                                    member = s1.currentMember.map(_.name)) {
                     case true =>
                       failure1 combine Q(s1, SeqAt(t0, t1), eNew, v1)
                     case false =>
@@ -847,10 +857,14 @@ object evaluator extends EvaluationRules {
           } else {
             val assertExp = Option.when(withExp)(ast.GeCmp(e1, ast.IntLit(0)())(e1.pos, e1.info, e1.errT))
             val assertExpNew = Option.when(withExp)(ast.GeCmp(esNew.get(1), ast.IntLit(0)())(e1.pos, e1.info, e1.errT))
-            v1.decider.assert(AtLeast(t1, IntLiteral(0))) {
+            v1.decider.assert(AtLeast(t1, IntLiteral(0)),
+                              kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
+                              member = s1.currentMember.map(_.name)) {
               case true =>
                 val assertExp2New = Option.when(withExp)(ast.LtCmp(esNew.get(1), ast.SeqLength(esNew.get(0))())(e1.pos, e1.info, e1.errT))
-                v1.decider.assert(Less(t1, SeqLength(t0))) {
+                v1.decider.assert(Less(t1, SeqLength(t0)),
+                                  kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
+                                  member = s1.currentMember.map(_.name)) {
                   case true =>
                     Q(s1, SeqUpdate(t0, t1, t2), eNew, v1)
                   case false =>
@@ -867,7 +881,9 @@ object evaluator extends EvaluationRules {
                   v1.decider.assume(AtLeast(t1, IntLiteral(0)), assertExp, assertExpNew)
                   val assertExp2 = Option.when(withExp)(ast.LtCmp(e1, ast.SeqLength(e0)())(e1.pos, e1.info, e1.errT))
                   val assertExp2New = Option.when(withExp)(ast.LtCmp(esNew.get(1), ast.SeqLength(esNew.get(0))())(e1.pos, e1.info, e1.errT))
-                  v1.decider.assert(Less(t1, SeqLength(t0))) {
+                  v1.decider.assert(Less(t1, SeqLength(t0)),
+                                    kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
+                                    member = s1.currentMember.map(_.name)) {
                     case true =>
                       failure1 combine Q(s1, SeqUpdate(t0, t1, t2), eNew, v1)
                     case false =>
@@ -985,7 +1001,10 @@ object evaluator extends EvaluationRules {
             Q(s1, MapLookup(baseT, keyT), esNew.map(es => ast.MapLookup(es(0), es(1))(e.pos, e.info, e.errT)), v1)
           case (s1, Seq(baseT, keyT), esNew, v1) =>
             val eNew = esNew.map(es => ast.MapLookup(es(0), es(1))(e.pos, e.info, e.errT))
-            v1.decider.assert(SetIn(keyT, MapDomain(baseT))) {
+            v1.decider.assert(SetIn(keyT, MapDomain(baseT)),
+                              kind = ProofQueryKind.FunctionalCorrectness,
+                              pos = ml.pos,
+                              member = s1.currentMember.map(_.name)) {
               case true => Q(s1, MapLookup(baseT, keyT), eNew, v1)
               case false =>
                 val assertExp = Option.when(withExp)(ast.MapContains(key, base)(ml.pos, ml.info, ml.errT))
@@ -1214,7 +1233,10 @@ object evaluator extends EvaluationRules {
                              (Q: (State, Term, Verifier) => VerificationResult)
                              : VerificationResult = {
 
-    v.decider.assert(tDivisor !== tZero){
+    v.decider.assert(tDivisor !== tZero,
+                     kind = ProofQueryKind.FunctionalCorrectness,
+                     pos = eDivisor.pos,
+                     member = s.currentMember.map(_.name)) {
       case true => Q(s, t, v)
       case false =>
         val (notZeroExp, notZeroExpNew) = if (withExp) {

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -562,7 +562,8 @@ object evaluator extends EvaluationRules {
             Q(s2, tQuant, eQuantNew, v1)
           case (s1, _, _, _, _, None, v1) =>
             // This should not happen unless the current path is dead.
-            if (v1.decider.checkSmoke(true, pos = sourceQuant.pos, member = s1.currentMember.map(_.name))) {
+            if (v1.decider.checkSmoke(true, pos = sourceQuant.pos, member = s1.currentMember.map(_.name),
+                                      description = Some("smoke check: quantifier body"))) {
               Unreachable()
             } else {
               createFailure(pve.dueTo(InternalReason(sourceQuant, "Quantifier evaluation failed.")), v1, s1, "quantifier could be evaluated")
@@ -695,7 +696,8 @@ object evaluator extends EvaluationRules {
               v2.decider.assert(IsPositive(tPerm), // TODO: Replace with permissionSupporter.assertNotNegative
                                 kind = ProofQueryKind.Heap,
                                 pos = ePerm.map(_.pos).getOrElse(ast.NoPosition),
-                                member = s2.currentMember.map(_.name)) {
+                                member = s2.currentMember.map(_.name),
+                                description = Some("perm expression: non-negative")) {
                 case true =>
                   joiner.join[(Term, Option[ast.Exp]), (Term, Option[ast.Exp])](s2, v2)((s3, v3, QB) => {
                     val s4 = s3.incCycleCounter(predicate)
@@ -800,11 +802,13 @@ object evaluator extends EvaluationRules {
           } else {
             v1.decider.assert(AtLeast(t1, IntLiteral(0)),
                               kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
-                              member = s1.currentMember.map(_.name)) {
+                              member = s1.currentMember.map(_.name),
+                              description = Some("sequence index non-negative")) {
               case true =>
                 v1.decider.assert(Less(t1, SeqLength(t0)),
                                   kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
-                                  member = s1.currentMember.map(_.name)) {
+                                  member = s1.currentMember.map(_.name),
+                                  description = Some("sequence index < length")) {
                   case true =>
                     Q(s1, SeqAt(t0, t1), eNew, v1)
                   case false =>
@@ -826,7 +830,8 @@ object evaluator extends EvaluationRules {
                   val assertExp2New = Option.when(withExp)(ast.LtCmp(esNew.get(1), ast.SeqLength(esNew.get(0))())(e1.pos, e1.info, e1.errT))
                   v1.decider.assert(Less(t1, SeqLength(t0)),
                                     kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
-                                    member = s1.currentMember.map(_.name)) {
+                                    member = s1.currentMember.map(_.name),
+                                    description = Some("sequence index < length (retry)")) {
                     case true =>
                       failure1 combine Q(s1, SeqAt(t0, t1), eNew, v1)
                     case false =>
@@ -859,12 +864,14 @@ object evaluator extends EvaluationRules {
             val assertExpNew = Option.when(withExp)(ast.GeCmp(esNew.get(1), ast.IntLit(0)())(e1.pos, e1.info, e1.errT))
             v1.decider.assert(AtLeast(t1, IntLiteral(0)),
                               kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
-                              member = s1.currentMember.map(_.name)) {
+                              member = s1.currentMember.map(_.name),
+                              description = Some("sequence update index non-negative")) {
               case true =>
                 val assertExp2New = Option.when(withExp)(ast.LtCmp(esNew.get(1), ast.SeqLength(esNew.get(0))())(e1.pos, e1.info, e1.errT))
                 v1.decider.assert(Less(t1, SeqLength(t0)),
                                   kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
-                                  member = s1.currentMember.map(_.name)) {
+                                  member = s1.currentMember.map(_.name),
+                                  description = Some("sequence update index < length")) {
                   case true =>
                     Q(s1, SeqUpdate(t0, t1, t2), eNew, v1)
                   case false =>
@@ -883,7 +890,8 @@ object evaluator extends EvaluationRules {
                   val assertExp2New = Option.when(withExp)(ast.LtCmp(esNew.get(1), ast.SeqLength(esNew.get(0))())(e1.pos, e1.info, e1.errT))
                   v1.decider.assert(Less(t1, SeqLength(t0)),
                                     kind = ProofQueryKind.FunctionalCorrectness, pos = e1.pos,
-                                    member = s1.currentMember.map(_.name)) {
+                                    member = s1.currentMember.map(_.name),
+                                    description = Some("sequence update index < length (retry)")) {
                     case true =>
                       failure1 combine Q(s1, SeqUpdate(t0, t1, t2), eNew, v1)
                     case false =>
@@ -1004,7 +1012,8 @@ object evaluator extends EvaluationRules {
             v1.decider.assert(SetIn(keyT, MapDomain(baseT)),
                               kind = ProofQueryKind.FunctionalCorrectness,
                               pos = ml.pos,
-                              member = s1.currentMember.map(_.name)) {
+                              member = s1.currentMember.map(_.name),
+                              description = Some("map key in domain")) {
               case true => Q(s1, MapLookup(baseT, keyT), eNew, v1)
               case false =>
                 val assertExp = Option.when(withExp)(ast.MapContains(key, base)(ml.pos, ml.info, ml.errT))
@@ -1236,7 +1245,8 @@ object evaluator extends EvaluationRules {
     v.decider.assert(tDivisor !== tZero,
                      kind = ProofQueryKind.FunctionalCorrectness,
                      pos = eDivisor.pos,
-                     member = s.currentMember.map(_.name)) {
+                     member = s.currentMember.map(_.name),
+                     description = Some("non-zero divisor")) {
       case true => Q(s, t, v)
       case false =>
         val (notZeroExp, notZeroExpNew) = if (withExp) {

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1091,7 +1091,7 @@ object evaluator extends EvaluationRules {
                     recordPossibleTriggers = true,
                     possibleTriggers = Map.empty) // TODO: Why reset possibleTriggers if they are merged with s.possibleTriggers later anyway?
     type R = (State, Seq[Term], Option[Seq[ast.Exp]], Option[(Seq[Term], Option[Seq[ast.Exp]], Seq[Trigger], (Seq[Term], Seq[Quantification]), Option[(InsertionOrderedSet[DebugExp], InsertionOrderedSet[DebugExp])], Map[ast.Exp, Term])])
-    executionFlowController.locallyWithResult[R](s1, v)((s2, v1, QB) => {
+    executionFlowController.locallyWithResult[R](s1, v, description = Some("quantified expression evaluation"))((s2, v1, QB) => {
        val preMark = v1.decider.setPathConditionMark()
       evals(s2, es1, _ => pve, v1)((s3, ts1, es1New, v2) => {
         val bc = And(ts1)

--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -562,7 +562,9 @@ object evaluator extends EvaluationRules {
             Q(s2, tQuant, eQuantNew, v1)
           case (s1, _, _, _, _, None, v1) =>
             // This should not happen unless the current path is dead.
-            if (v1.decider.checkSmoke(true, pos = sourceQuant.pos, member = s1.currentMember.map(_.name),
+            if (v1.decider.checkSmoke(true,
+                                      pos = sourceQuant.pos,
+                                      member = s1.currentMember.map(_.name),
                                       description = Some("smoke check: quantifier body"))) {
               Unreachable()
             } else {

--- a/src/main/scala/rules/ExecutionFlowController.scala
+++ b/src/main/scala/rules/ExecutionFlowController.scala
@@ -15,12 +15,12 @@ import viper.silicon.supporters.AnnotationSupporter
 import viper.silicon.verifier.Verifier
 
 trait ExecutionFlowRules extends SymbolicExecutionRules {
-  def locallyWithResult[R](s: State, v: Verifier)
+  def locallyWithResult[R](s: State, v: Verifier, description: Option[String] = None)
                           (block: (State, Verifier, R => VerificationResult) => VerificationResult)
                           (Q: R => VerificationResult)
                           : VerificationResult
 
-  def locally(s: State, v: Verifier)
+  def locally(s: State, v: Verifier, description: Option[String] = None)
              (block: (State, Verifier) => VerificationResult)
              : VerificationResult
 
@@ -50,14 +50,15 @@ trait ExecutionFlowRules extends SymbolicExecutionRules {
 }
 
 object executionFlowController extends ExecutionFlowRules {
-  def locallyWithResult[R](s: State, v: Verifier)
+  def locallyWithResult[R](s: State, v: Verifier, description: Option[String] = None)
                           (block: (State, Verifier, R => VerificationResult) => VerificationResult)
                           (Q: R => VerificationResult)
                           : VerificationResult = {
 
     var optBlockData: Option[R] = None
 
-    v.decider.pushScope()
+    val member = s.currentMember.map(_.name)
+    v.decider.pushScope(member = member, description = description)
 
     val blockResult: VerificationResult =
       block(s, v, blockData => {
@@ -69,7 +70,7 @@ object executionFlowController extends ExecutionFlowRules {
 
         Success()})
 
-    v.decider.popScope()
+    v.decider.popScope(member = member, description = description)
 
     blockResult match {
       case _: FatalResult =>
@@ -93,11 +94,11 @@ object executionFlowController extends ExecutionFlowRules {
     }
   }
 
-  def locally(s: State, v: Verifier)
+  def locally(s: State, v: Verifier, description: Option[String] = None)
              (block: (State, Verifier) => VerificationResult)
              : VerificationResult =
 
-    locallyWithResult[VerificationResult](s, v)((s1, v1, QL) => QL(block(s1, v1)))(Predef.identity)
+    locallyWithResult[VerificationResult](s, v, description)((s1, v1, QL) => QL(block(s1, v1)))(Predef.identity)
 
 
   private def tryOrFailWithResult[R](s: State, v: Verifier)

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -19,6 +19,7 @@ import viper.silver.verifier.reasons._
 import viper.silver.{ast, cfg}
 import viper.silicon.decider.RecordedPathConditions
 import viper.silicon.interfaces._
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.logger.records.data.{CommentRecord, ConditionalEdgeRecord, ExecuteRecord, MethodCallRecord}
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -278,7 +279,7 @@ object executor extends ExecutionRules {
                         v2.decider.declareAndRecordAsFreshMacros(fm1.filter(!v2.decider.freshMacros.contains(_)))  /* [BRANCH-PARALLELISATION] */
                         v2.decider.assume(pcs.assumptions, Option.when(withExp)(DebugExp.createInstance("Loop invariant", pcs.assumptionExps)), false)
                         v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
-                        if (v2.decider.checkSmoke())
+                        if (v2.decider.checkSmoke(member = s3.currentMember.map(_.name)))
                           Success()
                         else {
                           execs(s3, stmts, v2)((s4, v3) => {
@@ -432,7 +433,7 @@ object executor extends ExecutionRules {
       case assert @ ast.Assert(a: ast.FalseLit) if !s.isInPackage =>
         /* "assert false" triggers a smoke check. If successful, we backtrack. */
         executionFlowController.tryOrFail0(s.copy(h = magicWandSupporter.getEvalHeap(s)), v)((s1, v1, QS) => {
-          if (v1.decider.checkSmoke(true))
+          if (v1.decider.checkSmoke(true, pos = assert.pos, member = s1.currentMember.map(_.name)))
             QS(s1.copy(h = s.h), v1)
           else
             createFailure(AssertFailed(assert) dueTo AssertionFalse(a), v1, s1, False, true, Option.when(withExp)(a))

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -279,7 +279,8 @@ object executor extends ExecutionRules {
                         v2.decider.declareAndRecordAsFreshMacros(fm1.filter(!v2.decider.freshMacros.contains(_)))  /* [BRANCH-PARALLELISATION] */
                         v2.decider.assume(pcs.assumptions, Option.when(withExp)(DebugExp.createInstance("Loop invariant", pcs.assumptionExps)), false)
                         v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
-                        if (v2.decider.checkSmoke(member = s3.currentMember.map(_.name)))
+                        if (v2.decider.checkSmoke(member = s3.currentMember.map(_.name),
+                                                  description = Some("smoke check: post-statement")))
                           Success()
                         else {
                           execs(s3, stmts, v2)((s4, v3) => {
@@ -433,7 +434,8 @@ object executor extends ExecutionRules {
       case assert @ ast.Assert(a: ast.FalseLit) if !s.isInPackage =>
         /* "assert false" triggers a smoke check. If successful, we backtrack. */
         executionFlowController.tryOrFail0(s.copy(h = magicWandSupporter.getEvalHeap(s)), v)((s1, v1, QS) => {
-          if (v1.decider.checkSmoke(true, pos = assert.pos, member = s1.currentMember.map(_.name)))
+          if (v1.decider.checkSmoke(true, pos = assert.pos, member = s1.currentMember.map(_.name),
+                                    description = Some("smoke check: assert statement")))
             QS(s1.copy(h = s.h), v1)
           else
             createFailure(AssertFailed(assert) dueTo AssertionFalse(a), v1, s1, False, true, Option.when(withExp)(a))

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -256,7 +256,7 @@ object executor extends ExecutionRules {
             type PhaseData = (State, RecordedPathConditions, Set[FunctionDecl], Seq[MacroDecl])
             var phase1data: Vector[PhaseData] = Vector.empty
 
-            (executionFlowController.locally(sBody, v)((s0, v0) => {
+            (executionFlowController.locally(sBody, v, description = Some("loop head: invariant well-definedness check"))((s0, v0) => {
                 v0.decider.prover.comment("Loop head block: Check well-definedness of invariant")
                 val mark = v0.decider.setPathConditionMark()
                 produces(s0, freshSnap, invs, ContractNotWellformed, v0)((s1, v1) => {
@@ -266,7 +266,7 @@ object executor extends ExecutionRules {
                                               v1.decider.freshMacros    /* [BRANCH-PARALLELISATION] */)
                   Success()
                 })})
-            combine executionFlowController.locally(s, v)((s0, v0) => {
+            combine executionFlowController.locally(s, v, description = Some("loop head: establish invariant"))((s0, v0) => {
                 v0.decider.prover.comment("Loop head block: Establish invariant")
                 consumes(s0, invs, false, LoopInvariantNotEstablished, v0)((sLeftover, _, v1) => {
                   v1.decider.prover.comment("Loop head block: Execute statements of loop head block (in invariant state)")
@@ -274,7 +274,7 @@ object executor extends ExecutionRules {
                     case (result, _) if !result.continueVerification => result
                     case (intermediateResult, (s1, pcs, ff1, fm1)) => /* [BRANCH-PARALLELISATION] ff1, m1 */
                       val s2 = s1.copy(invariantContexts = sLeftover.h +: s1.invariantContexts)
-                      intermediateResult combine executionFlowController.locally(s2, v1)((s3, v2) => {
+                      intermediateResult combine executionFlowController.locally(s2, v1, description = Some("loop head: execute statements in invariant state"))((s3, v2) => {
                         v2.decider.declareAndRecordAsFreshFunctions(ff1 -- v2.decider.freshFunctions) /* [BRANCH-PARALLELISATION] */
                         v2.decider.declareAndRecordAsFreshMacros(fm1.filter(!v2.decider.freshMacros.contains(_)))  /* [BRANCH-PARALLELISATION] */
                         v2.decider.assume(pcs.assumptions, Option.when(withExp)(DebugExp.createInstance("Loop invariant", pcs.assumptionExps)), false)
@@ -289,7 +289,7 @@ object executor extends ExecutionRules {
                               edgeConditions.foldLeft(Success(): VerificationResult) {
                                 case (result, _) if !result.continueVerification => result
                                 case (intermediateResult, eCond) =>
-                                  intermediateResult combine executionFlowController.locally(s4, v3)((s5, v4) => {
+                                  intermediateResult combine executionFlowController.locally(s4, v3, description = Some("loop head: edge-condition well-definedness"))((s5, v4) => {
                                     eval(s5, eCond, WhileFailed(eCond), v4)((_, _, _, _) =>
                                       Success())
                                   })

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -20,7 +20,6 @@ import viper.silver.verifier.reasons._
 import viper.silver.{ast, cfg}
 import viper.silicon.decider.RecordedPathConditions
 import viper.silicon.interfaces._
-import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.logger.records.data.{CommentRecord, ConditionalEdgeRecord, ExecuteRecord, MethodCallRecord}
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -477,7 +476,9 @@ object executor extends ExecutionRules {
       case assert @ ast.Assert(a: ast.FalseLit) if !s.isInPackage =>
         /* "assert false" triggers a smoke check. If successful, we backtrack. */
         executionFlowController.tryOrFail0(s.copy(h = magicWandSupporter.getEvalHeap(s)), v)((s1, v1, QS) => {
-          if (v1.decider.checkSmoke(true, pos = assert.pos, member = s1.currentMember.map(_.name),
+          if (v1.decider.checkSmoke(true,
+                                    pos = assert.pos,
+                                    member = s1.currentMember.map(_.name),
                                     description = Some("smoke check: assert statement")))
             QS(s1.copy(h = s.h), v1)
           else

--- a/src/main/scala/rules/HavocSupporter.scala
+++ b/src/main/scala/rules/HavocSupporter.scala
@@ -8,6 +8,7 @@ package viper.silicon.rules
 
 import viper.silicon.debugger.DebugExp
 import viper.silicon.interfaces.VerificationResult
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.rules.evaluator.{eval, evalQuantified, evals}
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -120,7 +121,10 @@ object havocSupporter extends SymbolicExecutionRules {
 
         val injectivityDebugExp = Option.when(withExp)(DebugExp.createInstance("QP receiver injectivity check is well-defined", true))
         v.decider.assume(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), injectivityDebugExp)
-        v.decider.assert(receiverInjectivityCheck) {
+        v.decider.assert(receiverInjectivityCheck,
+                         kind = ProofQueryKind.Consistency,
+                         pos = havocall.pos,
+                         member = s.currentMember.map(_.name)) {
           case false => createFailure(pve dueTo notInjectiveReason, v, s1, receiverInjectivityCheck, "QP receiver injective")
           case true =>
             // Generate the inverse axioms

--- a/src/main/scala/rules/HavocSupporter.scala
+++ b/src/main/scala/rules/HavocSupporter.scala
@@ -124,7 +124,8 @@ object havocSupporter extends SymbolicExecutionRules {
         v.decider.assert(receiverInjectivityCheck,
                          kind = ProofQueryKind.Consistency,
                          pos = havocall.pos,
-                         member = s.currentMember.map(_.name)) {
+                         member = s.currentMember.map(_.name),
+                         description = Some("havoc receiver injectivity")) {
           case false => createFailure(pve dueTo notInjectiveReason, v, s1, receiverInjectivityCheck, "QP receiver injective")
           case true =>
             // Generate the inverse axioms

--- a/src/main/scala/rules/HeapSupporter.scala
+++ b/src/main/scala/rules/HeapSupporter.scala
@@ -185,7 +185,7 @@ class DefaultHeapSupportRules extends HeapSupportRules {
       val (relevantChunks, otherChunks) =
         quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s.h, BasicChunkIdentifier(field.name))
       val hints = quantifiedChunkSupporter.extractHints(None, Seq(tRcvr))
-      val chunkOrderHeuristics = quantifiedChunkSupporter.singleReceiverChunkOrderHeuristic(Seq(tRcvr), hints, v)
+      val chunkOrderHeuristics = quantifiedChunkSupporter.singleReceiverChunkOrderHeuristic(Seq(tRcvr), hints, v, s.currentMember.map(_.name), ass.pos)
       val s2 = triggerResourceIfNeeded(s, ass.lhs, Seq(tRcvr), eRcvrNew.map(Seq(_)), v)
       v.decider.clearModel()
       val result = quantifiedChunkSupporter.removePermissions(

--- a/src/main/scala/rules/HeapSupporter.scala
+++ b/src/main/scala/rules/HeapSupporter.scala
@@ -10,6 +10,7 @@ import viper.silicon
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.debugger.DebugExp
 import viper.silicon.interfaces.VerificationResult
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.interfaces.state.{ChunkIdentifer, NonQuantifiedChunk}
 import viper.silicon.resources.{FieldID, PredicateID}
 import viper.silicon.rules.havocSupporter.{HavocHelperData, HavocOneData, HavocallData}
@@ -333,7 +334,10 @@ class DefaultHeapSupportRules extends HeapSupportRules {
             Q(s2, fvfLookup, v)
           } else {
             val toAssert = IsPositive(totalPermissions.replace(`?r`, tRcvr))
-            v.decider.assert(toAssert) {
+            v.decider.assert(toAssert,
+                             kind = ProofQueryKind.Heap,
+                             pos = fa.pos,
+                             member = s.currentMember.map(_.name)) {
               case false =>
                 createFailure(ve, v, s, toAssert, Option.when(withExp)(perms.IsPositive(ast.CurrentPerm(fa)())()))
               case true =>
@@ -384,7 +388,10 @@ class DefaultHeapSupportRules extends HeapSupportRules {
               }
               (Implies(lhs, IsPositive(totalPerms)), Option.when(withExp)(perms.IsPositive(ast.CurrentPerm(fa)(fa.pos, fa.info, fa.errT))(fa.pos, fa.info, fa.errT)), s3)
             }
-          v.decider.assert(permCheck) {
+          v.decider.assert(permCheck,
+                           kind = ProofQueryKind.Heap,
+                           pos = fa.pos,
+                           member = s3.currentMember.map(_.name)) {
             case false =>
               createFailure(ve, v, s3, permCheck, permCheckExp)
             case true =>

--- a/src/main/scala/rules/HeapSupporter.scala
+++ b/src/main/scala/rules/HeapSupporter.scala
@@ -337,7 +337,8 @@ class DefaultHeapSupportRules extends HeapSupportRules {
             v.decider.assert(toAssert,
                              kind = ProofQueryKind.Heap,
                              pos = fa.pos,
-                             member = s.currentMember.map(_.name)) {
+                             member = s.currentMember.map(_.name),
+                             description = Some("heap property holds")) {
               case false =>
                 createFailure(ve, v, s, toAssert, Option.when(withExp)(perms.IsPositive(ast.CurrentPerm(fa)())()))
               case true =>
@@ -391,7 +392,8 @@ class DefaultHeapSupportRules extends HeapSupportRules {
           v.decider.assert(permCheck,
                            kind = ProofQueryKind.Heap,
                            pos = fa.pos,
-                           member = s3.currentMember.map(_.name)) {
+                           member = s3.currentMember.map(_.name),
+                           description = Some("heap permission consistency")) {
             case false =>
               createFailure(ve, v, s3, permCheck, permCheckExp)
             case true =>

--- a/src/main/scala/rules/HeapSupporter.scala
+++ b/src/main/scala/rules/HeapSupporter.scala
@@ -197,7 +197,12 @@ class DefaultHeapSupportRules extends HeapSupportRules {
       val (relevantChunks, otherChunks) =
         quantifiedChunkSupporter.splitHeap[QuantifiedFieldChunk](s.h, BasicChunkIdentifier(field.name))
       val hints = quantifiedChunkSupporter.extractHints(None, Seq(tRcvr))
-      val chunkOrderHeuristics = quantifiedChunkSupporter.singleReceiverChunkOrderHeuristic(Seq(tRcvr), hints, v, s.currentMember.map(_.name), ass.pos)
+      val chunkOrderHeuristics =
+        quantifiedChunkSupporter.singleReceiverChunkOrderHeuristic(Seq(tRcvr),
+                                                                   hints,
+                                                                   v,
+                                                                   member = s.currentMember.map(_.name),
+                                                                   pos = ass.pos)
       val s2 = triggerResourceIfNeeded(s, ass.lhs, Seq(tRcvr), eRcvrNew.map(Seq(_)), v)
       v.decider.clearModel()
       val result = quantifiedChunkSupporter.removePermissions(

--- a/src/main/scala/rules/Joiner.scala
+++ b/src/main/scala/rules/Joiner.scala
@@ -54,7 +54,7 @@ object joiner extends JoiningRules {
     val joiningRecord = new JoiningRecord(s, v.decider.pcs)
     val uidJoin = v.symbExLog.openScope(joiningRecord)
 
-    executionFlowController.locally(s, v)((s1, v1) => {
+    executionFlowController.locally(s, v, description = Some("join-point coordination"))((s1, v1) => {
       val preMark = v1.decider.setPathConditionMark()
       val s2 = s1.copy(underJoin = true)
 

--- a/src/main/scala/rules/MagicWandSupporter.scala
+++ b/src/main/scala/rules/MagicWandSupporter.scala
@@ -11,6 +11,7 @@ import viper.silicon._
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.decider.RecordedPathConditions
 import viper.silicon.interfaces._
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.interfaces.state._
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -196,7 +197,7 @@ object magicWandSupporter extends SymbolicExecutionRules {
              * from heap, i.e. that tEq does not result in already having the required permissions before
              * consuming from heap.
              */
-            if (v.decider.checkSmoke()) {
+            if (v.decider.checkSmoke(member = sOut.currentMember.map(_.name))) {
               (Complete(), sOut, h +: hps, cch +: cchs)
             } else {
               (success, sOut, h +: hps, cch +: cchs)

--- a/src/main/scala/rules/MagicWandSupporter.scala
+++ b/src/main/scala/rules/MagicWandSupporter.scala
@@ -156,7 +156,7 @@ object magicWandSupporter extends SymbolicExecutionRules {
                               (Q: (State, Stack[Heap], Stack[Option[CH]], Verifier) => VerificationResult)
                               : VerificationResult = {
 
-    val initialConsumptionResult = ConsumptionResult(pLoss, pLossExp, qvars, v, Verifier.config.checkTimeout())
+    val initialConsumptionResult = ConsumptionResult(pLoss, pLossExp, qvars, v, Verifier.config.checkTimeout(), s.currentMember.map(_.name))
       /* TODO: Introduce a dedicated timeout for the permission check performed by ConsumptionResult,
        *       instead of using checkTimeout. Reason: checkTimeout is intended for checks that are
        *       optimisations, e.g. detecting if a chunk provided no permissions or if a branch is

--- a/src/main/scala/rules/MagicWandSupporter.scala
+++ b/src/main/scala/rules/MagicWandSupporter.scala
@@ -197,7 +197,8 @@ object magicWandSupporter extends SymbolicExecutionRules {
              * from heap, i.e. that tEq does not result in already having the required permissions before
              * consuming from heap.
              */
-            if (v.decider.checkSmoke(member = sOut.currentMember.map(_.name))) {
+            if (v.decider.checkSmoke(member = sOut.currentMember.map(_.name),
+                                     description = Some("smoke check: magic wand"))) {
               (Complete(), sOut, h +: hps, cch +: cchs)
             } else {
               (success, sOut, h +: hps, cch +: cchs)

--- a/src/main/scala/rules/MagicWandSupporter.scala
+++ b/src/main/scala/rules/MagicWandSupporter.scala
@@ -355,7 +355,7 @@ object magicWandSupporter extends SymbolicExecutionRules {
       })
     }
 
-    val tempResult = executionFlowController.locally(sEmp, v)((s1, v1) => {
+    val tempResult = executionFlowController.locally(sEmp, v, description = Some("magic wand: package operation"))((s1, v1) => {
       /* A snapshot (binary tree) will be constructed using First/Second datatypes,
        * that preserves the original root. The leafs of this tree will later appear
        * in the snapshot of the RHS at the appropriate places. Thus equating
@@ -428,7 +428,7 @@ object magicWandSupporter extends SymbolicExecutionRules {
         )
 
         // We execute the continuation Q in a new scope with all branch conditions and all conserved path conditions.
-        executionFlowController.locally(s1, v)((s2, v1) => {
+        executionFlowController.locally(s1, v, description = Some("magic wand: continuation in branch scope"))((s2, v1) => {
           val exp = viper.silicon.utils.ast.BigAnd(branchConditionsExp.map(_._1))
           val expNew = Option.when(withExp)(viper.silicon.utils.ast.BigAnd(branchConditionsExp.map(_._2.get)))
           // Set the branch conditions

--- a/src/main/scala/rules/MagicWandSupporter.scala
+++ b/src/main/scala/rules/MagicWandSupporter.scala
@@ -197,8 +197,11 @@ object magicWandSupporter extends SymbolicExecutionRules {
              * from heap, i.e. that tEq does not result in already having the required permissions before
              * consuming from heap.
              */
+            /* The check does not look for an infeasible path here: it establishes that permissions
+             * were actually taken from the heap, which is a heap proof obligation. */
             if (v.decider.checkSmoke(member = sOut.currentMember.map(_.name),
-                                     description = Some("smoke check: magic wand"))) {
+                                     description = Some("magic wand: permissions taken from heap"),
+                                     kind = ProofQueryKind.Heap)) {
               (Complete(), sOut, h +: hps, cch +: cchs)
             } else {
               (success, sOut, h +: hps, cch +: cchs)

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -9,6 +9,7 @@ package viper.silicon.rules
 import viper.silicon.debugger.DebugExp
 import viper.silicon.interfaces.state._
 import viper.silicon.interfaces.{Success, VerificationResult}
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.resources.{FieldID, NonQuantifiedPropertyInterpreter, Resources}
 import viper.silicon.rules.chunkSupporter.findChunksWithID
 import viper.silicon.state._
@@ -121,7 +122,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                   // We have not yet checked for a definite alias
                   val id = ChunkIdentifier(resource, s.program)
                   val potentialAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v)
-                  potentialAlias.filter(c => v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout())).map(_.snap)
+                  potentialAlias.filter(c => v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
+                    kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))).map(_.snap)
                 case Some(v) =>
                   // We have checked for a definite alias and may or may not have found one.
                   v
@@ -166,7 +168,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     if (relevantChunks.size == 1 &&  !Verifier.config.counterexample.isDefined) {
       val chunk = relevantChunks.head
       val argsEqual = And(chunk.args.zip(args).map { case (t1, t2) => t1 === t2 })
-      if (v.decider.check(argsEqual, Verifier.config.checkTimeout())) {
+      if (v.decider.check(argsEqual, Verifier.config.checkTimeout(),
+                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))) {
         return Q(s, chunk.snap, chunk.perm, chunk.permExp, v)
       }
     }
@@ -203,7 +206,7 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     val relevantChunks = findChunksWithID[NonQuantifiedChunk](h.values, id).toSeq
 
     if (relevantChunks.isEmpty) {
-      if (v.decider.checkSmoke(true)) {
+      if (v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name))) {
         if (s.isInPackage) {
           val snap = v.decider.fresh(v.snapshotSupporter.optimalSnapshotSort(resource, s, v), Option.when(withExp)(PUnknown()))
           Q(s, snap, v)
@@ -215,7 +218,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
       }
     } else {
       summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
-        v.decider.assert(IsPositive(permSum)) {
+        v.decider.assert(IsPositive(permSum),
+                         kind = ProofQueryKind.Heap, pos = resource.pos,
+                         member = s1.currentMember.map(_.name)) {
           case true =>
             Q(s1, snap, v1)
           case false =>
@@ -260,7 +265,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
     if (returnSnap) {
       summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
-        v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum))) {
+        v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum)),
+                         kind = ProofQueryKind.Heap, pos = resource.pos,
+                         member = s1.currentMember.map(_.name)) {
           case true =>
             Q(s1, h, Some(snap), v1)
           case false =>
@@ -268,7 +275,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         })
     } else {
       val (s1, permSum, permSumExp) = permSummariseOnly(s, relevantChunks, resource, args, argsExp)
-      v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum))) {
+      v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum)),
+                       kind = ProofQueryKind.Heap, pos = resource.pos,
+                       member = s1.currentMember.map(_.name)) {
         case true =>
           Q(s1, h, None, v)
         case false =>
@@ -300,7 +309,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
     if (relevantChunks.isEmpty) {
       // if no permission is exhaled, return none
-      v.decider.assert(perms === NoPerm) {
+      v.decider.assert(perms === NoPerm,
+                       kind = ProofQueryKind.Heap, pos = resource.pos,
+                       member = s.currentMember.map(_.name)) {
         case true => Q(s, h, None, v)
         case false => createFailure(ve, v, s, perms === NoPerm, permsExp.map(pe => ast.EqCmp(pe, ast.NoPerm()())(pe.pos, pe.info, pe.errT)))
       }
@@ -318,7 +329,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         var moreNeeded = true
 
         val definiteAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v).filter(c =>
-          v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout())
+          v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
+            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
         )
 
         val sortFunction: (NonQuantifiedChunk, NonQuantifiedChunk) => Boolean = (ch1, ch2) => {
@@ -363,11 +375,13 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
             pNeeded = PermMinus(pNeeded, pTaken)
             pNeededExp = permsExp.map(pe => ast.PermSub(pNeededExp.get, pTakenExp.get)(pe.pos, pe.info, pe.errT))
 
-            if (!v.decider.check(IsNonPositive(newChunk.perm), Verifier.config.splitTimeout())) {
+            if (!v.decider.check(IsNonPositive(newChunk.perm), Verifier.config.splitTimeout(),
+                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))) {
               newChunks.append(newChunk)
             }
 
-            moreNeeded = !v.decider.check(pNeeded === NoPerm, Verifier.config.splitTimeout())
+            moreNeeded = !v.decider.check(pNeeded === NoPerm, Verifier.config.splitTimeout(),
+                                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
           } else {
             newChunks.append(ch)
           }
@@ -390,7 +404,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
         if (returnSnap) {
           summarise(s0, relevantChunks.toSeq, resource, args, argsExp, Some(definiteAlias.map(_.snap)), v)((s1, snap, _, _, v1) => {
-            val condSnap = Some(if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout())) {
+            val condSnap = Some(if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout(),
+                                                    kind = ProofQueryKind.Heap, pos = resource.pos,
+                                                    member = s1.currentMember.map(_.name))) {
               snap
             } else {
               Ite(IsPositive(perms), snap.convert(sorts.Snap), Unit)
@@ -398,7 +414,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
           if (!moreNeeded) {
             Q(s1, newHeap, condSnap, v1)
           } else {
-            v1.decider.assert(pNeeded === NoPerm) {
+            v1.decider.assert(pNeeded === NoPerm,
+                              kind = ProofQueryKind.Heap, pos = resource.pos,
+                              member = s1.currentMember.map(_.name)) {
               case true =>
                 Q(s1, newHeap, condSnap, v1)
               case false =>
@@ -410,7 +428,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
           if (!moreNeeded) {
             Q(s0, newHeap, None, v)
           } else {
-            v.decider.assert(pNeeded === NoPerm) {
+            v.decider.assert(pNeeded === NoPerm,
+                             kind = ProofQueryKind.Heap, pos = resource.pos,
+                             member = s0.currentMember.map(_.name)) {
               case true =>
                 Q(s0, newHeap, None, v)
               case false =>
@@ -490,7 +510,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
     val s1 = s.copy(functionRecorder = newFr)
 
-    v.decider.assert(Implies(PermLess(NoPerm, perms), totalPermTaken !== NoPerm)) {
+    v.decider.assert(Implies(PermLess(NoPerm, perms), totalPermTaken !== NoPerm),
+                     kind = ProofQueryKind.Heap, pos = resource.pos,
+                     member = s.currentMember.map(_.name)) {
       case true =>
         val constraintExp = permsExp.map(pe => ast.EqCmp(pe, totalPermTakenExp.get)())
         v.decider.assume(perms === totalPermTaken, Option.when(withExp)(DebugExp.createInstance(constraintExp, constraintExp)))

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -124,7 +124,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                   val potentialAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v,
                     member = s.currentMember.map(_.name), pos = resource.pos)
                   potentialAlias.filter(c => v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
-                    kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))).map(_.snap)
+                    kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+                    description = Some("MCE definite alias permission"))).map(_.snap)
                 case Some(v) =>
                   // We have checked for a definite alias and may or may not have found one.
                   v
@@ -170,7 +171,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
       val chunk = relevantChunks.head
       val argsEqual = And(chunk.args.zip(args).map { case (t1, t2) => t1 === t2 })
       if (v.decider.check(argsEqual, Verifier.config.checkTimeout(),
-                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))) {
+                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+                          description = Some("MCE argument equality"))) {
         return Q(s, chunk.snap, chunk.perm, chunk.permExp, v)
       }
     }
@@ -207,7 +209,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     val relevantChunks = findChunksWithID[NonQuantifiedChunk](h.values, id).toSeq
 
     if (relevantChunks.isEmpty) {
-      if (v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name))) {
+      if (v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name),
+                               description = Some("MCE smoke check"))) {
         if (s.isInPackage) {
           val snap = v.decider.fresh(v.snapshotSupporter.optimalSnapshotSort(resource, s, v), Option.when(withExp)(PUnknown()))
           Q(s, snap, v)
@@ -221,7 +224,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
       summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
         v.decider.assert(IsPositive(permSum),
                          kind = ProofQueryKind.Heap, pos = resource.pos,
-                         member = s1.currentMember.map(_.name)) {
+                         member = s1.currentMember.map(_.name),
+                         description = Some("MCE total permission positive")) {
           case true =>
             Q(s1, snap, v1)
           case false =>
@@ -268,7 +272,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
       summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
         v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum)),
                          kind = ProofQueryKind.Heap, pos = resource.pos,
-                         member = s1.currentMember.map(_.name)) {
+                         member = s1.currentMember.map(_.name),
+                         description = Some("MCE read: total perm positive (w/ snap)")) {
           case true =>
             Q(s1, h, Some(snap), v1)
           case false =>
@@ -278,7 +283,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
       val (s1, permSum, permSumExp) = permSummariseOnly(s, relevantChunks, resource, args, argsExp)
       v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum)),
                        kind = ProofQueryKind.Heap, pos = resource.pos,
-                       member = s1.currentMember.map(_.name)) {
+                       member = s1.currentMember.map(_.name),
+                       description = Some("MCE read: total perm positive (no snap)")) {
         case true =>
           Q(s1, h, None, v)
         case false =>
@@ -312,7 +318,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
       // if no permission is exhaled, return none
       v.decider.assert(perms === NoPerm,
                        kind = ProofQueryKind.Heap, pos = resource.pos,
-                       member = s.currentMember.map(_.name)) {
+                       member = s.currentMember.map(_.name),
+                       description = Some("MCE read unneeded")) {
         case true => Q(s, h, None, v)
         case false => createFailure(ve, v, s, perms === NoPerm, permsExp.map(pe => ast.EqCmp(pe, ast.NoPerm()())(pe.pos, pe.info, pe.errT)))
       }
@@ -332,7 +339,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         val definiteAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v,
           member = s.currentMember.map(_.name), pos = resource.pos).filter(c =>
           v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
-            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
+            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+            description = Some("MCE candidate has permission"))
         )
 
         val sortFunction: (NonQuantifiedChunk, NonQuantifiedChunk) => Boolean = (ch1, ch2) => {
@@ -378,12 +386,14 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
             pNeededExp = permsExp.map(pe => ast.PermSub(pNeededExp.get, pTakenExp.get)(pe.pos, pe.info, pe.errT))
 
             if (!v.decider.check(IsNonPositive(newChunk.perm), Verifier.config.splitTimeout(),
-                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))) {
+                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+                                 description = Some("MCE chunk depleted (split)"))) {
               newChunks.append(newChunk)
             }
 
             moreNeeded = !v.decider.check(pNeeded === NoPerm, Verifier.config.splitTimeout(),
-                                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
+                                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+                                          description = Some("MCE enough taken (split)"))
           } else {
             newChunks.append(ch)
           }
@@ -408,7 +418,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
           summarise(s0, relevantChunks.toSeq, resource, args, argsExp, Some(definiteAlias.map(_.snap)), v)((s1, snap, _, _, v1) => {
             val condSnap = Some(if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout(),
                                                     kind = ProofQueryKind.Heap, pos = resource.pos,
-                                                    member = s1.currentMember.map(_.name))) {
+                                                    member = s1.currentMember.map(_.name),
+                                                    description = Some("MCE snap condition positive"))) {
               snap
             } else {
               Ite(IsPositive(perms), snap.convert(sorts.Snap), Unit)
@@ -418,7 +429,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
           } else {
             v1.decider.assert(pNeeded === NoPerm,
                               kind = ProofQueryKind.Heap, pos = resource.pos,
-                              member = s1.currentMember.map(_.name)) {
+                              member = s1.currentMember.map(_.name),
+                              description = Some("MCE sufficient permission (split)")) {
               case true =>
                 Q(s1, newHeap, condSnap, v1)
               case false =>
@@ -432,7 +444,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
           } else {
             v.decider.assert(pNeeded === NoPerm,
                              kind = ProofQueryKind.Heap, pos = resource.pos,
-                             member = s0.currentMember.map(_.name)) {
+                             member = s0.currentMember.map(_.name),
+                             description = Some("MCE sufficient permission")) {
               case true =>
                 Q(s0, newHeap, None, v)
               case false =>
@@ -514,7 +527,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
     v.decider.assert(Implies(PermLess(NoPerm, perms), totalPermTaken !== NoPerm),
                      kind = ProofQueryKind.Heap, pos = resource.pos,
-                     member = s.currentMember.map(_.name)) {
+                     member = s.currentMember.map(_.name),
+                     description = Some("MCE took some permission")) {
       case true =>
         val constraintExp = permsExp.map(pe => ast.EqCmp(pe, totalPermTakenExp.get)())
         v.decider.assume(perms === totalPermTaken, Option.when(withExp)(DebugExp.createInstance(constraintExp, constraintExp)))

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -390,7 +390,7 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         val allChunks = otherChunks ++ newChunks
         // TODO: Since no permissions were gained, I don't see why the PropertyInterpreter would yield any new assumptions.
         //       See if it can be removed here.
-        val interpreter = new NonQuantifiedPropertyInterpreter(allChunks, v)
+        val interpreter = new NonQuantifiedPropertyInterpreter(allChunks, v, s.currentMember.map(_.name))
         newChunks foreach { ch =>
           val resource = Resources.resourceDescriptions(ch.resourceID)
           val pathCond = interpreter.buildPathConditionsForChunk(ch, resource.instanceProperties(s.mayAssumeUpperBounds))

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -121,7 +121,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                 case None =>
                   // We have not yet checked for a definite alias
                   val id = ChunkIdentifier(resource, s.program)
-                  val potentialAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v)
+                  val potentialAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v,
+                    member = s.currentMember.map(_.name), pos = resource.pos)
                   potentialAlias.filter(c => v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
                     kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))).map(_.snap)
                 case Some(v) =>
@@ -328,7 +329,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         val newChunks = ListBuffer[NonQuantifiedChunk]()
         var moreNeeded = true
 
-        val definiteAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v).filter(c =>
+        val definiteAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v,
+          member = s.currentMember.map(_.name), pos = resource.pos).filter(c =>
           v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
             kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
         )

--- a/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
+++ b/src/main/scala/rules/MoreCompleteExhaleSupporter.scala
@@ -121,11 +121,16 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
                 case None =>
                   // We have not yet checked for a definite alias
                   val id = ChunkIdentifier(resource, s.program)
-                  val potentialAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v,
-                    member = s.currentMember.map(_.name), pos = resource.pos)
-                  potentialAlias.filter(c => v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
-                    kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
-                    description = Some("MCE definite alias permission"))).map(_.snap)
+                  val potentialAlias =
+                    chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v,
+                                                                 member = s.currentMember.map(_.name),
+                                                                 pos = resource.pos)
+                  potentialAlias.filter(c => v.decider.check(IsPositive(c.perm),
+                                                             Verifier.config.checkTimeout(),
+                                                             kind = ProofQueryKind.Heap,
+                                                             pos = resource.pos,
+                                                             member = s.currentMember.map(_.name),
+                                                             description = Some("MCE definite alias permission"))).map(_.snap)
                 case Some(v) =>
                   // We have checked for a definite alias and may or may not have found one.
                   v
@@ -170,8 +175,11 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     if (relevantChunks.size == 1 &&  !Verifier.config.counterexample.isDefined) {
       val chunk = relevantChunks.head
       val argsEqual = And(chunk.args.zip(args).map { case (t1, t2) => t1 === t2 })
-      if (v.decider.check(argsEqual, Verifier.config.checkTimeout(),
-                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+      if (v.decider.check(argsEqual,
+                          Verifier.config.checkTimeout(),
+                          kind = ProofQueryKind.Heap,
+                          pos = resource.pos,
+                          member = s.currentMember.map(_.name),
                           description = Some("MCE argument equality"))) {
         return Q(s, chunk.snap, chunk.perm, chunk.permExp, v)
       }
@@ -209,7 +217,9 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     val relevantChunks = findChunksWithID[NonQuantifiedChunk](h.values, id).toSeq
 
     if (relevantChunks.isEmpty) {
-      if (v.decider.checkSmoke(true, pos = resource.pos, member = s.currentMember.map(_.name),
+      if (v.decider.checkSmoke(true,
+                               pos = resource.pos,
+                               member = s.currentMember.map(_.name),
                                description = Some("MCE smoke check"))) {
         if (s.isInPackage) {
           val snap = v.decider.fresh(v.snapshotSupporter.optimalSnapshotSort(resource, s, v), Option.when(withExp)(PUnknown()))
@@ -223,7 +233,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     } else {
       summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
         v.decider.assert(IsPositive(permSum),
-                         kind = ProofQueryKind.Heap, pos = resource.pos,
+                         kind = ProofQueryKind.Heap,
+                         pos = resource.pos,
                          member = s1.currentMember.map(_.name),
                          description = Some("MCE total permission positive")) {
           case true =>
@@ -271,7 +282,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     if (returnSnap) {
       summarise(s, relevantChunks, resource, args, argsExp, None, v)((s1, snap, permSum, permSumExp, v1) =>
         v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum)),
-                         kind = ProofQueryKind.Heap, pos = resource.pos,
+                         kind = ProofQueryKind.Heap,
+                         pos = resource.pos,
                          member = s1.currentMember.map(_.name),
                          description = Some("MCE read: total perm positive (w/ snap)")) {
           case true =>
@@ -282,7 +294,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     } else {
       val (s1, permSum, permSumExp) = permSummariseOnly(s, relevantChunks, resource, args, argsExp)
       v.decider.assert(Implies(IsPositive(perm), IsPositive(permSum)),
-                       kind = ProofQueryKind.Heap, pos = resource.pos,
+                       kind = ProofQueryKind.Heap,
+                       pos = resource.pos,
                        member = s1.currentMember.map(_.name),
                        description = Some("MCE read: total perm positive (no snap)")) {
         case true =>
@@ -317,7 +330,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     if (relevantChunks.isEmpty) {
       // if no permission is exhaled, return none
       v.decider.assert(perms === NoPerm,
-                       kind = ProofQueryKind.Heap, pos = resource.pos,
+                       kind = ProofQueryKind.Heap,
+                       pos = resource.pos,
                        member = s.currentMember.map(_.name),
                        description = Some("MCE read unneeded")) {
         case true => Q(s, h, None, v)
@@ -337,10 +351,14 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
         var moreNeeded = true
 
         val definiteAlias = chunkSupporter.findChunk[NonQuantifiedChunk](relevantChunks, id, args, v,
-          member = s.currentMember.map(_.name), pos = resource.pos).filter(c =>
-          v.decider.check(IsPositive(c.perm), Verifier.config.checkTimeout(),
-            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
-            description = Some("MCE candidate has permission"))
+                                                                        member = s.currentMember.map(_.name),
+                                                                        pos = resource.pos).filter(c =>
+          v.decider.check(IsPositive(c.perm),
+                          Verifier.config.checkTimeout(),
+                          kind = ProofQueryKind.Heap,
+                          pos = resource.pos,
+                          member = s.currentMember.map(_.name),
+                          description = Some("MCE candidate has permission"))
         )
 
         val sortFunction: (NonQuantifiedChunk, NonQuantifiedChunk) => Boolean = (ch1, ch2) => {
@@ -386,15 +404,21 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
             pNeeded = PermMinus(pNeeded, pTaken)
             pNeededExp = permsExp.map(pe => ast.PermSub(pNeededExp.get, pTakenExp.get)(pe.pos, pe.info, pe.errT))
 
-            if (!v.decider.check(IsNonPositive(newChunk.perm), Verifier.config.splitTimeout(),
-                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
-                                 description = Some("MCE chunk depleted (split)"))) {
+            if (!v.decider.check(IsNonPositive(newChunk.perm),
+                                 Verifier.config.splitTimeout(),
+                                 kind = ProofQueryKind.Heap,
+                                 pos = resource.pos,
+                                 member = s.currentMember.map(_.name),
+                                 description = Some("MCE: chunk depleted after taking permission"))) {
               newChunks.append(newChunk)
             }
 
-            moreNeeded = !v.decider.check(pNeeded === NoPerm, Verifier.config.splitTimeout(),
-                                          kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
-                                          description = Some("MCE enough taken (split)"))
+            moreNeeded = !v.decider.check(pNeeded === NoPerm,
+                                          Verifier.config.splitTimeout(),
+                                          kind = ProofQueryKind.Heap,
+                                          pos = resource.pos,
+                                          member = s.currentMember.map(_.name),
+                                          description = Some("MCE: needed permission fully taken (loop guard)"))
           } else {
             newChunks.append(ch)
           }
@@ -417,10 +441,12 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
 
         if (returnSnap) {
           summarise(s0, relevantChunks.toSeq, resource, args, argsExp, Some(definiteAlias.map(_.snap)), v)((s1, snap, _, _, v1) => {
-            val condSnap = Some(if (v1.decider.check(IsPositive(perms), Verifier.config.checkTimeout(),
-                                                    kind = ProofQueryKind.Heap, pos = resource.pos,
-                                                    member = s1.currentMember.map(_.name),
-                                                    description = Some("MCE snap condition positive"))) {
+            val condSnap = Some(if (v1.decider.check(IsPositive(perms),
+                                                     Verifier.config.checkTimeout(),
+                                                     kind = ProofQueryKind.Heap,
+                                                     pos = resource.pos,
+                                                     member = s1.currentMember.map(_.name),
+                                                     description = Some("MCE snap condition positive"))) {
               snap
             } else {
               Ite(IsPositive(perms), snap.convert(sorts.Snap), Unit)
@@ -429,9 +455,10 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
             Q(s1, newHeap, condSnap, v1)
           } else {
             v1.decider.assert(pNeeded === NoPerm,
-                              kind = ProofQueryKind.Heap, pos = resource.pos,
+                              kind = ProofQueryKind.Heap,
+                              pos = resource.pos,
                               member = s1.currentMember.map(_.name),
-                              description = Some("MCE sufficient permission (split)")) {
+                              description = Some("MCE: needed permission fully taken (snapshot returned)")) {
               case true =>
                 Q(s1, newHeap, condSnap, v1)
               case false =>
@@ -444,9 +471,10 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
             Q(s0, newHeap, None, v)
           } else {
             v.decider.assert(pNeeded === NoPerm,
-                             kind = ProofQueryKind.Heap, pos = resource.pos,
+                             kind = ProofQueryKind.Heap,
+                             pos = resource.pos,
                              member = s0.currentMember.map(_.name),
-                             description = Some("MCE sufficient permission")) {
+                             description = Some("MCE: needed permission fully taken")) {
               case true =>
                 Q(s0, newHeap, None, v)
               case false =>
@@ -527,7 +555,8 @@ object moreCompleteExhaleSupporter extends SymbolicExecutionRules {
     val s1 = s.copy(functionRecorder = newFr)
 
     v.decider.assert(Implies(PermLess(NoPerm, perms), totalPermTaken !== NoPerm),
-                     kind = ProofQueryKind.Heap, pos = resource.pos,
+                     kind = ProofQueryKind.Heap,
+                     pos = resource.pos,
                      member = s.currentMember.map(_.name),
                      description = Some("MCE took some permission")) {
       case true =>

--- a/src/main/scala/rules/PermissionSupporter.scala
+++ b/src/main/scala/rules/PermissionSupporter.scala
@@ -27,7 +27,8 @@ object permissionSupporter extends SymbolicExecutionRules {
         v.decider.assert(perms.IsNonNegative(tPerm),
                          kind = ProofQueryKind.Consistency,
                          pos = ePerm.pos,
-                         member = s.currentMember.map(_.name)) {
+                         member = s.currentMember.map(_.name),
+                         description = Some("permission amount is non-negative")) {
           case true => Q(s, v)
           case false =>
             val assertExp = ePermNew.map(ep => perms.IsNonNegative(ep)(ep.pos, ep.info, ep.errT))
@@ -47,7 +48,8 @@ object permissionSupporter extends SymbolicExecutionRules {
         v.decider.assert(perms.IsPositive(tPerm),
                          kind = ProofQueryKind.Consistency,
                          pos = ePerm.pos,
-                         member = s.currentMember.map(_.name)) {
+                         member = s.currentMember.map(_.name),
+                         description = Some("permission amount is positive")) {
           case true => Q(s, v)
           case false => createFailure(pve dueTo NonPositivePermission(ePerm), v, s, perms.IsPositive(tPerm), Option.when(withExp)(perms.IsPositive(ePerm)()))
         }

--- a/src/main/scala/rules/PermissionSupporter.scala
+++ b/src/main/scala/rules/PermissionSupporter.scala
@@ -9,6 +9,7 @@ package viper.silicon.rules
 import viper.silver.ast
 import viper.silver.verifier.PartialVerificationError
 import viper.silicon.interfaces.VerificationResult
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.state.State
 import viper.silicon.state.terms.{Term, Var, perms}
 import viper.silicon.verifier.Verifier
@@ -23,7 +24,10 @@ object permissionSupporter extends SymbolicExecutionRules {
       case k: Var if s.constrainableARPs.contains(k) =>
         Q(s, v)
       case _ =>
-        v.decider.assert(perms.IsNonNegative(tPerm)) {
+        v.decider.assert(perms.IsNonNegative(tPerm),
+                         kind = ProofQueryKind.Consistency,
+                         pos = ePerm.pos,
+                         member = s.currentMember.map(_.name)) {
           case true => Q(s, v)
           case false =>
             val assertExp = ePermNew.map(ep => perms.IsNonNegative(ep)(ep.pos, ep.info, ep.errT))
@@ -40,7 +44,10 @@ object permissionSupporter extends SymbolicExecutionRules {
       case k: Var if s.constrainableARPs.contains(k) =>
         Q(s, v)
       case _ =>
-        v.decider.assert(perms.IsPositive(tPerm)) {
+        v.decider.assert(perms.IsPositive(tPerm),
+                         kind = ProofQueryKind.Consistency,
+                         pos = ePerm.pos,
+                         member = s.currentMember.map(_.name)) {
           case true => Q(s, v)
           case false => createFailure(pve dueTo NonPositivePermission(ePerm), v, s, perms.IsPositive(tPerm), Option.when(withExp)(perms.IsPositive(ePerm)()))
         }

--- a/src/main/scala/rules/PermissionSupporter.scala
+++ b/src/main/scala/rules/PermissionSupporter.scala
@@ -25,7 +25,7 @@ object permissionSupporter extends SymbolicExecutionRules {
         Q(s, v)
       case _ =>
         v.decider.assert(perms.IsNonNegative(tPerm),
-                         kind = ProofQueryKind.Consistency,
+                         kind = ProofQueryKind.Heap,
                          pos = ePerm.pos,
                          member = s.currentMember.map(_.name),
                          description = Some("permission amount is non-negative")) {
@@ -46,7 +46,7 @@ object permissionSupporter extends SymbolicExecutionRules {
         Q(s, v)
       case _ =>
         v.decider.assert(perms.IsPositive(tPerm),
-                         kind = ProofQueryKind.Consistency,
+                         kind = ProofQueryKind.Heap,
                          pos = ePerm.pos,
                          member = s.currentMember.map(_.name),
                          description = Some("permission amount is positive")) {

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -14,6 +14,7 @@ import viper.silver.ast
 import viper.silver.ast.utility.QuantifiedPermissions.QuantifiedPermissionAssertion
 import viper.silver.verifier.PartialVerificationError
 import viper.silicon.interfaces.{Unreachable, VerificationResult}
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.logger.records.data.{CondExpRecord, ImpliesRecord, ProduceRecord}
 import viper.silicon.state._
 import viper.silicon.state.terms._
@@ -160,7 +161,9 @@ object producer extends ProductionRules {
           // We will get an IllegalArgumentException from createSnapshotPair if sf(...) returns Unit.
           // This should never happen if we're in a reachable state, so here we check for that
           // (without timeout, since there is no fallback) and stop verifying the current branch.
-          case _: IllegalArgumentException if v.decider.check(False, Verifier.config.assertTimeout.getOrElse(0)) =>
+          case _: IllegalArgumentException if v.decider.check(False, Verifier.config.assertTimeout.getOrElse(0),
+                                                               kind = ProofQueryKind.PathInfeasibility,
+                                                               member = s.currentMember.map(_.name)) =>
             Unreachable()
         }
 

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -163,7 +163,8 @@ object producer extends ProductionRules {
           // (without timeout, since there is no fallback) and stop verifying the current branch.
           case _: IllegalArgumentException if v.decider.check(False, Verifier.config.assertTimeout.getOrElse(0),
                                                                kind = ProofQueryKind.PathInfeasibility,
-                                                               member = s.currentMember.map(_.name)) =>
+                                                               member = s.currentMember.map(_.name),
+                                                               description = Some("path infeasibility (produce exception)")) =>
             Unreachable()
         }
 

--- a/src/main/scala/rules/Producer.scala
+++ b/src/main/scala/rules/Producer.scala
@@ -161,10 +161,11 @@ object producer extends ProductionRules {
           // We will get an IllegalArgumentException from createSnapshotPair if sf(...) returns Unit.
           // This should never happen if we're in a reachable state, so here we check for that
           // (without timeout, since there is no fallback) and stop verifying the current branch.
-          case _: IllegalArgumentException if v.decider.check(False, Verifier.config.assertTimeout.getOrElse(0),
-                                                               kind = ProofQueryKind.PathInfeasibility,
-                                                               member = s.currentMember.map(_.name),
-                                                               description = Some("path infeasibility (produce exception)")) =>
+          case _: IllegalArgumentException if v.decider.check(False,
+                                                              Verifier.config.assertTimeout.getOrElse(0),
+                                                              kind = ProofQueryKind.PathInfeasibility,
+                                                              member = s.currentMember.map(_.name),
+                                                              description = Some("path infeasibility (produce exception)")) =>
             Unreachable()
         }
 

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1509,7 +1509,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     // final check
     val result =
       if (v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0), /* This check is a must-check, i.e. an assert */
-                          kind = ProofQueryKind.Heap, pos = resource.pos,
+                          kind = ProofQueryKind.Heap, pos = permsExp.map(_.pos).getOrElse(ast.NoPosition),
                           member = s.currentMember.map(_.name)))
         Complete()
       else

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -1169,7 +1169,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       case true =>
         val hints = quantifiedChunkSupporter.extractHints(Some(tCond), tArgs)
         val chunkOrderHeuristics =
-          qpAppChunkOrderHeuristics(inverseFunctions.invertibles, qvars, hints, v, s.currentMember.map(_.name))
+          qpAppChunkOrderHeuristics(inverseFunctions.invertibles, qvars, hints, v, s.currentMember.map(_.name), pos = resource.pos)
         val loss = if (!Verifier.config.unsafeWildcardOptimization() ||
             (resource.isInstanceOf[ast.Location] && s.permLocations.contains(resource.asInstanceOf[ast.Location])))
           PermTimes(tPerm, s.permissionScalingFactor)
@@ -1380,7 +1380,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         heuristics
       case None =>
         quantifiedChunkSupporter.singleReceiverChunkOrderHeuristic(arguments,
-          quantifiedChunkSupporter.extractHints(None, arguments), v, s.currentMember.map(_.name))
+          quantifiedChunkSupporter.extractHints(None, arguments), v, s.currentMember.map(_.name), pos = resourceAccess.pos)
     }
 
     if (s.exhaleExt) {
@@ -2114,7 +2114,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
   }
 
   def qpAppChunkOrderHeuristics(receiverTerms: Seq[Term], quantVars: Seq[Var], hints: Seq[Term], v: Verifier,
-                               member: Option[String] = None)
+                               member: Option[String] = None, pos: ast.Position = ast.NoPosition)
                                : Seq[QuantifiedBasicChunk] => Seq[QuantifiedBasicChunk] = {
     // Heuristics that looks for quantified chunks that have the same shape (as in, the same number and types of
     // quantified variables) and identical receiver terms.
@@ -2141,7 +2141,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               if (cQvars.length == quantVars.length && cQvars.zip(quantVars).forall(vars => vars._1.sort == vars._2.sort)) {
                 val secondReplaced = p._2.replace(cQvars, quantVars)
                 v.decider.check(SimplifyingForall(quantVars, p._1 === secondReplaced, Seq()), Verifier.config.checkTimeout(),
-                  kind = ProofQueryKind.Heap, member = member)
+                  kind = ProofQueryKind.Heap, member = member, pos = pos)
               } else {
                 false
               }
@@ -2158,7 +2158,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
   }
 
   def singleReceiverChunkOrderHeuristic(receiver: Seq[Term], hints: Seq[Term], v: Verifier,
-                                       member: Option[String] = None)
+                                       member: Option[String] = None, pos: ast.Position = ast.NoPosition)
                                        : Seq[QuantifiedBasicChunk] => Seq[QuantifiedBasicChunk] = {
     // Heuristic that emulates greedy Silicon behavior for consuming single-receiver permissions.
     // First:  Find singleton chunks that have the same receiver syntactically.
@@ -2176,7 +2176,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val greedyMatch = chunks.find(c => c.singletonArguments match {
           case Some(args) if args.length == receiver.length =>
             args.zip(receiver).forall(ts => v.decider.check(ts._1 === ts._2, Verifier.config.checkTimeout(),
-              kind = ProofQueryKind.Heap, member = member))
+              kind = ProofQueryKind.Heap, member = member, pos = pos))
           case _ =>
             false
         }).toSeq

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -11,6 +11,7 @@ import viper.silicon.debugger.DebugExp
 import viper.silicon.Map
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.interfaces.VerificationResult
+import viper.silicon.interfaces.decider.ProofQueryKind
 import viper.silicon.interfaces.state._
 import viper.silicon.logger.records.data.CommentRecord
 import viper.silicon.resources.{NonQuantifiedPropertyInterpreter, QuantifiedPropertyInterpreter, Resources}
@@ -919,7 +920,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val nonNegImplicationExp = eCond.map(c => ast.Implies(c, ast.PermGeCmp(ePerm.get, ast.NoPerm()())())(c.pos, c.info, c.errT))
     val nonNegTerm = Forall(qvars, Implies(FunctionPreconditionTransformer.transform(nonNegImplication, s.program), nonNegImplication), Nil)
     // TODO: Replace by QP-analogue of permissionSupporter.assertNotNegative
-    v.decider.assert(nonNegTerm) {
+    v.decider.assert(nonNegTerm,
+                     kind = ProofQueryKind.Consistency, pos = forall.pos,
+                     member = s.currentMember.map(_.name)) {
       case true =>
 
         /* TODO: Can we omit/simplify the injectivity check in certain situations? */
@@ -941,7 +944,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         v.decider.prover.comment(comment)
         val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program),
           receiverInjectivityCheck)
-        v.decider.assert(completeReceiverInjectivityCheck) {
+        v.decider.assert(completeReceiverInjectivityCheck,
+                         kind = ProofQueryKind.Consistency, pos = forall.pos,
+                         member = s.currentMember.map(_.name)) {
           case true =>
             val ax = inverseFunctions.axiomInversesOfInvertibles
             val inv = inverseFunctions.copy(axiomInversesOfInvertibles = Forall(ax.vars, ax.body, effectiveTriggers))
@@ -1158,7 +1163,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val nonNegTerm = Forall(qvars, Implies(FunctionPreconditionTransformer.transform(nonNegImplication, s.program), nonNegImplication), Nil)
     val nonNegExp = qvarExps.map(qv => ast.Forall(qv, Nil, nonNegImplicationExp.get)())
     // TODO: Replace by QP-analogue of permissionSupporter.assertNotNegative
-    v.decider.assert(nonNegTerm) {
+    v.decider.assert(nonNegTerm,
+                     kind = ProofQueryKind.Consistency, pos = resource.pos,
+                     member = s.currentMember.map(_.name)) {
       case true =>
         val hints = quantifiedChunkSupporter.extractHints(Some(tCond), tArgs)
         val chunkOrderHeuristics =
@@ -1194,7 +1201,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             program = s.program)
         v.decider.prover.comment("Check receiver injectivity")
         val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), receiverInjectivityCheck)
-        v.decider.assert(completeReceiverInjectivityCheck) {
+        v.decider.assert(completeReceiverInjectivityCheck,
+                         kind = ProofQueryKind.Consistency, pos = resource.pos,
+                         member = s.currentMember.map(_.name)) {
           case true =>
             val qvarsToInvOfLoc = inverseFunctions.qvarsToInversesOf(formalQVars)
             val condOfInvOfLoc = tCond.replace(qvarsToInvOfLoc)
@@ -1499,7 +1508,9 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     // final check
     val result =
-      if (v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0)) /* This check is a must-check, i.e. an assert */ )
+      if (v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0), /* This check is a must-check, i.e. an assert */
+                          kind = ProofQueryKind.Heap, pos = resource.pos,
+                          member = s.currentMember.map(_.name)))
         Complete()
       else
         Incomplete(PermMinus(permsAvailable, perms), permsAvailableExp.map(pa => ast.PermSub(pa, permsExp.get)()))
@@ -1608,10 +1619,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             remainingChunks :+ ithChunk.permMinus(ithPTaken, ithPTakenExp)
         } else {
           v.decider.prover.comment(s"Chunk depleted?")
-          val chunkDepleted = v.decider.check(depletedCheck, Verifier.config.splitTimeout())
+          val chunkDepleted = v.decider.check(depletedCheck, Verifier.config.splitTimeout(),
+            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
           if (!chunkDepleted) {
             val unusedCheck = Forall(codomainQVars, ithPTaken === NoPerm, Nil)
-            val chunkUnused = v.decider.check(unusedCheck, Verifier.config.checkTimeout())
+            val chunkUnused = v.decider.check(unusedCheck, Verifier.config.checkTimeout(),
+              kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
             if (chunkUnused) {
               remainingChunks = remainingChunks :+ ithChunk
             } else {
@@ -1630,7 +1643,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           Forall(codomainQVars, Implies(condition, ithPNeeded === NoPerm), Nil)
 
         v.decider.prover.comment(s"Intermediate check if already taken enough permissions")
-        success = if (v.decider.check(tookEnoughCheck, Verifier.config.splitTimeout())) {
+        success = if (v.decider.check(tookEnoughCheck, Verifier.config.splitTimeout(),
+                                      kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))) {
           Complete()
         } else {
           Incomplete(ithPNeeded, ithPNeededExp)
@@ -1640,7 +1654,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     v.decider.prover.comment("Final check if taken enough permissions")
     success =
-      if (success.isComplete || v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0)) /* This check is a must-check, i.e. an assert */)
+      if (success.isComplete || v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0), /* This check is a must-check, i.e. an assert */
+                                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name)))
         Complete()
       else
         success
@@ -2000,7 +2015,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               // Hence, we need to compare the conditions for equality in addition to verifying that the receivers match.
               val equalityCond = And(cond.replace(chunk.quantifiedVars, singletonArguments),
                 cCond.replace(ch.quantifiedVars, cSingletonArguments))
-              val result = v.decider.check(And(equalityCond, equalityTerm), Verifier.config.checkTimeout())
+              val result = v.decider.check(And(equalityCond, equalityTerm), Verifier.config.checkTimeout(),
+                kind = ProofQueryKind.Heap)
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2030,7 +2046,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               val condReplaced = cCond.replace(cQvars, quantVars)
               val secondReplaced = p._2.replace(cQvars, quantVars)
               val equalityTerm = SimplifyingForall(quantVars, And(Seq(p._1 === secondReplaced, cond === condReplaced)), Seq())
-              val result = v.decider.check(equalityTerm, Verifier.config.checkTimeout())
+              val result = v.decider.check(equalityTerm, Verifier.config.checkTimeout(),
+                kind = ProofQueryKind.Heap)
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2122,7 +2139,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             receiverTerms.zip(cInvertibles).forall(p => {
               if (cQvars.length == quantVars.length && cQvars.zip(quantVars).forall(vars => vars._1.sort == vars._2.sort)) {
                 val secondReplaced = p._2.replace(cQvars, quantVars)
-                v.decider.check(SimplifyingForall(quantVars, p._1 === secondReplaced, Seq()), Verifier.config.checkTimeout())
+                v.decider.check(SimplifyingForall(quantVars, p._1 === secondReplaced, Seq()), Verifier.config.checkTimeout(),
+                  kind = ProofQueryKind.Heap)
               } else {
                 false
               }
@@ -2155,7 +2173,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       } else {
         val greedyMatch = chunks.find(c => c.singletonArguments match {
           case Some(args) if args.length == receiver.length =>
-            args.zip(receiver).forall(ts => v.decider.check(ts._1 === ts._2, Verifier.config.checkTimeout()))
+            args.zip(receiver).forall(ts => v.decider.check(ts._1 === ts._2, Verifier.config.checkTimeout(),
+              kind = ProofQueryKind.Heap))
           case _ =>
             false
         }).toSeq

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -922,7 +922,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     // TODO: Replace by QP-analogue of permissionSupporter.assertNotNegative
     v.decider.assert(nonNegTerm,
                      kind = ProofQueryKind.Consistency, pos = forall.pos,
-                     member = s.currentMember.map(_.name)) {
+                     member = s.currentMember.map(_.name),
+                     description = Some("QP non-negative permission (produce)")) {
       case true =>
 
         /* TODO: Can we omit/simplify the injectivity check in certain situations? */
@@ -946,7 +947,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           receiverInjectivityCheck)
         v.decider.assert(completeReceiverInjectivityCheck,
                          kind = ProofQueryKind.Consistency, pos = forall.pos,
-                         member = s.currentMember.map(_.name)) {
+                         member = s.currentMember.map(_.name),
+                         description = Some("QP receiver injectivity (produce)")) {
           case true =>
             val ax = inverseFunctions.axiomInversesOfInvertibles
             val inv = inverseFunctions.copy(axiomInversesOfInvertibles = Forall(ax.vars, ax.body, effectiveTriggers))
@@ -1165,7 +1167,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     // TODO: Replace by QP-analogue of permissionSupporter.assertNotNegative
     v.decider.assert(nonNegTerm,
                      kind = ProofQueryKind.Consistency, pos = resource.pos,
-                     member = s.currentMember.map(_.name)) {
+                     member = s.currentMember.map(_.name),
+                     description = Some("QP non-negative permission (consume)")) {
       case true =>
         val hints = quantifiedChunkSupporter.extractHints(Some(tCond), tArgs)
         val chunkOrderHeuristics =
@@ -1203,7 +1206,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), receiverInjectivityCheck)
         v.decider.assert(completeReceiverInjectivityCheck,
                          kind = ProofQueryKind.Consistency, pos = resource.pos,
-                         member = s.currentMember.map(_.name)) {
+                         member = s.currentMember.map(_.name),
+                         description = Some("QP receiver injectivity (consume)")) {
           case true =>
             val qvarsToInvOfLoc = inverseFunctions.qvarsToInversesOf(formalQVars)
             val condOfInvOfLoc = tCond.replace(qvarsToInvOfLoc)
@@ -1510,7 +1514,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val result =
       if (v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0), /* This check is a must-check, i.e. an assert */
                           kind = ProofQueryKind.Heap, pos = permsExp.map(_.pos).getOrElse(ast.NoPosition),
-                          member = s.currentMember.map(_.name)))
+                          member = s.currentMember.map(_.name),
+                          description = Some("QP took enough permission")))
         Complete()
       else
         Incomplete(PermMinus(permsAvailable, perms), permsAvailableExp.map(pa => ast.PermSub(pa, permsExp.get)()))
@@ -1620,11 +1625,13 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         } else {
           v.decider.prover.comment(s"Chunk depleted?")
           val chunkDepleted = v.decider.check(depletedCheck, Verifier.config.splitTimeout(),
-            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
+            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+            description = Some("QP chunk depleted"))
           if (!chunkDepleted) {
             val unusedCheck = Forall(codomainQVars, ithPTaken === NoPerm, Nil)
             val chunkUnused = v.decider.check(unusedCheck, Verifier.config.checkTimeout(),
-              kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))
+              kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+              description = Some("QP chunk unused"))
             if (chunkUnused) {
               remainingChunks = remainingChunks :+ ithChunk
             } else {
@@ -1644,7 +1651,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
         v.decider.prover.comment(s"Intermediate check if already taken enough permissions")
         success = if (v.decider.check(tookEnoughCheck, Verifier.config.splitTimeout(),
-                                      kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name))) {
+                                      kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+                                      description = Some("QP took enough (after split)"))) {
           Complete()
         } else {
           Incomplete(ithPNeeded, ithPNeededExp)
@@ -1655,7 +1663,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     v.decider.prover.comment("Final check if taken enough permissions")
     success =
       if (success.isComplete || v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0), /* This check is a must-check, i.e. an assert */
-                                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name)))
+                                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+                                                 description = Some("QP took enough (final)")))
         Complete()
       else
         success
@@ -2016,7 +2025,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               val equalityCond = And(cond.replace(chunk.quantifiedVars, singletonArguments),
                 cCond.replace(ch.quantifiedVars, cSingletonArguments))
               val result = v.decider.check(And(equalityCond, equalityTerm), Verifier.config.checkTimeout(),
-                kind = ProofQueryKind.Heap, member = member)
+                kind = ProofQueryKind.Heap, member = member,
+                description = Some("QP singleton chunk alias"))
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2047,7 +2057,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               val secondReplaced = p._2.replace(cQvars, quantVars)
               val equalityTerm = SimplifyingForall(quantVars, And(Seq(p._1 === secondReplaced, cond === condReplaced)), Seq())
               val result = v.decider.check(equalityTerm, Verifier.config.checkTimeout(),
-                kind = ProofQueryKind.Heap, member = member)
+                kind = ProofQueryKind.Heap, member = member,
+                description = Some("QP invertible chunk alias"))
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2141,7 +2152,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               if (cQvars.length == quantVars.length && cQvars.zip(quantVars).forall(vars => vars._1.sort == vars._2.sort)) {
                 val secondReplaced = p._2.replace(cQvars, quantVars)
                 v.decider.check(SimplifyingForall(quantVars, p._1 === secondReplaced, Seq()), Verifier.config.checkTimeout(),
-                  kind = ProofQueryKind.Heap, member = member, pos = pos)
+                  kind = ProofQueryKind.Heap, member = member, pos = pos,
+                  description = Some("QP receiver forall match"))
               } else {
                 false
               }
@@ -2176,7 +2188,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val greedyMatch = chunks.find(c => c.singletonArguments match {
           case Some(args) if args.length == receiver.length =>
             args.zip(receiver).forall(ts => v.decider.check(ts._1 === ts._2, Verifier.config.checkTimeout(),
-              kind = ProofQueryKind.Heap, member = member, pos = pos))
+              kind = ProofQueryKind.Heap, member = member, pos = pos,
+              description = Some("QP singleton arg equality")))
           case _ =>
             false
         }).toSeq

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -240,7 +240,7 @@ trait QuantifiedChunkSupport extends SymbolicExecutionRules {
   def hintBasedChunkOrderHeuristic(hints: Seq[Term])
                                   : Seq[QuantifiedBasicChunk] => Seq[QuantifiedBasicChunk]
 
-  def findChunk(chunks: Iterable[Chunk], chunk: QuantifiedChunk, v: Verifier): Option[QuantifiedChunk]
+  def findChunk(chunks: Iterable[Chunk], chunk: QuantifiedChunk, v: Verifier, member: Option[String] = None): Option[QuantifiedChunk]
 
   /** Merge the snapshots of two quantified heap chunks that denote the same field locations
    *
@@ -1052,7 +1052,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val s1 = if (mergeAndTrigger) {
       val (fr1, h1) = v.stateConsolidator(s).merge(s.functionRecorder, s, s.h, Heap(Seq(ch)), v)
 
-      val interpreter = new NonQuantifiedPropertyInterpreter(h1.values, v)
+      val interpreter = new NonQuantifiedPropertyInterpreter(h1.values, v, s.currentMember.map(_.name))
       val resourceDescription = Resources.resourceDescriptions(ch.resourceID)
       val pcs = interpreter.buildPathConditionsForChunk(ch, resourceDescription.instanceProperties(s.mayAssumeUpperBounds))
       pcs.foreach(p => v.decider.assume(p._1, Option.when(withExp)(DebugExp.createInstance(p._2, p._2))))
@@ -1169,7 +1169,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       case true =>
         val hints = quantifiedChunkSupporter.extractHints(Some(tCond), tArgs)
         val chunkOrderHeuristics =
-          qpAppChunkOrderHeuristics(inverseFunctions.invertibles, qvars, hints, v)
+          qpAppChunkOrderHeuristics(inverseFunctions.invertibles, qvars, hints, v, s.currentMember.map(_.name))
         val loss = if (!Verifier.config.unsafeWildcardOptimization() ||
             (resource.isInstanceOf[ast.Location] && s.permLocations.contains(resource.asInstanceOf[ast.Location])))
           PermTimes(tPerm, s.permissionScalingFactor)
@@ -1380,7 +1380,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         heuristics
       case None =>
         quantifiedChunkSupporter.singleReceiverChunkOrderHeuristic(arguments,
-          quantifiedChunkSupporter.extractHints(None, arguments), v)
+          quantifiedChunkSupporter.extractHints(None, arguments), v, s.currentMember.map(_.name))
     }
 
     if (s.exhaleExt) {
@@ -1974,7 +1974,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       matchingChunks ++ otherChunks
     }
 
-  override def findChunk(chunks: Iterable[Chunk], chunk: QuantifiedChunk, v: Verifier): Option[QuantifiedChunk] = {
+  override def findChunk(chunks: Iterable[Chunk], chunk: QuantifiedChunk, v: Verifier, member: Option[String] = None): Option[QuantifiedChunk] = {
     val lr = chunk match {
       case qfc: QuantifiedFieldChunk if qfc.invs.isDefined =>
         val qvarsAndInverses = qfc.invs.get.qvarsToInverses.map(qvi => (qvi._1, App(qvi._2, qfc.invs.get.additionalArguments.toSeq ++ qfc.quantifiedVars)))
@@ -2016,7 +2016,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               val equalityCond = And(cond.replace(chunk.quantifiedVars, singletonArguments),
                 cCond.replace(ch.quantifiedVars, cSingletonArguments))
               val result = v.decider.check(And(equalityCond, equalityTerm), Verifier.config.checkTimeout(),
-                kind = ProofQueryKind.Heap)
+                kind = ProofQueryKind.Heap, member = member)
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2047,7 +2047,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               val secondReplaced = p._2.replace(cQvars, quantVars)
               val equalityTerm = SimplifyingForall(quantVars, And(Seq(p._1 === secondReplaced, cond === condReplaced)), Seq())
               val result = v.decider.check(equalityTerm, Verifier.config.checkTimeout(),
-                kind = ProofQueryKind.Heap)
+                kind = ProofQueryKind.Heap, member = member)
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2113,7 +2113,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     (fr2, sm, Forall(qVars, smDef, triggers))
   }
 
-  def qpAppChunkOrderHeuristics(receiverTerms: Seq[Term], quantVars: Seq[Var], hints: Seq[Term], v: Verifier)
+  def qpAppChunkOrderHeuristics(receiverTerms: Seq[Term], quantVars: Seq[Var], hints: Seq[Term], v: Verifier,
+                               member: Option[String] = None)
                                : Seq[QuantifiedBasicChunk] => Seq[QuantifiedBasicChunk] = {
     // Heuristics that looks for quantified chunks that have the same shape (as in, the same number and types of
     // quantified variables) and identical receiver terms.
@@ -2140,7 +2141,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               if (cQvars.length == quantVars.length && cQvars.zip(quantVars).forall(vars => vars._1.sort == vars._2.sort)) {
                 val secondReplaced = p._2.replace(cQvars, quantVars)
                 v.decider.check(SimplifyingForall(quantVars, p._1 === secondReplaced, Seq()), Verifier.config.checkTimeout(),
-                  kind = ProofQueryKind.Heap)
+                  kind = ProofQueryKind.Heap, member = member)
               } else {
                 false
               }
@@ -2156,7 +2157,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     }
   }
 
-  def singleReceiverChunkOrderHeuristic(receiver: Seq[Term], hints: Seq[Term], v: Verifier)
+  def singleReceiverChunkOrderHeuristic(receiver: Seq[Term], hints: Seq[Term], v: Verifier,
+                                       member: Option[String] = None)
                                        : Seq[QuantifiedBasicChunk] => Seq[QuantifiedBasicChunk] = {
     // Heuristic that emulates greedy Silicon behavior for consuming single-receiver permissions.
     // First:  Find singleton chunks that have the same receiver syntactically.
@@ -2174,7 +2176,7 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val greedyMatch = chunks.find(c => c.singletonArguments match {
           case Some(args) if args.length == receiver.length =>
             args.zip(receiver).forall(ts => v.decider.check(ts._1 === ts._2, Verifier.config.checkTimeout(),
-              kind = ProofQueryKind.Heap))
+              kind = ProofQueryKind.Heap, member = member))
           case _ =>
             false
         }).toSeq

--- a/src/main/scala/rules/QuantifiedChunkSupport.scala
+++ b/src/main/scala/rules/QuantifiedChunkSupport.scala
@@ -922,7 +922,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val nonNegTerm = Forall(qvars, Implies(FunctionPreconditionTransformer.transform(nonNegImplication, s.program), nonNegImplication), Nil)
     // TODO: Replace by QP-analogue of permissionSupporter.assertNotNegative
     v.decider.assert(nonNegTerm,
-                     kind = ProofQueryKind.Consistency, pos = forall.pos,
+                     kind = ProofQueryKind.Heap,
+                     pos = forall.pos,
                      member = s.currentMember.map(_.name),
                      description = Some("QP non-negative permission (produce)")) {
       case true =>
@@ -947,7 +948,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program),
           receiverInjectivityCheck)
         v.decider.assert(completeReceiverInjectivityCheck,
-                         kind = ProofQueryKind.Consistency, pos = forall.pos,
+                         kind = ProofQueryKind.Consistency,
+                         pos = forall.pos,
                          member = s.currentMember.map(_.name),
                          description = Some("QP receiver injectivity (produce)")) {
           case true =>
@@ -1167,13 +1169,16 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
     val nonNegExp = qvarExps.map(qv => ast.Forall(qv, Nil, nonNegImplicationExp.get)())
     // TODO: Replace by QP-analogue of permissionSupporter.assertNotNegative
     v.decider.assert(nonNegTerm,
-                     kind = ProofQueryKind.Consistency, pos = resource.pos,
+                     kind = ProofQueryKind.Heap,
+                     pos = resource.pos,
                      member = s.currentMember.map(_.name),
                      description = Some("QP non-negative permission (consume)")) {
       case true =>
         val hints = quantifiedChunkSupporter.extractHints(Some(tCond), tArgs)
         val chunkOrderHeuristics =
-          qpAppChunkOrderHeuristics(inverseFunctions.invertibles, qvars, hints, v, s.currentMember.map(_.name), pos = resource.pos)
+          qpAppChunkOrderHeuristics(inverseFunctions.invertibles, qvars, hints, v,
+                                    member = s.currentMember.map(_.name),
+                                    pos = resource.pos)
         val loss = if (!Verifier.config.unsafeWildcardOptimization() ||
             (resource.isInstanceOf[ast.Location] && s.permLocations.contains(resource.asInstanceOf[ast.Location])))
           PermTimes(tPerm, s.permissionScalingFactor)
@@ -1206,7 +1211,8 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         v.decider.prover.comment("Check receiver injectivity")
         val completeReceiverInjectivityCheck = Implies(FunctionPreconditionTransformer.transform(receiverInjectivityCheck, s.program), receiverInjectivityCheck)
         v.decider.assert(completeReceiverInjectivityCheck,
-                         kind = ProofQueryKind.Consistency, pos = resource.pos,
+                         kind = ProofQueryKind.Consistency,
+                         pos = resource.pos,
                          member = s.currentMember.map(_.name),
                          description = Some("QP receiver injectivity (consume)")) {
           case true =>
@@ -1385,7 +1391,10 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
         heuristics
       case None =>
         quantifiedChunkSupporter.singleReceiverChunkOrderHeuristic(arguments,
-          quantifiedChunkSupporter.extractHints(None, arguments), v, s.currentMember.map(_.name), pos = resourceAccess.pos)
+                                                                   quantifiedChunkSupporter.extractHints(None, arguments),
+                                                                   v,
+                                                                   member = s.currentMember.map(_.name),
+                                                                   pos = resourceAccess.pos)
     }
 
     if (s.exhaleExt) {
@@ -1517,8 +1526,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     // final check
     val result =
-      if (v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0), /* This check is a must-check, i.e. an assert */
-                          kind = ProofQueryKind.Heap, pos = permsExp.map(_.pos).getOrElse(ast.NoPosition),
+      if (v.decider.check(tookEnoughCheck,
+                          Verifier.config.assertTimeout.getOrElse(0),
+                          /* This check is a must-check,
+                          i.e. an assert */
+                          kind = ProofQueryKind.Heap,
+                          pos = permsExp.map(_.pos).getOrElse(ast.NoPosition),
                           member = s.currentMember.map(_.name),
                           description = Some("QP took enough permission")))
         Complete()
@@ -1629,14 +1642,20 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             remainingChunks :+ ithChunk.permMinus(ithPTaken, ithPTakenExp)
         } else {
           v.decider.prover.comment(s"Chunk depleted?")
-          val chunkDepleted = v.decider.check(depletedCheck, Verifier.config.splitTimeout(),
-            kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
-            description = Some("QP chunk depleted"))
+          val chunkDepleted = v.decider.check(depletedCheck,
+                                              Verifier.config.splitTimeout(),
+                                              kind = ProofQueryKind.Heap,
+                                              pos = resource.pos,
+                                              member = s.currentMember.map(_.name),
+                                              description = Some("QP chunk depleted"))
           if (!chunkDepleted) {
             val unusedCheck = Forall(codomainQVars, ithPTaken === NoPerm, Nil)
-            val chunkUnused = v.decider.check(unusedCheck, Verifier.config.checkTimeout(),
-              kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
-              description = Some("QP chunk unused"))
+            val chunkUnused = v.decider.check(unusedCheck,
+                                              Verifier.config.checkTimeout(),
+                                              kind = ProofQueryKind.Heap,
+                                              pos = resource.pos,
+                                              member = s.currentMember.map(_.name),
+                                              description = Some("QP chunk unused"))
             if (chunkUnused) {
               remainingChunks = remainingChunks :+ ithChunk
             } else {
@@ -1655,8 +1674,11 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
           Forall(codomainQVars, Implies(condition, ithPNeeded === NoPerm), Nil)
 
         v.decider.prover.comment(s"Intermediate check if already taken enough permissions")
-        success = if (v.decider.check(tookEnoughCheck, Verifier.config.splitTimeout(),
-                                      kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
+        success = if (v.decider.check(tookEnoughCheck,
+                                      Verifier.config.splitTimeout(),
+                                      kind = ProofQueryKind.Heap,
+                                      pos = resource.pos,
+                                      member = s.currentMember.map(_.name),
                                       description = Some("QP took enough (after split)"))) {
           Complete()
         } else {
@@ -1667,9 +1689,14 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
 
     v.decider.prover.comment("Final check if taken enough permissions")
     success =
-      if (success.isComplete || v.decider.check(tookEnoughCheck, Verifier.config.assertTimeout.getOrElse(0), /* This check is a must-check, i.e. an assert */
-                                                 kind = ProofQueryKind.Heap, pos = resource.pos, member = s.currentMember.map(_.name),
-                                                 description = Some("QP took enough (final)")))
+      if (success.isComplete || v.decider.check(tookEnoughCheck,
+                                                Verifier.config.assertTimeout.getOrElse(0),
+                                                /* This check is a must-check,
+                                                i.e. an assert */
+                                                 kind = ProofQueryKind.Heap,
+                                                pos = resource.pos,
+                                                member = s.currentMember.map(_.name),
+                                                description = Some("QP took enough (final)")))
         Complete()
       else
         success
@@ -2029,9 +2056,11 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               // Hence, we need to compare the conditions for equality in addition to verifying that the receivers match.
               val equalityCond = And(cond.replace(chunk.quantifiedVars, singletonArguments),
                 cCond.replace(ch.quantifiedVars, cSingletonArguments))
-              val result = v.decider.check(And(equalityCond, equalityTerm), Verifier.config.checkTimeout(),
-                kind = ProofQueryKind.Heap, member = member,
-                description = Some("QP singleton chunk alias"))
+              val result = v.decider.check(And(equalityCond, equalityTerm),
+                                           Verifier.config.checkTimeout(),
+                                           kind = ProofQueryKind.Heap,
+                                           member = member,
+                                           description = Some("QP singleton chunk alias"))
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2061,9 +2090,11 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
               val condReplaced = cCond.replace(cQvars, quantVars)
               val secondReplaced = p._2.replace(cQvars, quantVars)
               val equalityTerm = SimplifyingForall(quantVars, And(Seq(p._1 === secondReplaced, cond === condReplaced)), Seq())
-              val result = v.decider.check(equalityTerm, Verifier.config.checkTimeout(),
-                kind = ProofQueryKind.Heap, member = member,
-                description = Some("QP invertible chunk alias"))
+              val result = v.decider.check(equalityTerm,
+                                           Verifier.config.checkTimeout(),
+                                           kind = ProofQueryKind.Heap,
+                                           member = member,
+                                           description = Some("QP invertible chunk alias"))
               if (result) {
                 // Learn the equality
                 val debugExp = Option.when(withExp)(DebugExp.createInstance("Chunks alias", true))
@@ -2156,9 +2187,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
             receiverTerms.zip(cInvertibles).forall(p => {
               if (cQvars.length == quantVars.length && cQvars.zip(quantVars).forall(vars => vars._1.sort == vars._2.sort)) {
                 val secondReplaced = p._2.replace(cQvars, quantVars)
-                v.decider.check(SimplifyingForall(quantVars, p._1 === secondReplaced, Seq()), Verifier.config.checkTimeout(),
-                  kind = ProofQueryKind.Heap, member = member, pos = pos,
-                  description = Some("QP receiver forall match"))
+                v.decider.check(SimplifyingForall(quantVars, p._1 === secondReplaced, Seq()),
+                                Verifier.config.checkTimeout(),
+                                kind = ProofQueryKind.Heap,
+                                member = member,
+                                pos = pos,
+                                description = Some("QP receiver forall match"))
               } else {
                 false
               }
@@ -2192,9 +2226,12 @@ object quantifiedChunkSupporter extends QuantifiedChunkSupport {
       } else {
         val greedyMatch = chunks.find(c => c.singletonArguments match {
           case Some(args) if args.length == receiver.length =>
-            args.zip(receiver).forall(ts => v.decider.check(ts._1 === ts._2, Verifier.config.checkTimeout(),
-              kind = ProofQueryKind.Heap, member = member, pos = pos,
-              description = Some("QP singleton arg equality")))
+            args.zip(receiver).forall(ts => v.decider.check(ts._1 === ts._2,
+                                                            Verifier.config.checkTimeout(),
+                                                            kind = ProofQueryKind.Heap,
+                                                            member = member,
+                                                            pos = pos,
+                                                            description = Some("QP singleton arg equality")))
           case _ =>
             false
         }).toSeq

--- a/src/main/scala/rules/StateConsolidator.scala
+++ b/src/main/scala/rules/StateConsolidator.scala
@@ -189,7 +189,7 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
   private def findMatchingChunk(chunks: Iterable[Chunk], chunk: Chunk, v: Verifier, member: Option[String] = None): Option[Chunk] = {
     chunk match {
       case chunk: BasicChunk =>
-        chunkSupporter.findChunk[BasicChunk](chunks, chunk.id, chunk.args, v)
+        chunkSupporter.findChunk[BasicChunk](chunks, chunk.id, chunk.args, v, member = member)
       case chunk: QuantifiedChunk => quantifiedChunkSupporter.findChunk(chunks, chunk, v, member)
       case _ => None
     }

--- a/src/main/scala/rules/StateConsolidator.scala
+++ b/src/main/scala/rules/StateConsolidator.scala
@@ -78,7 +78,7 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
           val roundLog = new CommentRecord("Round " + fixedPointRound, s, v.decider.pcs)
           val roundSepIdentifier = v.symbExLog.openScope(roundLog)
 
-          val (_functionRecorder, _mergedChunks, _, snapEqs) = singleMerge(functionRecorder, destChunks, newChunks, s.functionRecorderQuantifiedVariables().map(_._1), v)
+          val (_functionRecorder, _mergedChunks, _, snapEqs) = singleMerge(functionRecorder, destChunks, newChunks, s.functionRecorderQuantifiedVariables().map(_._1), v, s.currentMember.map(_.name))
 
           snapEqs foreach (t => v.decider.assume(t, Option.when(withExp)(DebugExp.createInstance("Snapshot Equations", true))))
 
@@ -93,7 +93,7 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
         } while (continue)
 
 
-        val interpreter = new NonQuantifiedPropertyInterpreter(mergedChunks, v)
+        val interpreter = new NonQuantifiedPropertyInterpreter(mergedChunks, v, s.currentMember.map(_.name))
 
         mergedChunks.filter(_.isInstanceOf[BasicChunk]) foreach { case ch: BasicChunk =>
           val resource = Resources.resourceDescriptions(ch.resourceID)
@@ -130,11 +130,11 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
   def merge(fr1: FunctionRecorder, s: State, h: Heap, newH: Heap, v: Verifier): (FunctionRecorder, Heap) = {
     val mergeLog = new CommentRecord("Merge", null, v.decider.pcs)
     val sepIdentifier = v.symbExLog.openScope(mergeLog)
-    val (fr2, mergedChunks, newlyAddedChunks, snapEqs) = singleMerge(fr1, h.values.toSeq, newH.values.toSeq, s.functionRecorderQuantifiedVariables().map(_._1), v)
+    val (fr2, mergedChunks, newlyAddedChunks, snapEqs) = singleMerge(fr1, h.values.toSeq, newH.values.toSeq, s.functionRecorderQuantifiedVariables().map(_._1), v, s.currentMember.map(_.name))
 
     v.decider.assume(snapEqs, Option.when(withExp)(DebugExp.createInstance("Snapshot", isInternal_ = true)), enforceAssumption = false)
 
-    val interpreter = new NonQuantifiedPropertyInterpreter(mergedChunks, v)
+    val interpreter = new NonQuantifiedPropertyInterpreter(mergedChunks, v, s.currentMember.map(_.name))
     newlyAddedChunks.filter(_.isInstanceOf[BasicChunk]) foreach { case ch: BasicChunk =>
       val resource = Resources.resourceDescriptions(ch.resourceID)
       val pathCond = interpreter.buildPathConditionsForChunk(ch, resource.instanceProperties(s.mayAssumeUpperBounds))
@@ -149,7 +149,8 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
                           destChunks: Seq[Chunk],
                           newChunks: Seq[Chunk],
                           qvars: Seq[Var],
-                          v: Verifier)
+                          v: Verifier,
+                          member: Option[String] = None)
                          : (FunctionRecorder,
                             Seq[Chunk],
                             Seq[Chunk],
@@ -169,7 +170,7 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
        *           sequence of destination chunks
        */
 
-      findMatchingChunk(accMergedChunks, nextChunk, v) match {
+      findMatchingChunk(accMergedChunks, nextChunk, v, member) match {
         case Some(ch) =>
           mergeChunks(fr1, ch, nextChunk, qvars, v) match {
             case Some((fr2, newChunk, snapEq)) =>
@@ -185,11 +186,11 @@ class DefaultStateConsolidator(protected val config: Config) extends StateConsol
     result
   }
 
-  private def findMatchingChunk(chunks: Iterable[Chunk], chunk: Chunk, v: Verifier): Option[Chunk] = {
+  private def findMatchingChunk(chunks: Iterable[Chunk], chunk: Chunk, v: Verifier, member: Option[String] = None): Option[Chunk] = {
     chunk match {
       case chunk: BasicChunk =>
         chunkSupporter.findChunk[BasicChunk](chunks, chunk.id, chunk.args, v)
-      case chunk: QuantifiedChunk => quantifiedChunkSupporter.findChunk(chunks, chunk, v)
+      case chunk: QuantifiedChunk => quantifiedChunkSupporter.findChunk(chunks, chunk, v, member)
       case _ => None
     }
   }

--- a/src/main/scala/supporters/CfgSupporter.scala
+++ b/src/main/scala/supporters/CfgSupporter.scala
@@ -54,7 +54,7 @@ trait DefaultCfgVerificationUnitProvider extends VerifierComponent { v: Verifier
       }
 
       val result = {
-        executionFlowController.locally(s, v)((s3, v3) =>  {
+        executionFlowController.locally(s, v, description = Some("CFG execution"))((s3, v3) =>  {
           exec(s3, cfg, v3)((_, _) =>
             Success())}) }
 

--- a/src/main/scala/supporters/MethodSupporter.scala
+++ b/src/main/scala/supporters/MethodSupporter.scala
@@ -81,11 +81,11 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
         /* Combined the well-formedness check and the execution of the body, which are two separate
          * rules in Smans' paper.
          */
-        executionFlowController.locally(s, v)((s1, v1) => {
+        executionFlowController.locally(s, v, description = Some("method: precondition production and body verification"))((s1, v1) => {
           produces(s1, freshSnap, pres, ContractNotWellformed, v1)((s2, v2) => {
             v2.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)
             val s2a = s2.copy(oldHeaps = s2.oldHeaps + (Verifier.PRE_STATE_LABEL -> s2.h))
-            (  executionFlowController.locally(s2a, v2)((s3, v3) => {
+            (  executionFlowController.locally(s2a, v2, description = Some("method: postcondition well-formedness"))((s3, v3) => {
                   val s4 = s3.copy(h = v3.heapSupporter.getEmptyHeap(s3.program))
                   val impLog = new WellformednessCheckRecord(posts, s, v.decider.pcs)
                   val sepIdentifier = symbExLog.openScope(impLog)
@@ -93,7 +93,7 @@ trait DefaultMethodVerificationUnitProvider extends VerifierComponent { v: Verif
                     symbExLog.closeScope(sepIdentifier)
                     Success()})})
             && {
-               executionFlowController.locally(s2a, v2)((s3, v3) =>  {
+               executionFlowController.locally(s2a, v2, description = Some("method: body execution and postcondition check"))((s3, v3) =>  {
                   exec(s3, body, v3)((s4, v4) =>
                     consumes(s4, posts, false, postViolated, v4)((_, _, _) =>
                       Success()))}) }  )})})

--- a/src/main/scala/supporters/PredicateVerificationUnit.scala
+++ b/src/main/scala/supporters/PredicateVerificationUnit.scala
@@ -122,7 +122,7 @@ trait DefaultPredicateVerificationUnitProvider extends VerifierComponent { v: Ve
         case Some(body) =>
           /*    locallyXXX {
                 magicWandSupporter.checkWandsAreSelfFraming(σ.γ, σ.h, predicate, c)}
-          &&*/  executionFlowController.locally(s, v)((s1, _) => {
+          &&*/  executionFlowController.locally(s, v, description = Some("predicate: body production"))((s1, _) => {
                   produce(s1, toSf(snap), body, err, v)((s2, v2) => {
                     val branchConds = v2.decider.pcs.branchConditions.reverse
                     val branchCondExps = v2.decider.pcs.branchConditionExps.reverse

--- a/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
+++ b/src/main/scala/supporters/functions/FunctionVerificationUnit.scala
@@ -229,7 +229,7 @@ trait DefaultFunctionVerificationUnitProvider extends VerifierComponent { v: Ver
       var phase1Data: Seq[Phase1Data] = Vector.empty
       var recorders: Seq[FunctionRecorder] = Vector.empty
 
-      val result = executionFlowController.locally(s, v)((s0, _) => {
+      val result = executionFlowController.locally(s, v, description = Some("function: precondition and postcondition production"))((s0, _) => {
         val preMark = decider.setPathConditionMark()
         produces(s0, toSf(`?s`), pres, ContractNotWellformed, v)((s1, _) => {
           val relevantPathConditionStack = decider.pcs.after(preMark)
@@ -249,7 +249,6 @@ trait DefaultFunctionVerificationUnitProvider extends VerifierComponent { v: Ver
 
     private def verify(function: ast.Function, phase1data: Seq[Phase1Data])
                       : VerificationResult = {
-
       val comment = ("-" * 5) + " Verification of function body and postcondition " + ("-" * 5)
       logger.debug(s"\n\n$comment\n")
       decider.prover.comment(comment)
@@ -265,7 +264,7 @@ trait DefaultFunctionVerificationUnitProvider extends VerifierComponent { v: Ver
       val result = phase1data.foldLeft(Success(): VerificationResult) {
         case (fatalResult: FatalResult, _) => fatalResult
         case (intermediateResult, Phase1Data(sPre, bcsPre, bcsPreExp, pcsPre, pcsPreExp)) =>
-          intermediateResult && executionFlowController.locally(sPre, v)((s1, _) => {
+          intermediateResult && executionFlowController.locally(sPre, v, description = Some("function: body evaluation and postcondition check"))((s1, _) => {
             decider.setCurrentBranchCondition(And(bcsPre), (BigAnd(bcsPreExp.map(_._1)), Option.when(wExp)(BigAnd(bcsPreExp.map(_._2.get)))))
             decider.assume(pcsPre, Option.when(wExp)(DebugExp.createInstance(s"precondition of ${function.name}", pcsPreExp.get)), enforceAssumption = false)
             v.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)


### PR DESCRIPTION
**Architecturally, the way we record the per-query data might not be the most adequate; perhaps the symbex logger would be a better place for that.**

This PR introduces support for recording and classifying SMT interactions (assertions, checks, and scope push/pop operations) issued during verification. Each recorded interaction carries two orthogonal labels:

**`kind` (`QueryKind`)** — the type of solver interaction:
  - `Assert` — from `Decider#assert`
  - `Check` — from `Decider#check` and `Decider#checkSmoke`
  - `Push` / `Pop` — from `Decider#pushScope` / `Decider#popScope`

**`category` (`ProofQueryKind`)** — the semantic purpose of the query:
  - `Consistency` — well-formedness obligations (injectivity of quantified-permission receivers, ...)
  - `Heap` — heap-access and permission-amount correctness (chunk existence, alias, sufficient permission, non-negativity/positivity of permission amounts, ...)
  - `FunctionalCorrectness` — user-visible proof obligations (pre/postconditions, `assert` statements, sequence-index bounds, non-zero divisor, ...)
  - `PathInfeasibility` — branch feasibility and smoke checks
  - `ScopeManagement` — push/pop of the prover assertion stack

Each recorded interaction also carries:
- **`member`** — name of the program member (method/function/predicate/domain) whose verification triggered the query, if known;
- **`pos`** — source position of the proof obligation;
- **`durationMs`** — wall-clock time of the prover call;
- **`succeeded`** — whether the query returned true / Unsat;
- **`description`** — an optional short text description populated at call sites for extra clarity

The feature is enabled by the CLI option `--recordProofQueries <file>`, which writes a CSV to the given path at the end of verification.

## Implementation Details
- Recording is only performed when `Verifier.config.recordProofQueries` is defined; there is no runtime cost when the flag is off.
- Queries that are trivially entailed by the current path conditions (short-circuited by `isKnownToBeTrue`) are **not** recorded — only queries that actually reach the prover.
- The `kind` parameter is **required** on `Decider#check` and `Decider#assert`, so every call site must state its intent explicitly. This makes classification decisions easy to audit in review, and it makes the compiler reject any new query site that is added without a classification.
- `checkSmoke` defaults `kind` to `PathInfeasibility` but accepts an override for smoke checks that are semantically used for a different purpose (e.g. verifying that permission was actually taken from the heap in `MagicWandSupporter`).
- `member` and `pos` are threaded through `findChunk` / `findChunkWithProver` and the chunk-order heuristics so nearly every recorded query is attributed to a specific program member and source position.
- CSV export renders missing metadata as `?`.

## Known Limitation
`member` is `None` only on the CFG-based verification path (`DefaultMainVerifier#createInitialState(cfg, ...)`), which is used by external CFG-driven callers rather than by terminal Viper runs. A bare `SilverCfg` carries no owning `ast.Member`, so there is nothing to thread through `cfgSupporter.verify`; queries issued on that path are exported with `member = ?`.