### PR TITLE
Do not sort reported branch conditions by source position

### DIFF
--- a/src/main/scala/rules/SymbolicExecutionRules.scala
+++ b/src/main/scala/rules/SymbolicExecutionRules.scala
@@ -87,11 +87,6 @@ trait SymbolicExecutionRules {
     val branchconditions = if (Verifier.config.enableBranchconditionReporting()) {
       v.decider.pcs.branchConditionExps.map(_._1)
         .filterNot(e => e.isInstanceOf[viper.silver.ast.TrueLit]) /* remove "true" bcs introduced by viper.silicon.utils.ast.BigAnd */
-        .sortBy(_.pos match {
-          /* Order branchconditions according to source position */
-          case pos: viper.silver.ast.HasLineColumn => (pos.line, pos.column)
-          case _ => (-1, -1)
-        })
     } else Seq()
 
     if (Verifier.config.enableDebugging()){


### PR DESCRIPTION
For the branch conditions reported with ``--enableBranchconditionReporting``, the code currently sorts them by source position. There seems to be no good reason to do this, it simply results in a loss of information about the order in which we actually branched on what condition, so we drop the sorting.