### PR TITLE
Fixing issue #996

### DIFF
--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -9,8 +9,6 @@ package viper.silicon.rules
 import viper.silicon.debugger.DebugExp
 import viper.silicon.common.collections.immutable.InsertionOrderedSet
 import viper.silicon.Config.JoinMode
-
-import scala.annotation.unused
 import viper.silver.cfg.silver.SilverCfg
 import viper.silver.cfg.silver.SilverCfg.{SilverBlock, SilverEdge}
 import viper.silver.verifier.{CounterexampleTransformer, NullPartialVerificationError, PartialVerificationError}
@@ -27,7 +25,7 @@ import viper.silicon.utils.ast.{BigAnd, extractPTypeFromExp, simplifyVariableNam
 import viper.silicon.utils.{freshSnap, toSf}
 import viper.silicon.verifier.Verifier
 import viper.silver.cfg.{ConditionalEdge, StatementBlock}
-
+import scala.annotation.unused
 import java.util.concurrent.atomic.AtomicInteger
 
 trait ExecutionRules extends SymbolicExecutionRules {

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -15,7 +15,7 @@ import viper.silver.cfg.silver.SilverCfg
 import viper.silver.cfg.silver.SilverCfg.{SilverBlock, SilverEdge}
 import viper.silver.verifier.{CounterexampleTransformer, NullPartialVerificationError, PartialVerificationError}
 import viper.silver.verifier.errors._
-import viper.silver.reporter.{PathProcessedMessage, BlockReachedMessage}
+import viper.silver.reporter.{BlockReachedMessage, PathProcessedMessage}
 import viper.silver.verifier.reasons._
 import viper.silver.{ast, cfg}
 import viper.silicon.decider.RecordedPathConditions
@@ -24,9 +24,10 @@ import viper.silicon.logger.records.data.{CommentRecord, ConditionalEdgeRecord, 
 import viper.silicon.state._
 import viper.silicon.state.terms._
 import viper.silicon.utils.ast.{BigAnd, extractPTypeFromExp, simplifyVariableName}
-import viper.silicon.utils.freshSnap
+import viper.silicon.utils.{freshSnap, toSf}
 import viper.silicon.verifier.Verifier
 import viper.silver.cfg.{ConditionalEdge, StatementBlock}
+
 import java.util.concurrent.atomic.AtomicInteger
 
 trait ExecutionRules extends SymbolicExecutionRules {
@@ -561,13 +562,49 @@ object executor extends ExecutionRules {
             tArgs zip Seq.fill(tArgs.size)(None)
           val s2 = s1.copy(g = Store(fargs.zip(argsWithExp)),
                            recordVisited = true)
-          consumes(s2, meth.pres, false, _ => pvePre, v1)((s3, _, v2) => {
+          // Check if we need to reconstruct an old heap for producing the postcondition, which is
+          // the case if we're inside a package statement and the postcondition contains and old expression.
+          val needsOldHeapReconstruct = s.exhaleExt && meth.posts.exists(post => post.exists {
+            case _: ast.Old => true
+            case _ => false
+          })
+          consumes(s2, meth.pres, needsOldHeapReconstruct, _ => pvePre, v1)((s3, preSnap, v2) => {
             v2.symbExLog.closeScope(preCondId)
             val postCondLog = new CommentRecord("Postcondition", s3, v2.decider.pcs)
             val postCondId = v2.symbExLog.openScope(postCondLog)
             val outs = meth.formalReturns.map(_.localVar)
             val gOuts = Store(outs.map(x => (x, v2.decider.fresh(x))).toMap)
-            val s4 = s3.copy(g = s3.g + gOuts, oldHeaps = s3.oldHeaps + (Verifier.PRE_STATE_LABEL -> magicWandSupporter.getEvalHeap(s1)))
+
+            val newOldHeaps = if (needsOldHeapReconstruct) {
+              // We're in the process of packaging a wand, which means that we cannot simply use the
+              // heap before the call as the old heap for producing the postcondition.
+              // Instead, we produce the preconditions again to get an evalHeap that contains all permissions
+              // that were consumed by the call, but does *not* contain arbitrary permissions from outer
+              // heaps. This is not pretty, but it seems necessary:
+              // If we simply take the evalHeap of s1, we might be missing permissions that were moved
+              // into the wand heaps from outer reserveHeaps while consuming the precondition (see issue #996).
+              // If we simply make an evalHeap out of *all* reserveHeaps, we may get a heap that contains
+              // e.g. duplicate permissions for the same field (from the wand lhs and the surrounding
+              // context), which would be inconsistent, so that if state consolidation happens during
+              // the postcondition consume, we'll assume false.
+              var oldHeapState: Option[State] = None
+              produces(s3, toSf(preSnap.get), meth.pres, _ => pveCallTransformed, v2)((so, _) => {
+                oldHeapState = Some(so)
+                Success()
+              })
+              val oldHeap = oldHeapState match {
+                case Some(so) => magicWandSupporter.getEvalHeap(so)
+                case None => {
+                  // This basically should not happen, but to fail gracefully if it does because
+                  // of some incompleteness, we use an incomplete heap instead.
+                  magicWandSupporter.getEvalHeap(s1)
+                }
+              }
+              s3.oldHeaps + (Verifier.PRE_STATE_LABEL -> oldHeap)
+            } else {
+              s3.oldHeaps
+            }
+            val s4 = s3.copy(g = s3.g + gOuts, oldHeaps = newOldHeaps)
             produces(s4, freshSnap, meth.posts, _ => pveCallTransformed, v2)((s5, v3) => {
               v3.symbExLog.closeScope(postCondId)
               v3.decider.prover.saturate(Verifier.config.proverSaturationTimeouts.afterContract)

--- a/src/main/scala/rules/Executor.scala
+++ b/src/main/scala/rules/Executor.scala
@@ -602,7 +602,7 @@ object executor extends ExecutionRules {
               }
               s3.oldHeaps + (Verifier.PRE_STATE_LABEL -> oldHeap)
             } else {
-              s3.oldHeaps
+              s3.oldHeaps + (Verifier.PRE_STATE_LABEL -> magicWandSupporter.getEvalHeap(s1))
             }
             val s4 = s3.copy(g = s3.g + gOuts, oldHeaps = newOldHeaps)
             produces(s4, freshSnap, meth.posts, _ => pveCallTransformed, v2)((s5, v3) => {


### PR DESCRIPTION
Issue #996 happens because we're calling a method whose postcondition contains an old-expression inside a ``package`` statement. The tricky thing about that is that the old-expression has to be evaluated in a heap that may never have existed inside Silicon at any point; it's the different heaps accessible inside the package statement before the call *plus* any permissions that have been consumed from outer reserve heaps while consuming the precondition.

The current code simply combines the heaps accessible inside the package statement before the call, and uses that as the old heap. This old heap simply does not contain the permissions taken from outer heaps while consuming the precondition, which is why #996 happens.

At first I thought that, since the postcondition we're supposed to produce is known to be self-framing and we only have to make sure that everything that should be available in the old heap is actually available, that we can simply combine all reserve heaps before the call, and make this combination the old heap. The problem is that this combination can be inconsistent, and then any state consolidation while producing the postcondition can lead us to assume false.

So now the solution is to (in this relative rare case) explicitly reconstruct what the old heap is, by producing the precondition again into the heap that we get after consuming it. That will give us a heap where everything taken from outer heaps is available in the wand heap. 
It's not super pretty, but I cannot think of a better solution within our current framework.

Fixes #996 