### PR TITLE
Recording old-expression triggers more cleanly

### DIFF
--- a/src/main/scala/rules/Evaluator.scala
+++ b/src/main/scala/rules/Evaluator.scala
@@ -1157,17 +1157,15 @@ object evaluator extends EvaluationRules {
                             : VerificationResult = {
 
     val h = s.oldHeaps(label)
-    val s1 = s.copy(h = h, partiallyConsumedHeap = None, isEvalInOld = true)
+    val s1 = s.copy(h = h, partiallyConsumedHeap = None, isEvalInOld = true, possibleTriggers = Map.empty)
     val s2 = v.stateConsolidator(s1).consolidateOptionally(s1, v)
-    val possibleTriggersBefore: Map[ast.Exp, Term] = if (s.recordPossibleTriggers) s.possibleTriggers else Map.empty
 
     eval(s2, e, pve, v)((s3, t, eNew, v1) => {
       val newPossibleTriggers = if (s.recordPossibleTriggers) {
         // For all new possible trigger expressions e and translated term t,
         // make sure we remember t as the term for old[label](e) instead.
         // If e is not heap-dependent, we also remember t as the term for e.
-        val addedOrChangedPairs = s3.possibleTriggers.filter(t =>
-          !possibleTriggersBefore.contains(t._1) || possibleTriggersBefore(t._1) != t._2)
+        val newTriggers = s3.possibleTriggers
 
         def wrapInOld(e: ast.Exp) = {
           if (label == Verifier.PRE_STATE_LABEL) {
@@ -1177,8 +1175,8 @@ object evaluator extends EvaluationRules {
           }
         }
 
-        val oldPairs = addedOrChangedPairs.map(t => wrapInOld(t._1) -> t._2) ++
-          addedOrChangedPairs.filter(t => !t._1.isHeapDependent(s.program))
+        val oldPairs = newTriggers.map(t => wrapInOld(t._1) -> t._2) ++
+          newTriggers.filter(t => !t._1.isHeapDependent(s.program))
         s.possibleTriggers ++ oldPairs
       } else {
         s.possibleTriggers


### PR DESCRIPTION
Previously, we did not record the term ``t`` for expression ``old(e)`` that is evaluated while evaluating the body of a quantifier as a possible trigger if we had previously evaluated ``e`` and it also evaluated to ``t``. Now we just record every term that comes up while evaluating the body, without any weird exceptions.