### PR TITLE
Fixing issues #960 and #967

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1339,6 +1339,7 @@ object evaluator extends EvaluationRules {
     val preMark = v.decider.setPathConditionMark()
     var pcDelta = InsertionOrderedSet.empty[Term]
     var pcDeltaExp = InsertionOrderedSet.empty[DebugExp]
+    var functionRecorder = s.functionRecorder
 
     /* TODO: Evaluate as many remaining expressions as possible, i.e. don't
      *       stop if evaluating one fails
@@ -1373,10 +1374,11 @@ object evaluator extends EvaluationRules {
      */
 
     val r =
-      evals(s.copy(triggerExp = true), remainingTriggerExpressions, _ => pve, v)((_, remainingTriggerTerms, _, v1) => {
+      evals(s.copy(triggerExp = true), remainingTriggerExpressions, _ => pve, v)((s1, remainingTriggerTerms, _, v1) => {
         optRemainingTriggerTerms = Some(remainingTriggerTerms)
         pcDelta = v1.decider.pcs.after(preMark).assumptions //decider.π -- πPre
         pcDeltaExp = v1.decider.pcs.after(preMark).assumptionExps
+        functionRecorder = s1.functionRecorder
         Success()})
 
     // Remove all assumptions resulting from evaluating the trigger.
@@ -1389,7 +1391,7 @@ object evaluator extends EvaluationRules {
     (r, optRemainingTriggerTerms) match {
       case (Success(), Some(remainingTriggerTerms)) =>
         v.decider.assume(pcDelta, Option.when(withExp)(DebugExp.createInstance("pcDeltaExp", children = pcDeltaExp)), enforceAssumption = false)
-        Q(s, cachedTriggerTerms ++ remainingTriggerTerms, v)
+        Q(s.copy(functionRecorder = functionRecorder), cachedTriggerTerms ++ remainingTriggerTerms, v)
       case _ =>
         for (e <- remainingTriggerExpressions)
           v.reporter.report(WarningsDuringVerification(Seq(

--- a/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
+++ b/src/main/scala/supporters/functions/HeapAccessReplacingExpressionTranslator.scala
@@ -35,6 +35,7 @@ class HeapAccessReplacingExpressionTranslator(symbolConverter: SymbolConverter,
   private var ignoreAccessPredicates = false
   private var failed = false
   private var context: Seq[ExpContext] = Seq.empty
+  private var checkInnerContexts: Boolean = false
 
   var functionData: Map[String, FunctionData] = _
 
@@ -123,6 +124,8 @@ class HeapAccessReplacingExpressionTranslator(symbolConverter: SymbolConverter,
          * 'x' is bound by the surrounding quantifier.
          */
         context = context :+ QuantifierContext(eQuant)
+        val oldCheckInnerContext = checkInnerContexts
+        checkInnerContexts = true
         val tQuant = super.translate(symbolConverter.toSort)(eQuant).asInstanceOf[Quantification]
         val names = tQuant.vars.map(_.id.name)
 
@@ -134,6 +137,7 @@ class HeapAccessReplacingExpressionTranslator(symbolConverter: SymbolConverter,
           }
         })()
         context = context.init
+        checkInnerContexts = oldCheckInnerContext
         res
 
       case loc: ast.LocationAccess => getOrFail(data.locToSnap, loc, context, toSort(loc.typ), Option.when(Verifier.config.enableDebugging())(extractPTypeFromExp(loc)))
@@ -173,6 +177,16 @@ class HeapAccessReplacingExpressionTranslator(symbolConverter: SymbolConverter,
       case Some(s) =>
         s.convert(sort)
       case None =>
+        if (checkInnerContexts) {
+          // Sometimes, we also want to check if the expression can be found in some nested context inside
+          // the current one, so we check for any contexts in the map that start with the current one.
+          // See issue #967.
+          val innerContextVals = map.find({ case ((k, c), _) => k == key && c.startsWith(ctx) })
+          if (innerContextVals.nonEmpty) {
+            return innerContextVals.get._2.convert(sort)
+          }
+        }
+
         if (!failed && data.verificationFailures.isEmpty) {
           val msg = resolutionFailureMessage(key, data)
 


### PR DESCRIPTION
Fixing two issues with translating quantifier triggers inside heap-dependent functions.
- For #960: When translating triggers that were part of the quantifier body, we now keep the resulting FunctionRecorder
- For #967 (it's not super pretty but I couldn't come up with a better solution): We change the ExpressionTranslator used for function translation so that when we're translating a quantifier, a flag is set that tells it that if it cannot find a translation for some heap-dependent expression, it should look not only in the current context, but also in other contexts inside the current one.